### PR TITLE
Wrapped portals GP models to allow pandas input

### DIFF
--- a/src/mitim_modules/portals/utils/PORTALSanalysis.py
+++ b/src/mitim_modules/portals/utils/PORTALSanalysis.py
@@ -873,6 +873,24 @@ class wrapped_model_portals:
             out = self.sample(x, samples=samples, outputs=outputs)
         return out
 
+    def generateScan(self, output, iteration=-1, scan_range=0.5, scan_resolution=2):
+        scan_list = []
+        if output in self.training_inputs:
+            base = self.training_inputs[output]
+            idx = base.index.values[iteration]
+            for var in base:
+                scan_length = scan_resolution * 2 - 1
+                scan_data = {}
+                if scan_length > 1:
+                    scan_data = {key: np.array([base.loc[idx, key]] * scan_length) for key in base}
+                    scan_data[var] = (1.0 + np.linspace(-1.0, 1.0, scan_length) * scan_range) * scan_data[var]
+                else:
+                    scan_data = base.loc[idx, :].to_dict()
+                for key in scan_data:
+                    scan_data[key] = np.atleast_1d(scan_data[key])
+                scan_list.append(pd.DataFrame(data=scan_data))
+        return pd.concat(scan_list, axis=0, ignore_index=True)
+
 
 def calcLinearizedModel(
     prfs_model, DeltaQ, posBase=-1, numChannels=3, numRadius=4, sepers=[]

--- a/src/mitim_modules/portals/utils/PORTALSanalysis.py
+++ b/src/mitim_modules/portals/utils/PORTALSanalysis.py
@@ -444,7 +444,6 @@ class PORTALSanalyzer:
         # Make dictionary
         models = {}
         for gp in gps:
-            #models[gp.output] = simple_model_portals(gp)
             models[gp.output] = gp
 
         # PRINTING
@@ -711,53 +710,6 @@ class PORTALSanalyzer:
 # ****************************************************************************
 # Helpers
 # ****************************************************************************
-
-
-class simple_model_portals:
-    def __init__(self, gp):
-        self.gp = gp
-
-        self.x = self.gp.gpmodel.train_X_usedToTrain
-        self.y = self.gp.gpmodel.train_Y_usedToTrain
-        self.yvar = self.gp.gpmodel.train_Yvar_usedToTrain
-
-        # self.printInfo()
-
-    def printInfo(self):
-        print(f"> Model for {self.gp.output} created")
-        print(
-            f"\t- Fitted to {len(self.gp.variables)} variables in this order: {self.gp.variables}"
-        )
-        print(f"\t- Trained with {self.x.shape[0]} points")
-
-    def __call__(self, x, samples=None):
-        numpy_provided = False
-        if isinstance(x, np.ndarray):
-            x = torch.Tensor(x)
-            numpy_provided = True
-
-        mean, upper, lower, samples = self.gp.predict(
-            x, produceFundamental=True, nSamples=samples
-        )
-
-        if samples is None:
-            if numpy_provided:
-                return (
-                    mean[..., 0].detach().cpu().numpy(),
-                    upper[..., 0].detach().cpu().numpy(),
-                    lower[..., 0].detach().cpu().numpy(),
-                )
-            else:
-                return (
-                    mean[..., 0].detach(),
-                    upper[..., 0].detach(),
-                    lower[..., 0].detach(),
-                )
-        else:
-            if numpy_provided:
-                return samples[..., 0].detach().cpu().numpy()
-            else:
-                return samples[..., 0].detach()
 
 
 class wrapped_model_portals:

--- a/src/mitim_modules/portals/utils/PORTALSanalysis.py
+++ b/src/mitim_modules/portals/utils/PORTALSanalysis.py
@@ -849,17 +849,18 @@ class wrapped_model_portals:
             out = self.sample(x, samples=samples, outputs=outputs)
         return out
 
-    def generateScan(self, output, iteration=-1, scan_range=0.5, scan_resolution=2):
+    def generateScan(self, output, iteration=-1, scan_range=0.5, scan_resolution=3):
         scan_list = []
         if output in self._training_inputs:
             base = self._training_inputs[output]
             idx = base.index.values[iteration]
             for var in base:
-                scan_length = scan_resolution * 2 - 1
+                scan_length = int(scan_resolution) if isinstance(scan_resolution, (float, int)) else 3
                 scan_data = {}
                 if scan_length > 1:
+                    scan_width = float(scan_range) if isinstance(scan_range, (float, int)) else 0.5
                     scan_data = {key: np.array([base.loc[idx, key]] * scan_length) for key in base}
-                    scan_data[var] = (1.0 + np.linspace(-1.0, 1.0, scan_length) * scan_range) * scan_data[var]
+                    scan_data[var] = (1.0 + np.linspace(-1.0, 1.0, scan_length) * scan_width) * scan_data[var]
                 else:
                     scan_data = base.loc[idx, :].to_dict()
                 for key in scan_data:


### PR DESCRIPTION
- Created new class: `wrapped_models_portals` (replaces `simple_model_portals`)
- Accepts nested `list`, `numpy.ndarray`, `pandas.DataFrame` as inputs
- Using `pandas.DataFrame` allows flexible variable order in input data
- Currently returns all outputs, unless specific targets are given through evaluation call
- Added `generateScan()` function which creates single variable scans around a given training point of a given model