### PR TITLE
General bugfixes in preparation of SMARTS integration

### DIFF
--- a/src/mitim_modules/portals/PORTALSmain.py
+++ b/src/mitim_modules/portals/PORTALSmain.py
@@ -479,7 +479,7 @@ class portals(STRATEGYtools.opt_evaluator):
                 )
                 self.PORTALSparameters["TargetCalc"] = "powerstate"
 
-        if (self.PORTALSparameters["transport_evaluator"] != TRANSPORTtools.tgyro_model) and (self.PORTALSparameters["TargetCalc"] == "tgyro"):
+        if not issubclass(self.PORTALSparameters["transport_evaluator"], TRANSPORTtools.tgyro_model) and (self.PORTALSparameters["TargetCalc"] == "tgyro"):
             print(
                 "\t- Requested TGYRO targets, but transport evaluator is not tgyro, so changing to powerstate",
                 typeMsg="w",

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -270,6 +270,10 @@ class powerstate:
 
         return state_temp
 
+    def to_cpu_tensors(self):
+        self._cpu_tensors()
+        return self
+
     # ------------------------------------------------------------------
     # Flux-matching and iteration tools
     # ------------------------------------------------------------------
@@ -458,6 +462,18 @@ class powerstate:
 
         # New batch size
         self.batch_size = batch_size
+
+    def _cpu_tensors(self):
+        self._detach_tensors()
+        self.plasma = {key: tensor.cpu() for key, tensor in self.plasma.items() if isinstance(tensor, torch.Tensor)}
+        if self.plasma_fine is not None:
+            self.plasma_fine = {key: tensor.cpu() for key, tensor in self.plasma_fine.items() if isinstance(tensor, torch.Tensor)}
+        if hasattr(self, 'Xcurrent') and self.Xcurrent is not None and isinstance(self.Xcurrent, torch.Tensor):
+            self.Xcurrent = self.Xcurrent.cpu()
+        if hasattr(self, 'FluxMatch_Yopt') and self.FluxMatch_Yopt is not None and isinstance(self.FluxMatch_Yopt, torch.Tensor):
+            self.FluxMatch_Yopt = self.FluxMatch_Yopt.cpu()
+        if hasattr(self, 'profiles'):
+            self.profiles.toNumpyArrays()
 
     def update_var(self, name, var=None, specific_deparametrizer=None):
         """

--- a/src/mitim_modules/powertorch/utils/ITtools.py
+++ b/src/mitim_modules/powertorch/utils/ITtools.py
@@ -84,7 +84,7 @@ def fluxMatchSimpleRelax(self, algorithmOptions={}, bounds=None):
     def evaluator(X, cont=0):
         nameRun = f"{namingConvention}{cont}"
         folder = f"{MainFolder}/{nameRun}/"
-        if self.TransportOptions["transport_evaluator"] == TRANSPORTtools.tgyro_model:
+        if issubclass(self.TransportOptions["transport_evaluator"], TRANSPORTtools.power_transport):
             os.makedirs(os.path.join(folder, "model_complete/"), exist_ok=True)
 
         # ***************************************************************************************************************
@@ -98,7 +98,7 @@ def fluxMatchSimpleRelax(self, algorithmOptions={}, bounds=None):
         )
 
         # Save state so that I can check initializations
-        if self.TransportOptions["transport_evaluator"] == TRANSPORTtools.tgyro_model:
+        if issubclass(self.TransportOptions["transport_evaluator"], TRANSPORTtools.power_transport):
             self.save(f"{folder}/powerstate.pkl")
             os.system(f"cp {folderTGYRO}/input.gacode {folder}/.")
 

--- a/src/mitim_tools/gacode_tools/PROFILEStools.py
+++ b/src/mitim_tools/gacode_tools/PROFILEStools.py
@@ -1423,6 +1423,10 @@ class PROFILES_GACODE:
                 ni_orig = self.profiles["ni(10^19/m^3)"][:, sp]
                 self.profiles["ni(10^19/m^3)"][:, sp] = scaleFactor_ions * ni_orig
 
+    def toNumpyArrays(self):
+        self.profiles.update({key: tensor.cpu().detach().numpy() for key, tensor in self.profiles.items() if isinstance(tensor, torch.Tensor)})
+        self.derived.update({key: tensor.cpu().detach().numpy() for key, tensor in self.derived.items() if isinstance(tensor, torch.Tensor)})
+
     def writeCurrentStatus(self, file=None, limitedNames=False):
         print("\t- Writting input.gacode file")
 

--- a/src/mitim_tools/misc_tools/CONFIGread.py
+++ b/src/mitim_tools/misc_tools/CONFIGread.py
@@ -3,7 +3,7 @@ import json
 import socket
 import getpass
 from mitim_tools.misc_tools import IOtools, LOGtools
-from mitim_tools.misc_tools.LOGtools import printMsg as print
+from mitim_tools.misc_tools.LOGtools import printMsg
 from IPython import embed
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -23,18 +23,21 @@ class ConfigManager:
         return cls._instance
 
     def set(self, path: str):
-        print(f"MITIM > Setting configuration file to: {path}")
+        if self._config_file_path is not None:
+            printMsg(f"MITIM > Setting configuration file to: {path}")
+        else:
+            print(f"MITIM > Setting configuration file to: {path}")
         self._config_file_path = path
 
     def get(self):
         if self._config_file_path is None:
             self._config_file_path = IOtools.expandPath("$MITIM_CONFIG")
             if os.path.exists(self._config_file_path):
-                print(f"MITIM Configuration file path taken from $MITIM_CONFIG = {self._config_file_path}", typeMsg='i')
+                printMsg(f"MITIM Configuration file path taken from $MITIM_CONFIG = {self._config_file_path}", typeMsg='i')
             else:
                 from mitim_tools import __mitimroot__
                 self._config_file_path = __mitimroot__ + "/templates/config_user.json"
-                print(f"MITIM Configuration file path not set, assuming {self._config_file_path}", typeMsg='i')
+                printMsg(f"MITIM Configuration file path not set, assuming {self._config_file_path}", typeMsg='i')
         return self._config_file_path
 
 config_manager = ConfigManager()


### PR DESCRIPTION
- Use Python built-in `issubclass()` function to check class definition object equality including possible inheritances (Note that Python built-in `isinstance()` function should be used for class instances)
- Remove calling of `printMsg()` when loading config file via `config_manager.set_config()`, which requires config file to already be set
- Added function `GACODE_PROFILES.toNumpyArrays()` to ensure all items in `GACODE_PROFILES.profiles` and `GACODE_PROFILES.derived` dictionaries are of type `numpy.ndarray`
- Added function `powerstate.to_cpu_tensors()` to ensure all items in `powerstate.plasma`, `powerstate.plasma_fine`, `powerstate.Xcurrent` and `powerstate.FluxMatch_Yopt` are moved to the CPU for downstream processing (This also calls `toNumpyArrays()` on `powerstate.profiles` if present)