### PR TITLE
Neoclassical Er, TGLF 2D plots, in-process TGLF/NEO/VGEN via ctypes, NPZ

### DIFF
--- a/docs/capabilities/freegsu_capabilities.rst
+++ b/docs/capabilities/freegsu_capabilities.rst
@@ -8,7 +8,7 @@ Once setup has been successful, the following regression test should run smoothl
 
 .. code-block:: console
 
-   python3 MITIM-fusion/tests/FREEGSU_workflow.py
+   python3 MITIM-fusion/tests/FREEGS_workflow.py
 
 *Under Development*
 

--- a/docs/capabilities/shell_scripts.rst
+++ b/docs/capabilities/shell_scripts.rst
@@ -1,6 +1,6 @@
 Shell Scripts
-====
-To run available shell scripts, go to your temineral, type the name of the script, and any required arguments. For the plotting scripts, usually the 
+=============
+To run available shell scripts, go to your terminal, type the name of the script, and any required arguments. For the plotting scripts, usually the 
 path to the folder in which the run was done is required. To see more information about the script including required arguments: 
 
 .. code-block:: bash
@@ -14,9 +14,12 @@ The following shell scripts are available in the MITIM-fusion repository:
 - mitim_plot_gacode
 - mitim_plot_tgyro
 - mitim_plot_tglf
+- mitim_plot_vgen
 - mitim_plot_cgyro
+- mitim_plot_gx
 - mitim_plot_eq
 - mitim_plot_transp
+- mitim_plot_eped
 - mitim_plot_opt
 - mitim_plot_portals
 - mitim_plot_maestro
@@ -24,14 +27,20 @@ The following shell scripts are available in the MITIM-fusion repository:
 **TRANSP**
 
 - mitim_trcheck
-- mitim_trcheck_p 
+- mitim_trcheck_p
 - mitim_trclean
-- mitim_trlook 
+- mitim_trlook
 - mitim_run_transp
+
+**Run tools**
+
+- mitim_run_tglf
+- mitim_run_portals
+- mitim_run_maestro
 
 **Miscellaneous**
 
-- mitim_run_tglf
-- mitim_slurm 
+- mitim_slurm
 - mitim_compare_nml
 - mitim_scp
+- mitim_check_maestro

--- a/docs/capabilities/tglf_capabilities.rst
+++ b/docs/capabilities/tglf_capabilities.rst
@@ -1,8 +1,8 @@
 TGLF
 ====
 
-**MITIM** can be used to run the TGLF model, interpret results, plot revelant quantities and perform scans and transport analyses.
-This framework does not provide linceses or support to run TGLF, therefore, please see :ref:`Installation` for information on how to get TGLF working and how to configure your setup.
+**MITIM** can be used to run the TGLF model, interpret results, plot relevant quantities and perform scans and transport analyses.
+This framework does not provide licenses or support to run TGLF, therefore, please see :ref:`Installation` for information on how to get TGLF working and how to configure your setup.
 
 Once setup has been successful, the following regression test should run smoothly:
 
@@ -121,6 +121,11 @@ As a result, a TGLF notebook with different tabs will be opened with all relevan
 Run TGLF from TRANSP results file
 ---------------------------------
 
+.. deprecated::
+
+   The ``prep_using_tgyro()`` method used in this workflow is deprecated and will be removed in a future release.
+   Consider preparing an ``input.gacode`` file separately and using the standard ``prep()`` workflow described in the previous section.
+
 If instead of an input.gacode, you have a TRANSP .CDF file (``cdf_file``) and want to run TGLF at a specific time (``time``) with an +- averaging time window (``avTime``), you must initialize the TGLF class as follows:
 
 .. code-block:: python
@@ -144,7 +149,7 @@ Similarly as in the previous section, you need to run the ``prep()`` command, bu
 
 .. note::
 
-    The ``.prep()`` method, when applied to a case that starts from a TRANSP .CDF file, now performs two extra operations:
+    The ``.prep_using_tgyro()`` method performs two extra operations:
 
     - **TRXPL** (https://w3.pppl.gov/~hammett/work/GS2/docs/trxpl.txt) to generate *plasmastate.cdf* and *.geq* files for a specific time-slice from the TRANSP outputs.
 
@@ -210,7 +215,7 @@ Run 1D scans of TGLF input parameter
 
 *Under Development*
 
-*(In the meantime, please checkout* `tutorials/TGLF_tutorial.py <https://github.com/pabloprf/MITIM-fusion/blob/main/tutorials/PORTALS_tutorial.py>`_ *)*
+*(In the meantime, please checkout* `tutorials/TGLF_tutorial.py <https://github.com/pabloprf/MITIM-fusion/blob/main/tutorials/TGLF_tutorial.py>`_ *)*
 
 
 TGLF aliases

--- a/docs/capabilities/tgyro_capabilities.rst
+++ b/docs/capabilities/tgyro_capabilities.rst
@@ -1,8 +1,8 @@
 TGYRO
 =====
 
-**MITIM** can be used to run the TGYRO transport solver, interpret results and plot revelant quantities.
-This framework does not provide linceses or support to run TGYRO, therefore, please see :ref:`Installation` for information on how to get TGYRO working and how to configure your setup.
+**MITIM** can be used to run the TGYRO transport solver, interpret results and plot relevant quantities.
+This framework does not provide licenses or support to run TGYRO, therefore, please see :ref:`Installation` for information on how to get TGYRO working and how to configure your setup.
 
 Once setup has been successful, the following regression test should run smoothly:
 

--- a/docs/capabilities/transp_capabilities.rst
+++ b/docs/capabilities/transp_capabilities.rst
@@ -1,8 +1,8 @@
 TRANSP
 ======
 
-**MITIM** can be used to run TRANSP, interpret results and plot revelant quantities.
-This framework does not provide linceses or support to run TRANSP, therefore, please see :ref:`Installation` for information on how to get TRANSP working and how to configure your setup.
+**MITIM** can be used to run TRANSP, interpret results and plot relevant quantities.
+This framework does not provide licenses or support to run TRANSP, therefore, please see :ref:`Installation` for information on how to get TRANSP working and how to configure your setup.
 
 Once setup has been successful, the following regression test should run smoothly:
 

--- a/docs/capabilities/vitals_capabilities.rst
+++ b/docs/capabilities/vitals_capabilities.rst
@@ -51,7 +51,7 @@ As a starting point of VITALS, you need to prepare and run TGLF for the base cas
 
 	    tglf.read( label = 'run_base', d_perp_cm = { rho: 1.9 } )
 
-	Currently, the synhetic diagnostic to produce fluctuation levels out of amplitude spectra is handled by the ``convolution_CECE`` function in ``mitim/gacode_tools/GACODEdefaults.py``. To understand the meaning of the ``d_perp_cm`` keyword argument provided above, please check out the code.
+	Currently, the synthetic diagnostic to produce fluctuation levels out of amplitude spectra is handled by the ``convolution_CECE`` function in ``mitim_tools/gacode_tools/utils/GACODEdefaults.py``. To understand the meaning of the ``d_perp_cm`` keyword argument provided above, please check out the code.
 
 Now, once TGLF has run and outputs have been read and stored in the ``tglf.results`` dictionary, information about the experiment needs to be provided. Note that the errors (standard deviation) are provided in absolute units (MW/m^2), but the Qe and Qi errors in the example above are written such as they are 20% from the base case. This is because the TGLF object already includes those experimental fluxes because they existed in the *input.gacode* file. However, this way of specifying the error is completely up to the user.
 
@@ -73,7 +73,7 @@ Now, once TGLF has run and outputs have been read and stored in the ``tglf.resul
 
 		tglf.NormalizationSets['EXP']['exp_TeFluct_rho']    = [rho]
 		tglf.NormalizationSets['EXP']['exp_TeFluct']        = [1.12] # Percent fluctuation
-		tglf.NormalizationSets['EXP']['exp_TeFluct_error']  = [0.1]  # Abolute error
+		tglf.NormalizationSets['EXP']['exp_TeFluct_error']  = [0.1]  # Absolute error
 
 		tglf.NormalizationSets['EXP']['exp_neTe_rho']       = [rho]
 		tglf.NormalizationSets['EXP']['exp_neTe']           = [-130] # Degrees
@@ -88,7 +88,7 @@ At this point, the TGLF class is ready to go into VITALS. One can give the ``tgl
 	tglf.save_pkl(tglf_file)
 
 
-1. VITALS Run 
+2. VITALS Run
 -------------
 
 First you must select the objective functions (``ofs``) you want VITALS to match:
@@ -125,7 +125,7 @@ Once the VITALS object has been created, parameters such as the TGLF control inp
 
 .. note::
 
-	At this point, the parameter ``vitals_fun.VITALSparameters['launchSlurm']`` is defaulted to ``False``. However, if the user wants to run VITALS as a slurm job in a cluster, this parameter should be set to ``True``.
+	At this point, the parameter ``vitals_fun.VITALSparameters['launchSlurm']`` is defaulted to ``True``. If the user does not want to run VITALS as a slurm job, this parameter should be set to ``False``.
 
 We are now ready to prepare the VITALS class. Here we have two options:
 
@@ -155,9 +155,9 @@ We can plot the VITALS results easily with:
 
 .. code-block:: python
 
-	vitals_fun.plot_optimization_results(full=True)
+	vitals_fun.plot_optimization_results(analysis_level=2)
 
-In the previous command, ``full=True`` means that VITALS will now run TGLF again for the base case (Evaluation #0) and the best case (best in terms of the lowest mean residual), then it will plot them together as a TGLF Notebook.
+In the previous command, ``analysis_level=2`` means that VITALS will perform a full analysis, running TGLF again for the base case (Evaluation #0) and the best case (best in terms of the lowest mean residual), then plotting them together as a TGLF Notebook.
 All information of the optimization process is also included in tabs in the notebook.
 
 .. figure:: ./figs/VITALSnotebook1.png

--- a/docs/detailed/grid_transformations.rst
+++ b/docs/detailed/grid_transformations.rst
@@ -1,0 +1,273 @@
+Grid Transformations and Profile Flow
+======================================
+
+PORTALS optimizes plasma profiles by working in normalized-gradient space (:math:`a/L_T`, :math:`a/L_n`) on a
+coarse radial grid of ~5 control points. Transport codes (TGLF, CGYRO, NEO) need full profiles on a fine
+grid. This page documents every grid transformation, interpolation, and derivative computation that happens
+along the way --- and the subtle numerical issues that arise from them.
+
+
+Grid types
+----------
+
+MITIM uses several radial grids throughout the workflow. Understanding which grid is active at each stage
+is essential for debugging discrepancies.
+
+.. list-table::
+   :widths: 20 15 65
+   :header-rows: 1
+
+   * - Grid
+     - Typical size
+     - Description
+   * - **Original**
+     - ~30--120 pts
+     - The user-provided ``input.gacode`` file. Profiles live on a :math:`\rho` (square root of normalized toroidal flux) coordinate.
+   * - **Enhanced fine**
+     - ~100+ pts
+     - After ``improve_resolution_profiles()``. Uniform fill between control points, plus extra points at :math:`\pm 10^{-3}` and :math:`\pm 2 \times 10^{-3}` around each control point.
+   * - **Coarse powerstate**
+     - ~5 pts
+     - The PORTALS prediction radii (e.g., :math:`\rho = 0.2, 0.4, 0.55, 0.7, 0.85`). These are the free-parameter locations for the optimization. A zero at the axis is prepended internally.
+   * - **Fine targets** (optional)
+     - variable
+     - A higher-resolution grid used only inside ``calculateTargets()`` for more accurate volume integration of power sources (fusion, radiation, exchange).
+   * - **Scalar extraction**
+     - 1 pt per surface
+     - What TGLF/CGYRO/NEO receives: local values at each flux surface, obtained by cubic-spline interpolation from the enhanced fine grid.
+
+
+Workflow overview
+-----------------
+
+The following diagram traces the ``input.gacode`` data from the user's file all the way to what TGLF/CGYRO receives.
+Grid changes and derivative computations are highlighted.
+
+.. code-block:: text
+
+   USER's input.gacode  (~30-120 pts, in rho)
+   |
+   +---> input.gacode_original  (untouched backup)
+   |
+   v
+   profiles.correct(recalculate_ptot=True)
+   |
+   ===== powerstate.__init__() ==========================================
+   |
+   |  improve_resolution_profiles()
+   |     ~40 pts --> ~100+ pts
+   |     Cubic-spline interpolation of all quantities to new grid
+   |     Adds extra points at +/-1e-3, +/-2e-3 of each control point
+   |     ** Modifies profiles IN-PLACE **
+   |
+   |  gacode_to_powerstate()
+   |     ~100+ pts --> ~5 coarse pts
+   |     Cubic-spline interpolation of profiles to powerstate grid
+   |     DERIVATIVE: parameterizers.piecewise_linear()
+   |       Computes a/LT via derivation_into_Lx() on the ~100+ pt grid
+   |       Samples at coarse control points
+   |       Creates profile_constructor functions (fine/coarse/middle)
+   |
+   ===== PORTALSinit: First roundtrip ===================================
+   |
+   |  update_var(): a/LT (coarse) --> integration --> T (coarse)
+   |     ** Profile now differs from original (roundtrip error) **
+   |
+   |  from_powerstate(): a/LT (coarse) --> profile_constructors_fine
+   |     --> T on ~100+ pt grid
+   |     Writes: input.gacode (parameterized), input.gacode_modified
+   |
+   ===== Each PORTALS evaluation ========================================
+   |
+   |  1. update_var(): insert new a/LT, integrate to T on coarse grid
+   |  2. calculateProfileFunctions(): gyro-Bohm norms, collisionality, etc.
+   |  3. calculateTargets(): power balance (optionally on fine targets grid)
+   |  4. _produce_profiles():
+   |       profile_constructors_fine: a/LT (coarse) --> T on ~100+ pt grid
+   |       derive_quantities(): recompute aLTe, aLne, etc. on fine grid
+   |       Write: input.gacode (~100+ pts)
+   |
+   |  5. Transport code input preparation:
+   |       to_tglf() / to_cgyro() / to_neo():
+   |         Cubic-spline interpolation in r/a space to exact flux surface
+   |         --> RLTS, RLNS, DLNTDR, DLNNDR (scalar values per surface)
+   |
+   ======================================================================
+
+
+Key operations
+--------------
+
+Derivative computation
+^^^^^^^^^^^^^^^^^^^^^^
+
+The normalized gradient scale length is defined as:
+
+.. math::
+
+   \frac{a}{L_X} = -\frac{a}{X} \frac{dX}{dr}
+
+MITIM computes this via ``derivation_into_Lx(r, p)``, which uses a **3-point Lagrange interpolating
+polynomial** derivative of :math:`-\ln(p)`. This is the same scheme as GACODE's ``bound_deriv`` in
+``expro_util.f90``, ensuring that MITIM and GACODE (TGLF, CGYRO, NEO) compute identical gradient
+values from the same ``input.gacode`` profiles.
+
+The Lagrange polynomial derivative evaluates at each point :math:`r_i` using its two nearest
+neighbors :math:`(r_{i-1}, r_i, r_{i+1})` for interior points, and a one-sided 3-point stencil
+at the boundaries.
+
+An alternative **central-difference** variant is available as ``derivation_into_Lx_central()``.
+It computes:
+
+.. math::
+
+   z_i = -\frac{\ln p_{i+1} - \ln p_{i-1}}{r_{i+1} - r_{i-1}} \quad \text{(interior points)}
+
+This is structurally more consistent with ``integration_Lx``'s trapezoidal log-space formula and
+reduces the fine-grid roundtrip error by ~30%. However, it uses a different stencil than GACODE's
+``bound_deriv``, which introduces small discrepancies (~0.01%) when transport codes recompute
+gradients from the same ``input.gacode``. For this reason, the Lagrange method is the default.
+
+
+Integration (gradient to profile)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``integration_Lx(x, z, f_bound)`` reconstructs a profile from its normalized gradient, adapted from
+TGYRO's ``tgyro_profile_functions.f90``:
+
+.. math::
+
+   \frac{T_i}{T_{i+1}} = \exp\!\Big[\tfrac{1}{2}(z_i + z_{i+1})(r_{i+1} - r_i)\Big]
+
+where :math:`z = a/L_T` and :math:`f_\text{bound}` is the boundary condition at the last grid point.
+This trapezoidal rule in log-space is **exact** for piecewise-linear :math:`z(r)`, which is the
+representation used after coarse-grid sampling and interpolation.
+
+
+Interpolation coordinate: :math:`r/a` vs :math:`\rho`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When extracting local quantities at a specific flux surface (e.g., for TGLF input), MITIM interpolates
+profiles using a cubic spline. The choice of **which radial coordinate** to use for the spline matters:
+
+- **GACODE's approach**: ``expro_locsim`` in GACODE uses natural cubic splines in :math:`r/a` (``rmin``)
+  space (see ``cub_spline1`` in ``expro_locsim.f90``).
+
+- **MITIM's approach**: The ``to_tglf()``, ``to_cgyro()``, ``to_neo()``, and ``to_gx()`` functions now
+  also interpolate in :math:`r/a` space, matching GACODE's convention. Input :math:`\rho` values are
+  first converted to :math:`r/a` before interpolation.
+
+**Why this matters**: The mapping :math:`\rho \to r/a` is nonlinear (it depends on the magnetic
+equilibrium geometry). For a point that falls between grid nodes, a cubic spline in :math:`\rho` and
+a cubic spline in :math:`r/a` will give slightly different interpolated values. Near the plasma edge
+where the mapping is most nonlinear, the discrepancy can reach ~0.1--0.2%.
+
+By using the same interpolation coordinate as GACODE, MITIM ensures that the gradient values written to
+``input.tglf`` / ``input.cgyro`` match what GACODE's internal routines would compute from
+``input.gacode`` via ``PROFILE_MODEL=2``.
+
+
+Profile reconstruction and the trailing edge
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When PORTALS reconstructs a full profile from coarse gradients (via ``profile_constructors_fine``),
+the following steps are applied:
+
+1. **Piecewise-linear gradient interpolation**: The gradient values at the coarse control points are
+   linearly interpolated to the full fine grid.
+
+2. **smoothAroundCoarsing** (controlled by ``transport.flatten_gradients_at_control_points`` in the PORTALS namelist):
+   The gradient between control points is piecewise-linear, which creates a slope change (kink in
+   gradient space) at each control point. If a code recomputes gradients from the reconstructed
+   profile using a higher-order stencil (e.g., TGYRO's 3-point Lagrange), it will "see" the slope
+   change through neighboring points and return a value that differs from the intended control point
+   gradient.
+
+   When enabled (default: ``true``), the gradient at :math:`\pm 1` neighboring fine-grid points
+   around each control point is flattened to match the control point value. This creates a tiny
+   plateau so that any derivative stencil returns the correct value regardless of its order.
+   The extra points at :math:`\pm 10^{-3}` added by ``improve_resolution_profiles()`` exist
+   specifically to provide these close neighbors; they are skipped when smoothing is disabled.
+
+   When disabled (``false``), the piecewise-linear gradient is left as-is, the :math:`\pm 10^{-3}`
+   extra grid points are not added, and the fine grid is more uniform. This may be preferable
+   when the PORTALS evaluation does not rely on codes that recompute gradients from profiles.
+
+3. **Integration with direct BC**: The gradient profile is integrated via ``integration_Lx`` with the
+   boundary condition applied directly at the last control point. No extra points or rescaling are
+   needed.
+
+4. **Hermite trailing edge blending**: Beyond the last control point, the reconstructed profile must
+   transition back to the original (unmodified) profile. This is done with a C1-continuous Hermite
+   smoothstep blend (:math:`w(t) = 3t^2 - 2t^3`) over a small region (a few grid points). The
+   reconstructed profile is linearly extrapolated from the junction using its last gradient, then
+   blended with the original profile. This eliminates the derivative discontinuity (kink) that
+   previously caused ~0.1% gradient discrepancies when transport codes recomputed gradients from
+   the reconstructed profiles.
+
+
+The roundtrip problem
+---------------------
+
+Converting a profile to gradients and back does not reproduce the original profile:
+
+.. math::
+
+   T \xrightarrow{\text{derivative}} \frac{a}{L_T} \xrightarrow{\text{coarsen to 5 pts}} \xrightarrow{\text{interpolate}} \xrightarrow{\text{integrate}} T' \neq T
+
+The error has two sources:
+
+1. **Derivative--integration mismatch**: No point-value derivative is the exact mathematical inverse of
+   ``integration_Lx``. The integration uses interval averages :math:`\tfrac{1}{2}(z_i + z_{i+1})`,
+   which cannot be uniquely inverted to point values :math:`z_i`.
+
+2. **Coarsening**: Sampling the gradient at ~5 points and piecewise-linearly interpolating loses the
+   original gradient shape between control points.
+
+**Current policy**: PORTALS allows exactly one roundtrip pass at initialization (in ``PORTALSinit``).
+This "bakes in" the roundtrip error but ensures the starting point is self-consistent with the
+parameterization. Subsequent evaluations operate purely in gradient space and do not introduce
+additional roundtrip degradation --- the profile is always reconstructed from the current gradients,
+never re-differentiated.
+
+
+GACODE consistency
+------------------
+
+GACODE's internal derivative (``bound_deriv`` in ``expro_util.f90``) and MITIM's
+``derivation_into_Lx`` are both 2nd-order accurate but use different stencils. When GACODE
+(e.g., CGYRO with ``PROFILE_MODEL=2``) reads the same ``input.gacode`` file and recomputes gradients,
+small differences can arise:
+
+.. list-table::
+   :widths: 30 30 40
+   :header-rows: 1
+
+   * - Source
+     - Typical magnitude
+     - Cause
+   * - Derivative stencil
+     - < 0.01%
+     - Both methods are 2nd-order on the same grid; differences are :math:`O(h^2)` where :math:`h` is the fine grid spacing.
+   * - Interpolation coordinate
+     - ~0.1--0.2% at edge
+     - Fixed by interpolating in :math:`r/a` instead of :math:`\rho` (now implemented).
+   * - Text format truncation
+     - ~0.001%
+     - ``input.gacode`` text format has ~7 significant digits. Derivatives of truncated values differ from derivatives of full-precision values.
+   * - Trailing edge blending
+     - negligible
+     - The Hermite smoothstep blend ensures C1 continuity at the trailing edge junction.
+
+
+Known caveats and future work
+-----------------------------
+
+- **Grid overdimensioning**: The :math:`\pm 10^{-3}` extra points added by
+  ``improve_resolution_profiles()`` exist to support ``smoothAroundCoarsing``. They are automatically
+  skipped when ``transport.flatten_gradients_at_control_points: false`` is set in the PORTALS namelist.
+
+- **Multi-pass idempotency**: Achieving perfect stability (pass 2 = pass 1) through the derivative
+  function alone is not possible because ``integration_Lx`` uses interval averages that cannot be
+  uniquely inverted to point values. True idempotency would require changes at the parameterization
+  level (e.g., self-consistent initialization via iterative gradient correction).

--- a/docs/detailed/index.rst
+++ b/docs/detailed/index.rst
@@ -1,0 +1,11 @@
+Technical Details
+=================
+
+These pages document the numerical methods, grid transformations, and internal design decisions in MITIM.
+They are intended for developers and advanced users who need to understand what happens under the hood,
+why certain choices were made, and where subtle discrepancies can arise.
+
+.. toctree::
+   :maxdepth: 2
+
+   grid_transformations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ significantly boosting the efficiency and effectiveness of their studies (see :r
    installation
    capabilities/standalone
    capabilities/optimization
+   detailed/index
    faq
 
 .. note:: 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,7 +33,7 @@ Use ``pip`` to install all the required MITIM requirements:
 
 .. note::
    
-   The optional argument ``[pyqt]`` added in the intallation command above must only be used if the machine allows for graphic interfaces.
+   The optional argument ``[pyqt]`` added in the installation command above must only be used if the machine allows for graphic interfaces.
    If running in a computing cluster, remove that flag.
    The ``pyqt`` package is used to create condensed figures into a single notebook when interpreting and plotting simulation results.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ test = [
 mitim_plot_gacode = "mitim_tools.gacode_tools.scripts.read_gacode:main"
 mitim_plot_tgyro = "mitim_tools.gacode_tools.scripts.read_tgyro:main"
 mitim_plot_tglf = "mitim_tools.gacode_tools.scripts.read_tglf:main"      # [--suffix _0.55] [--gacode input.gacode]
+mitim_plot_vgen = "mitim_tools.gacode_tools.scripts.read_vgen:main"      # <folder> [--gacode input.gacode]
 mitim_plot_cgyro = "mitim_tools.gacode_tools.scripts.read_cgyro:main"
 mitim_plot_gx = "mitim_tools.simulation_tools.scripts.read_gx:main"
 mitim_plot_eq = "mitim_tools.gs_tools.scripts.read_eq:main"

--- a/src/mitim_modules/portals/utils/PORTALSanalysis.py
+++ b/src/mitim_modules/portals/utils/PORTALSanalysis.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import torch
 import json
 import numpy as np
@@ -13,6 +14,16 @@ from mitim_modules.powertorch import STATEtools
 from mitim_modules.powertorch.utils import POWERplot
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from IPython import embed
+
+
+_TRAILING_INT_RE = re.compile(r"(\d+)$")
+
+
+def _extract_trailing_int(name):
+    """Return the trailing integer of a folder / file name, or None if there isn't one.
+    Used to sort `portals_sr_ev_<n>` folders and `input.gacode.<n>` files numerically."""
+    m = _TRAILING_INT_RE.search(name)
+    return int(m.group(1)) if m else None
 
 class PORTALSanalyzer:
     # ****************************************************************************
@@ -1018,28 +1029,57 @@ class PORTALSinitializer:
     def __init__(self, folder):
         self.folder = IOtools.expandPath(folder)
 
-        # Read powerstates
-        self.powerstates = []
+        # Read profiles that have already been emitted by the Evaluation pipeline.
+        # We glob + numerically sort rather than walking a contiguous integer range so that
+        # partial-initialization states with gaps (e.g. trajectory 0 finished, trajectory 1
+        # still running) do not truncate the list at the first missing index.
         self.profiles = []
-        for i in range(100):
+        profiles_dir = self.folder / "Outputs" / "portals_profiles"
+        profile_files = sorted(
+            profiles_dir.glob("input.gacode.*"),
+            key=lambda p: _extract_trailing_int(p.name),
+        ) if profiles_dir.exists() else []
+        for prof_path in profile_files:
+            if _extract_trailing_int(prof_path.name) is None:
+                continue
             try:
-                prof = PROFILEStools.gacode_state(
-                    self.folder / "Outputs" / "portals_profiles" / f"input.gacode.{i}"
-                )
+                self.profiles.append(PROFILEStools.gacode_state(prof_path))
             except FileNotFoundError:
-                break
-            self.profiles.append(prof)
+                continue
 
-        for i in range(100):
-            try:
-                p = STATEtools.read_saved_state(
-                    self.folder / "Initialization" / "initialization_simple_relax" / f"portals_sr_ev_{i}" / "powerstate.pkl"
-                )
-            except FileNotFoundError:
-                break
-
-            p.profiles.derive_quantities()
-            self.powerstates.append(p)
+        # Read powerstates written by initialization_simple_relax. Folders are laid out in
+        # step-major order across parallel trajectories (see PORTALSoptimization.initialization_simple_relax),
+        # so we glob every `portals_sr_ev_*` directory and sort by the numeric suffix. Each folder
+        # may or may not yet contain `powerstate.pkl` — skip the ones that don't.
+        self.powerstates = []
+        init_dir = self.folder / "Initialization" / "initialization_simple_relax"
+        if init_dir.exists():
+            powerstate_dirs = sorted(
+                (d for d in init_dir.glob("portals_sr_ev_*") if d.is_dir()),
+                key=lambda d: _extract_trailing_int(d.name) or 0,
+            )
+            for d in powerstate_dirs:
+                pkl = d / "powerstate.pkl"
+                if not pkl.exists():
+                    continue
+                try:
+                    p = STATEtools.read_saved_state(pkl)
+                except FileNotFoundError:
+                    continue
+                # A powerstate saved during a multi-trajectory parallel relax could, in principle,
+                # carry batch_size > 1. Fan it out into one single-batch copy per batch element so
+                # the downstream plotting code — which iterates `self.powerstates` and calls
+                # `.item()` on scalar residuals — keeps working without per-site batch handling.
+                batch_size = getattr(p, "batch_size", 0) or 1
+                if batch_size <= 1:
+                    p.profiles.derive_quantities()
+                    self.powerstates.append(p)
+                else:
+                    for b in range(batch_size):
+                        p_b = copy.deepcopy(p)
+                        p_b._repeat_tensors(batch_size=1, positionToUnrepeat=b)
+                        p_b.profiles.derive_quantities()
+                        self.powerstates.append(p_b)
 
         self.fn = None
 

--- a/src/mitim_modules/portals/utils/PORTALSanalysis.py
+++ b/src/mitim_modules/portals/utils/PORTALSanalysis.py
@@ -433,6 +433,17 @@ class PORTALSanalyzer:
 
             self.fn = FigureNotebook("PORTALS Summary", geometry="1700x1000", show=not noshow)
 
+        # Always attempt to render the SR initialization as the first tab — it shows the
+        # simple-relax trajectory that seeded the BO loop, which is useful context even
+        # (especially) after the run has progressed past initialization.
+        try:
+            sr_init = PORTALSinitializer(self.opt_fun.folder)
+            if len(sr_init.powerstates) > 0:
+                fig_init = self.fn.add_figure(label="SR Initialization", tab_color=tab_color_istart if tabs_colors_common is None else tabs_colors_common)
+                sr_init.plotMetrics(fig=fig_init)
+        except Exception:
+            pass
+
         fig = self.fn.add_figure(label="PROFILES Ranges", tab_color=tab_color_istart if tabs_colors_common is None else tabs_colors_common)
         self.plotRanges(fig=fig)
 
@@ -1036,7 +1047,7 @@ class PORTALSinitializer:
         self.profiles = []
         profiles_dir = self.folder / "Outputs" / "portals_profiles"
         profile_files = sorted(
-            profiles_dir.glob("input.gacode.*"),
+            (p for p in profiles_dir.glob("input.gacode.*") if _extract_trailing_int(p.name) is not None),
             key=lambda p: _extract_trailing_int(p.name),
         ) if profiles_dir.exists() else []
         for prof_path in profile_files:
@@ -1052,6 +1063,7 @@ class PORTALSinitializer:
         # so we glob every `portals_sr_ev_*` directory and sort by the numeric suffix. Each folder
         # may or may not yet contain `powerstate.pkl` — skip the ones that don't.
         self.powerstates = []
+        self.n_trajectories = 1
         init_dir = self.folder / "Initialization" / "initialization_simple_relax"
         if init_dir.exists():
             powerstate_dirs = sorted(
@@ -1066,11 +1078,9 @@ class PORTALSinitializer:
                     p = STATEtools.read_saved_state(pkl)
                 except FileNotFoundError:
                     continue
-                # A powerstate saved during a multi-trajectory parallel relax could, in principle,
-                # carry batch_size > 1. Fan it out into one single-batch copy per batch element so
-                # the downstream plotting code — which iterates `self.powerstates` and calls
-                # `.item()` on scalar residuals — keeps working without per-site batch handling.
                 batch_size = getattr(p, "batch_size", 0) or 1
+                if batch_size > 1:
+                    self.n_trajectories = batch_size
                 if batch_size <= 1:
                     p.profiles.derive_quantities()
                     self.powerstates.append(p)
@@ -1104,7 +1114,29 @@ class PORTALSinitializer:
 
         axs, axsM = STATEtools.add_axes_powerstate_plot(figMain, num_kp=np.max([3,len(self.powerstates[-1].predicted_channels)]))
 
-        colors = GRAPHICStools.listColors()
+        n_traj = self.n_trajectories
+        n_ps = len(self.powerstates)
+        steps_per_traj = n_ps // n_traj if n_traj > 1 else n_ps
+
+        # Per-trajectory color palette: each trajectory gets a distinct base color.
+        # Within a trajectory, steps use the same color with increasing alpha.
+        _TRAJ_COLORS = ['tab:blue', 'tab:red', 'tab:green', 'tab:orange', 'tab:purple',
+                        'tab:brown', 'tab:pink', 'tab:gray', 'tab:olive', 'tab:cyan']
+        if n_traj > 1:
+            import matplotlib.colors as mcolors
+            def _color_for(traj, step):
+                base = mcolors.to_rgba(_TRAJ_COLORS[traj % len(_TRAJ_COLORS)])
+                alpha = 0.35 + 0.65 * (step / max(steps_per_traj - 1, 1))
+                return (*base[:3], alpha)
+            def _label_for(traj, step):
+                return f"T{traj} s{step}"
+        else:
+            all_colors = GRAPHICStools.listColors()
+            def _color_for(traj, step):
+                return all_colors[step % len(all_colors)]
+            def _label_for(traj, step):
+                return f"#{step}"
+
         axsGrads_extra = []
         cont = 0
         for i in range(np.max([3,len(self.powerstates[-1].predicted_channels)])):
@@ -1117,16 +1149,25 @@ class PORTALSinitializer:
         # ---------------------------------------------------------------------------------
 
         if len(self.powerstates) > 0:
-            for i in range(len(self.powerstates)):
-                self.powerstates[i].plot(axs=axs, c=colors[i], label=f"#{i}")
+            for i in range(n_ps):
+                if n_traj > 1:
+                    # Step-major order: index i maps to (step, traj)
+                    traj_idx = i % n_traj
+                    step_idx = i // n_traj
+                else:
+                    traj_idx, step_idx = 0, i
 
-                # Add profiles too
+                c = _color_for(traj_idx, step_idx)
+                lab = _label_for(traj_idx, step_idx)
+
+                self.powerstates[i].plot(axs=axs, c=c, label=lab)
+
                 self.powerstates[i].profiles.plot_gradients(
                     axsGrads_extra,
-                    color=colors[i],
+                    color=c,
                     plotImpurity=self.powerstates[-1].impurityPosition if 'nZ' in self.powerstates[-1].predicted_channels else None,
                     plotRotation='w0' in self.powerstates[0].predicted_channels,
-                    ls='-',
+                    ls='-' if n_traj <= 1 else ('-' if traj_idx == 0 else '--'),
                     lw=0.5,
                     lastRho=self.powerstates[0].plasma["rho"][-1, -1].item(),
                     label='',
@@ -1135,10 +1176,11 @@ class PORTALSinitializer:
             axs[0].legend(prop={"size": 8})
 
         # Add next profile
+        next_color = 'k'
         if len(self.profiles) > len(self.powerstates):
             self.profiles[-1].plot_gradients(
                 axsGrads_extra,
-                color=colors[i+1],
+                color=next_color,
                 plotImpurity=self.powerstates[-1].impurityPosition_transport if 'nZ' in self.powerstates[-1].predicted_channels else None,
                 plotRotation='w0' in self.powerstates[0].predicted_channels,
                 ls='-',
@@ -1152,7 +1194,8 @@ class PORTALSinitializer:
             axsM,
             self.powerstates,
             profiles = self.profiles[-1] if len(self.profiles) > len(self.powerstates) else None,
-            profiles_color=colors[i+1],
+            profiles_color=next_color,
+            n_trajectories=n_traj,
         )
 
         # GRADIENTS
@@ -1161,24 +1204,30 @@ class PORTALSinitializer:
                 grid = plt.GridSpec(2, 5, hspace=0.3, wspace=0.3)
                 axsGrads = []
                 for j in range(5):
-                    for i in range(2):
-                        axsGrads.append(figG.add_subplot(grid[i, j]))
+                    for ii in range(2):
+                        axsGrads.append(figG.add_subplot(grid[ii, j]))
                 for i, p in enumerate(self.powerstates):
+                    if n_traj > 1:
+                        traj_idx = i % n_traj
+                        step_idx = i // n_traj
+                    else:
+                        traj_idx, step_idx = 0, i
+                    c = _color_for(traj_idx, step_idx)
+                    lab = _label_for(traj_idx, step_idx)
                     p.profiles.plot_gradients(
                         axsGrads,
-                        color=colors[i],
+                        color=c,
                         plotImpurity=p.impurityPosition if 'nZ' in p.predicted_channels else None,
                         plotRotation='w0' in p.predicted_channels,
                         lastRho=self.powerstates[0].plasma["rho"][-1, -1].item(),
-                        label=f"profile #{i}",
+                        label=lab,
                     )
-
 
                 if len(self.profiles) > len(self.powerstates):
                     prof = self.profiles[-1]
                     prof.plot_gradients(
                         axsGrads,
-                        color=colors[i+1],
+                        color=next_color,
                         plotImpurity=p.impurityPosition_transport if 'nZ' in p.predicted_channels else None,
                         plotRotation='w0' in p.predicted_channels,
                         lastRho=p.plasma["rho"][-1, -1].item(),

--- a/src/mitim_modules/portals/utils/PORTALSoptimization.py
+++ b/src/mitim_modules/portals/utils/PORTALSoptimization.py
@@ -295,7 +295,13 @@ def initialization_simple_relax(self):
             i = s * n_traj + t
             ff = self.folderExecution / "Execution" / f"Evaluation.{i}"
             ff.mkdir(parents=True, exist_ok=True)
-            source = MainFolder / f"portals_sr_ev_{s}" / "transport_simulation_folder" / f"plasma_{t}"
+
+            # For n_traj > 1 the batched evaluate path writes per-plasma sub-folders
+            # (plasma_0/, plasma_1/, ...) under each step's transport_simulation_folder.
+            # For n_traj == 1 the normal single-plasma evaluate path writes directly at
+            # the transport_simulation_folder level (no plasma_* sub-dir).
+            step_folder = MainFolder / f"portals_sr_ev_{s}" / "transport_simulation_folder"
+            source = step_folder / f"plasma_{t}" if n_traj > 1 else step_folder
 
             if (ff / "transport_simulation_folder").exists():
                 IOtools.shutil_rmtree(ff / "transport_simulation_folder")

--- a/src/mitim_modules/portals/utils/PORTALSoptimization.py
+++ b/src/mitim_modules/portals/utils/PORTALSoptimization.py
@@ -34,6 +34,7 @@ _SIMPLE_RELAX_ALLOWED_KEYS = {
     "relax", "dx_max", "dx_max_abs", "dx_min_abs",
     "relax_dyn", "relax_dyn_decrease", "relax_dyn_num",
     "tol", "tol_rel", "print_each",
+    "perturbation_base",
 }
 
 
@@ -185,8 +186,6 @@ def initialization_simple_relax(self):
         if not any_value:
             return None
         if any(v is None for v in vals):
-            # dx_max_abs is allowed to be None per-trajectory; a mixed None/float list is
-            # not something torch.where handles cleanly, so forbid it.
             raise ValueError(
                 f"initialization_params[*]['{key}'] mixes None and numeric entries; either "
                 "set a numeric value for every trajectory or omit the key from all of them."
@@ -208,6 +207,7 @@ def initialization_simple_relax(self):
     scalar_defaults.pop('dx_max', None)
     scalar_defaults.pop('dx_max_abs', None)
     scalar_defaults.pop('dx_min_abs', None)
+    scalar_defaults.pop('perturbation_base', None)
 
     solver_options = {
         'tol':             scalar_defaults.get('tol', None),
@@ -223,12 +223,10 @@ def initialization_simple_relax(self):
         'namingConvention': 'portals_sr_ev_batched',
     }
 
-    # Replicate the caller's powerstate to an N-batched view and stamp base_X across every
-    # batch row. flux_match builds x0 as (plasma.rho.shape[0], dvs) = (n_traj, dvs) and
-    # simple_relaxation walks all n_traj trajectories in lockstep, calling the evaluator
-    # once per step with the full batched X. The evaluator in turn runs one batched
-    # `self.calculate(X, folder=folder_run)` per step, which now routes to
-    # `power_transport._evaluate_batched` (triggered on powerstate.batch_size > 1).
+    # Replicate the caller's powerstate to an N-batched view. Each trajectory's starting
+    # point is base_X * (1 + perturbation_base), where perturbation_base defaults to 0
+    # (exact base) and can be set per-trajectory to create diversity (e.g. 0.1 = gradients
+    # increased by 10%).
     traj_state = copy.deepcopy(self.optimization_object.powerstate)
     traj_state._repeat_tensors(batch_size=n_traj)
 
@@ -236,7 +234,40 @@ def initialization_simple_relax(self):
         self.optimization_options["problem_options"]["dvs_base"]
     ).to(self.dfT)
     base_X_batched = base_X_row.unsqueeze(0).repeat(n_traj, 1)
+
+    perturbations = [float(tp.get('perturbation_base', 0.0)) for tp in traj_params]
+    for t in range(n_traj):
+        if perturbations[t] != 0.0:
+            base_X_batched[t, :] = base_X_row * (1.0 + perturbations[t])
+
     traj_state.modify(base_X_batched)
+
+    # ---------------------------------------------------------------------------
+    # Print SR information block before starting
+    # ---------------------------------------------------------------------------
+    n_radii = traj_state.plasma["rho"].shape[1] - 1
+    n_channels = len(traj_state.predicted_channels)
+
+    print("\n" + "=" * 80)
+    print("  PORTALS Simple-Relax Initialization")
+    print("=" * 80)
+    print(f"  Trajectories:         {n_traj}")
+    print(f"  Steps per trajectory: {steps_per_traj}")
+    print(f"  Total training pts:   {self.Originalinitial_training}")
+    print(f"  Effective maxiter:    {effective_maxiter} (skip_initial={skip_initial})")
+    print(f"  Radii (per plasma):   {n_radii}  ({', '.join(traj_state.predicted_channels)})")
+    print(f"  Seed addon_relax:     {addon_relax:+.4f}")
+    print(f"  Base X (dvs_base):    [{', '.join(f'{v:.3f}' for v in base_X_row.tolist())}]")
+    print(f"  ----- Per-step parallelism: {n_traj} trajectories x {n_radii} radii "
+          f"= {n_traj * n_radii} concurrent transport calls (TGLF + NEO)")
+    for t, tp in enumerate(traj_params):
+        pert = perturbations[t]
+        relax_val = relax_tensor[t].item() if relax_tensor is not None else _SIMPLE_RELAX_DEFAULTS['relax'] + addon_relax
+        dx_max_val = dx_max_tensor[t].item() if dx_max_tensor is not None else _SIMPLE_RELAX_DEFAULTS['dx_max']
+        dx_min_val = dx_min_abs_tensor[t].item() if dx_min_abs_tensor is not None else _SIMPLE_RELAX_DEFAULTS['dx_min_abs']
+        print(f"  Trajectory {t}: relax={relax_val:.4f}  dx_max={dx_max_val:.3f}  "
+              f"dx_min_abs={dx_min_val:.3f}  perturbation_base={pert:+.2%}")
+    print("=" * 80 + "\n")
 
     traj_state.flux_match(
         algorithm="simple_relax",

--- a/src/mitim_modules/portals/utils/PORTALSoptimization.py
+++ b/src/mitim_modules/portals/utils/PORTALSoptimization.py
@@ -125,8 +125,30 @@ def initialization_simple_relax(self):
     # (see STATEtools.flux_match) interleaves the step-s outputs of every trajectory into
     # positions `s * n_traj + t` so the resulting sequence portals_sr_ev_0..N-1 is step-major
     # and matches the Execution.{i} numbering downstream.
-    def _make_namer(traj_idx, n):
-        return lambda step: f"portals_sr_ev_{step * n + traj_idx}"
+    #
+    # Multi-trajectory subtlety: simple_relaxation records x_initial (= base_X) as the very
+    # first x_history entry of every trajectory. If we were to keep those, the step-0 row
+    # of every trajectory would be *identical* base_X, train_X would contain N duplicate
+    # rows, and optimization_data.find_point(base_X) downstream would match all N rows and
+    # crash on `df['Iteration'].item()`. To avoid that we run one extra relax iteration per
+    # trajectory (effective_maxiter = steps_per_traj + 1) and skip x_history[0] when
+    # collecting training points. That extra evaluation lands in a throwaway sub-folder
+    # `portals_sr_base_traj{t}` that is intentionally *not* matched by the
+    # `portals_sr_ev_*` glob used by PORTALSinitializer and the Evaluation.{i} copy loop.
+    # For the single-trajectory case no duplication is possible, so we keep the historical
+    # behaviour (x_initial included as the first training point, no throwaway folder).
+    skip_initial = n_traj > 1
+    effective_maxiter = steps_per_traj + (1 if skip_initial else 0)
+
+    if skip_initial:
+        def _make_namer(traj_idx, n):
+            return lambda step: (
+                f"portals_sr_base_traj{traj_idx}" if step == 0
+                else f"portals_sr_ev_{(step - 1) * n + traj_idx}"
+            )
+    else:
+        def _make_namer(traj_idx, n):
+            return lambda step: f"portals_sr_ev_{step * n + traj_idx}"
 
     Xopt_per_traj = []
     for t, user_overrides in enumerate(traj_params):
@@ -135,7 +157,7 @@ def initialization_simple_relax(self):
         # The seed-driven jitter is applied on top of the (possibly user-overridden) relax value
         # so setting `relax: 0.1` in the namelist lands at 0.1 ± addon_relax, not 0.2 ± addon_relax.
         solver_options["relax"] = solver_options["relax"] + addon_relax
-        solver_options["maxiter"] = steps_per_traj
+        solver_options["maxiter"] = effective_maxiter
         solver_options["folder"] = MainFolder
         solver_options["folder_namer"] = _make_namer(t, n_traj)
         # `namingConvention` is still consulted by the evaluator for `nameRun` logging — keep it
@@ -148,7 +170,10 @@ def initialization_simple_relax(self):
             algorithm="simple_relax",
             solver_options=solver_options,
         )
-        Xopt_per_traj.append(traj_state.FluxMatch_Xopt)
+        Xopt_traj = traj_state.FluxMatch_Xopt
+        if skip_initial:
+            Xopt_traj = Xopt_traj[1:]   # drop the shared base_X so the stack has no duplicates
+        Xopt_per_traj.append(Xopt_traj)
 
     # -------------------------------------------------------------------------------------------
     # Once every trajectory has completed, copy the step-major folder sequence into

--- a/src/mitim_modules/portals/utils/PORTALSoptimization.py
+++ b/src/mitim_modules/portals/utils/PORTALSoptimization.py
@@ -90,9 +90,46 @@ def initialization_simple_relax(self):
     # `optimization_options.initialization_options.initialization_params` (a list of
     # per-trajectory solver-option dicts). Each trajectory walks toward flux matching with
     # its own (relax, dx_max, …) and contributes `initial_training / N` points to the
-    # initial training set. All trajectories land in a single step-major folder sequence
-    # `portals_sr_ev_0..initial_training-1` so downstream code (Execution.{i} copy loop,
-    # PORTALSinitializer plotting) sees a flat list of evaluations exactly as before.
+    # initial training set.
+    #
+    # Implementation — one batched flux_match call, not a Python for-loop over trajectories:
+    #
+    #   1. Deep-copy the caller's powerstate once and tile its plasma tensors to N batches
+    #      via `_repeat_tensors(batch_size=n_traj)`. Every `plasma[*]` tensor now carries an
+    #      explicit leading batch axis of length n_traj.
+    #   2. Build per-trajectory tensor versions of the simple-relax solver knobs
+    #      (relax, dx_max, dx_max_abs, dx_min_abs) of shape (n_traj, 1) — `_sr_step` already
+    #      accepts per-batch tensors via its torch.where clamps, so the relax math iterates
+    #      in lockstep over the N trajectories for free.
+    #   3. Call `powerstate.flux_match(algorithm="simple_relax", solver_options=...)` exactly
+    #      once. Inside STATEtools.flux_match the evaluator constructs `x0` of shape
+    #      (n_traj, dvs) straight from the batched plasma and calls `self.calculate(X, ...)`
+    #      on the N-wide batch. `power_transport.evaluate` dispatches to `_evaluate_batched`,
+    #      which fans every (plasma, rho) work unit through `mitim_simulation.run_over_plasmas`
+    #      — the same FARMINGtools pipeline TGLFmulti_plasma_workflow.py exercises. One
+    #      parallel submission per relax step, so N TGLF calls fire concurrently.
+    #   4. Read the full `FluxMatch_Xopt_batches` tensor (shape (maxiter, n_traj, dvs))
+    #      instead of the scalar-best column `FluxMatch_Xopt`, and reshape to step-major
+    #      order for the downstream Execution/Evaluation.{i} copy loop.
+    #
+    # Folder layout under this scheme: each SR step writes ONE
+    # `MainFolder/portals_sr_ev_{s}/transport_simulation_folder` directory whose children
+    # are per-plasma sub-folders `plasma_{t}` (one per trajectory) holding the single-plasma
+    # `fluxes_{turb,neoc}.json` pair plus an `input.gacode`. The copy loop walks (step,
+    # trajectory) pairs and moves each `plasma_{t}` sub-folder into the matching
+    # `Execution/Evaluation.{s*n_traj + t}/transport_simulation_folder`, matching the
+    # step-major order of the flattened Xopt.
+    #
+    # Multi-trajectory `base_X` duplicate guard: `simple_relaxation` always records
+    # `x_initial` (= base_X) as the first entry of `x_history`. For n_traj>1 every
+    # trajectory shares the same base_X row, which would land as N identical training
+    # rows and crash `optimization_data.find_point(base_X)` downstream via `.item()` on a
+    # multi-row Series. We run one extra relax iteration (`effective_maxiter = steps_per_traj + 1`)
+    # and drop `Xopt_batches[0]` when skip_initial is True. Step 0 lands in a throwaway
+    # sub-folder `portals_sr_base_step0` whose name is deliberately *not* matched by the
+    # `portals_sr_ev_*` glob used by the copy loop and PORTALSinitializer. For
+    # single-trajectory runs no duplication is possible and the historical behaviour
+    # (include base_X, no throwaway folder) is preserved.
     # ------------------------------------------------------------------------------------
 
     traj_params = _normalize_initialization_params(
@@ -117,86 +154,126 @@ def initialization_simple_relax(self):
     else:
         addon_relax = 0.0
 
-    base_X = torch.from_numpy(
-        self.optimization_options["problem_options"]["dvs_base"]
-    ).to(self.dfT).unsqueeze(0)
-
-    # Each trajectory is run as an independent flux_match call. The folder_namer hook
-    # (see STATEtools.flux_match) interleaves the step-s outputs of every trajectory into
-    # positions `s * n_traj + t` so the resulting sequence portals_sr_ev_0..N-1 is step-major
-    # and matches the Execution.{i} numbering downstream.
-    #
-    # Multi-trajectory subtlety: simple_relaxation records x_initial (= base_X) as the very
-    # first x_history entry of every trajectory. If we were to keep those, the step-0 row
-    # of every trajectory would be *identical* base_X, train_X would contain N duplicate
-    # rows, and optimization_data.find_point(base_X) downstream would match all N rows and
-    # crash on `df['Iteration'].item()`. To avoid that we run one extra relax iteration per
-    # trajectory (effective_maxiter = steps_per_traj + 1) and skip x_history[0] when
-    # collecting training points. That extra evaluation lands in a throwaway sub-folder
-    # `portals_sr_base_traj{t}` that is intentionally *not* matched by the
-    # `portals_sr_ev_*` glob used by PORTALSinitializer and the Evaluation.{i} copy loop.
-    # For the single-trajectory case no duplication is possible, so we keep the historical
-    # behaviour (x_initial included as the first training point, no throwaway folder).
     skip_initial = n_traj > 1
     effective_maxiter = steps_per_traj + (1 if skip_initial else 0)
 
+    # Folder_namer hook: each relax step gets one folder. When we are running with
+    # skip_initial=True, step 0 is the throwaway base_X evaluation — route it to a
+    # differently-prefixed folder so the `portals_sr_ev_*` glob used below (and by
+    # PORTALSinitializer) does not see it.
     if skip_initial:
-        def _make_namer(traj_idx, n):
-            return lambda step: (
-                f"portals_sr_base_traj{traj_idx}" if step == 0
-                else f"portals_sr_ev_{(step - 1) * n + traj_idx}"
+        def folder_namer(step):
+            return (
+                "portals_sr_base_step0" if step == 0
+                else f"portals_sr_ev_{step - 1}"
             )
     else:
-        def _make_namer(traj_idx, n):
-            return lambda step: f"portals_sr_ev_{step * n + traj_idx}"
+        def folder_namer(step):
+            return f"portals_sr_ev_{step}"
 
-    Xopt_per_traj = []
-    for t, user_overrides in enumerate(traj_params):
-        solver_options = dict(_SIMPLE_RELAX_DEFAULTS)
-        solver_options.update(user_overrides)
-        # The seed-driven jitter is applied on top of the (possibly user-overridden) relax value
-        # so setting `relax: 0.1` in the namelist lands at 0.1 ± addon_relax, not 0.2 ± addon_relax.
-        solver_options["relax"] = solver_options["relax"] + addon_relax
-        solver_options["maxiter"] = effective_maxiter
-        solver_options["folder"] = MainFolder
-        solver_options["folder_namer"] = _make_namer(t, n_traj)
-        # `namingConvention` is still consulted by the evaluator for `nameRun` logging — keep it
-        # informative even though folder layout is owned by folder_namer.
-        solver_options["namingConvention"] = f"portals_sr_ev_traj{t}"
+    # Build per-trajectory tensor versions of each solver-option knob.
+    def _per_batch_tensor(key, scalar_default):
+        vals = []
+        any_value = False
+        for tp in traj_params:
+            v = tp.get(key, scalar_default)
+            if v is None:
+                vals.append(None)
+            else:
+                vals.append(float(v))
+                any_value = True
+        if not any_value:
+            return None
+        if any(v is None for v in vals):
+            # dx_max_abs is allowed to be None per-trajectory; a mixed None/float list is
+            # not something torch.where handles cleanly, so forbid it.
+            raise ValueError(
+                f"initialization_params[*]['{key}'] mixes None and numeric entries; either "
+                "set a numeric value for every trajectory or omit the key from all of them."
+            )
+        return torch.tensor(vals).to(self.dfT).view(n_traj, 1)
 
-        traj_state = copy.deepcopy(self.optimization_object.powerstate)
-        traj_state.modify(base_X)
-        traj_state.flux_match(
-            algorithm="simple_relax",
-            solver_options=solver_options,
-        )
-        Xopt_traj = traj_state.FluxMatch_Xopt
-        if skip_initial:
-            Xopt_traj = Xopt_traj[1:]   # drop the shared base_X so the stack has no duplicates
-        Xopt_per_traj.append(Xopt_traj)
+    relax_tensor       = _per_batch_tensor('relax',       _SIMPLE_RELAX_DEFAULTS['relax'])
+    if relax_tensor is not None:
+        relax_tensor = relax_tensor + addon_relax
+    dx_max_tensor      = _per_batch_tensor('dx_max',      _SIMPLE_RELAX_DEFAULTS['dx_max'])
+    dx_max_abs_tensor  = _per_batch_tensor('dx_max_abs',  _SIMPLE_RELAX_DEFAULTS['dx_max_abs'])
+    dx_min_abs_tensor  = _per_batch_tensor('dx_min_abs',  _SIMPLE_RELAX_DEFAULTS['dx_min_abs'])
+
+    # Scalar knobs inherit from the first trajectory's overrides (they must agree across
+    # trajectories because simple_relaxation reads them as scalars).
+    scalar_defaults = dict(_SIMPLE_RELAX_DEFAULTS)
+    scalar_defaults.update(traj_params[0])
+    scalar_defaults.pop('relax', None)
+    scalar_defaults.pop('dx_max', None)
+    scalar_defaults.pop('dx_max_abs', None)
+    scalar_defaults.pop('dx_min_abs', None)
+
+    solver_options = {
+        'tol':             scalar_defaults.get('tol', None),
+        'maxiter':         effective_maxiter,
+        'relax':           relax_tensor,
+        'dx_max':          dx_max_tensor,
+        'dx_max_abs':      dx_max_abs_tensor,
+        'dx_min_abs':      dx_min_abs_tensor,
+        'relax_dyn':       scalar_defaults.get('relax_dyn', False),
+        'print_each':      scalar_defaults.get('print_each', 1),
+        'folder':          MainFolder,
+        'folder_namer':    folder_namer,
+        'namingConvention': 'portals_sr_ev_batched',
+    }
+
+    # Replicate the caller's powerstate to an N-batched view and stamp base_X across every
+    # batch row. flux_match builds x0 as (plasma.rho.shape[0], dvs) = (n_traj, dvs) and
+    # simple_relaxation walks all n_traj trajectories in lockstep, calling the evaluator
+    # once per step with the full batched X. The evaluator in turn runs one batched
+    # `self.calculate(X, folder=folder_run)` per step, which now routes to
+    # `power_transport._evaluate_batched` (triggered on powerstate.batch_size > 1).
+    traj_state = copy.deepcopy(self.optimization_object.powerstate)
+    traj_state._repeat_tensors(batch_size=n_traj)
+
+    base_X_row = torch.from_numpy(
+        self.optimization_options["problem_options"]["dvs_base"]
+    ).to(self.dfT)
+    base_X_batched = base_X_row.unsqueeze(0).repeat(n_traj, 1)
+    traj_state.modify(base_X_batched)
+
+    traj_state.flux_match(
+        algorithm="simple_relax",
+        solver_options=solver_options,
+    )
+
+    # Full batched trajectory: shape (effective_maxiter, n_traj, dvs). For skip_initial
+    # we drop the very first step (the shared base_X row) so the downstream
+    # Execution/Evaluation.{i} layout never carries duplicate training rows.
+    Xopt_batches = traj_state.FluxMatch_Xopt_batches
+    if skip_initial:
+        Xopt_batches = Xopt_batches[1:]   # (steps_per_traj, n_traj, dvs)
 
     # -------------------------------------------------------------------------------------------
-    # Once every trajectory has completed, copy the step-major folder sequence into
-    # Execution/Evaluation.{i} as if they were ordinary MITIM evaluations.
+    # Fan the per-step batched folders into per-(step, trajectory) Execution/Evaluation.{i}
+    # entries. Each `MainFolder/portals_sr_ev_{s}/transport_simulation_folder` carries
+    # `plasma_{0..n_traj-1}/` sub-folders with per-plasma single-plasma flux JSON pairs
+    # produced by `power_transport._evaluate_batched`.
     # -------------------------------------------------------------------------------------------
 
     (self.folderExecution / "Execution").mkdir(parents=True, exist_ok=True)
 
-    for i in range(self.Originalinitial_training):
-        ff = self.folderExecution / "Execution" / f"Evaluation.{i}"
-        ff.mkdir(parents=True, exist_ok=True)
-        source = MainFolder / f"portals_sr_ev_{i}" / "transport_simulation_folder"
+    for s in range(steps_per_traj):
+        for t in range(n_traj):
+            i = s * n_traj + t
+            ff = self.folderExecution / "Execution" / f"Evaluation.{i}"
+            ff.mkdir(parents=True, exist_ok=True)
+            source = MainFolder / f"portals_sr_ev_{s}" / "transport_simulation_folder" / f"plasma_{t}"
 
-        if (ff / "transport_simulation_folder").exists():
-            IOtools.shutil_rmtree(ff / "transport_simulation_folder")
+            if (ff / "transport_simulation_folder").exists():
+                IOtools.shutil_rmtree(ff / "transport_simulation_folder")
 
-        shutil.copytree(source, ff / "transport_simulation_folder")
+            shutil.copytree(source, ff / "transport_simulation_folder")
 
-    # Assemble the train_X array in step-major order so it lines up with the folder naming:
-    # Xopt_per_traj[t] has shape (steps_per_traj, dvs); stacking gives (steps_per_traj, n_traj, dvs)
-    # and the reshape below flattens to (steps_per_traj * n_traj, dvs) = (initial_training, dvs).
-    Xopt_stack = torch.stack(Xopt_per_traj, dim=1)  # (steps_per_traj, n_traj, dvs)
-    Xopt = Xopt_stack.reshape(self.Originalinitial_training, -1)
+    # Flatten the (steps_per_traj, n_traj, dvs) Xopt tensor into step-major (N, dvs) training
+    # rows that line up with the Evaluation.{i} layout above (i = s * n_traj + t).
+    Xopt = Xopt_batches.reshape(self.Originalinitial_training, -1)
 
     return Xopt.cpu().numpy()
 

--- a/src/mitim_modules/portals/utils/PORTALSoptimization.py
+++ b/src/mitim_modules/portals/utils/PORTALSoptimization.py
@@ -18,56 +18,141 @@ from IPython import embed
 """
 
 
+_SIMPLE_RELAX_DEFAULTS = {
+    "tol": None,
+    "relax": 0.2,          # Defines relationship between flux and gradient
+    "dx_max": 0.2,         # Max relative step in gradient (20% of a/Lx per iter)
+    "dx_max_abs": None,    # Max absolute step in gradient
+    "dx_min_abs": 0.1,     # Min absolute step in gradient
+    "relax_dyn": False,
+    "print_each": 1,
+}
+
+# Keys that may appear in user-provided `initialization_params` entries. Anything else is rejected
+# so typos surface loudly instead of being silently ignored.
+_SIMPLE_RELAX_ALLOWED_KEYS = {
+    "relax", "dx_max", "dx_max_abs", "dx_min_abs",
+    "relax_dyn", "relax_dyn_decrease", "relax_dyn_num",
+    "tol", "tol_rel", "print_each",
+}
+
+
+def _normalize_initialization_params(raw):
+    """Normalize the namelist `initialization_params` field into a list of dicts.
+
+    Accepts three shapes:
+        - None (or missing) → [{}]   (single trajectory, all defaults)
+        - a bare dict        → [dict] (shorthand for one trajectory)
+        - a list of dicts    → returned as-is
+
+    Unknown keys raise a ValueError so typos don't silently vanish.
+    """
+    if raw is None:
+        return [{}]
+    if isinstance(raw, dict):
+        raw_list = [raw]
+    else:
+        raw_list = list(raw)
+        if len(raw_list) == 0:
+            return [{}]
+
+    normalized = []
+    for idx, entry in enumerate(raw_list):
+        if entry is None:
+            entry = {}
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"initialization_params[{idx}] must be a dict, got {type(entry).__name__}"
+            )
+        entry = dict(entry)
+        if "maxiter" in entry:
+            print(
+                f"\t- initialization_params[{idx}] contains a 'maxiter' key; the count of "
+                "simple-relax points is driven by initial_training, so this value is ignored.",
+                typeMsg="w",
+            )
+            entry.pop("maxiter")
+        bad = set(entry) - _SIMPLE_RELAX_ALLOWED_KEYS
+        if bad:
+            raise ValueError(
+                f"initialization_params[{idx}] has unknown key(s): {sorted(bad)}. "
+                f"Allowed: {sorted(_SIMPLE_RELAX_ALLOWED_KEYS)}"
+            )
+        normalized.append(entry)
+    return normalized
+
+
 def initialization_simple_relax(self):
     # ------------------------------------------------------------------------------------
-    # Perform flux matched using powerstate
+    # Perform flux matching using powerstate.
+    #
+    # A user may request N parallel simple-relax trajectories through the namelist field
+    # `optimization_options.initialization_options.initialization_params` (a list of
+    # per-trajectory solver-option dicts). Each trajectory walks toward flux matching with
+    # its own (relax, dx_max, …) and contributes `initial_training / N` points to the
+    # initial training set. All trajectories land in a single step-major folder sequence
+    # `portals_sr_ev_0..initial_training-1` so downstream code (Execution.{i} copy loop,
+    # PORTALSinitializer plotting) sees a flat list of evaluations exactly as before.
     # ------------------------------------------------------------------------------------
 
-    powerstate = copy.deepcopy(self.optimization_object.powerstate)
+    traj_params = _normalize_initialization_params(
+        self.optimization_options["initialization_options"].get("initialization_params")
+    )
+    n_traj = len(traj_params)
+
+    if self.Originalinitial_training % n_traj != 0:
+        raise ValueError(
+            f"initial_training ({self.Originalinitial_training}) must be divisible by the "
+            f"number of initialization_params trajectories ({n_traj}). Adjust one of the two."
+        )
+    steps_per_traj = self.Originalinitial_training // n_traj
 
     folderExecution = IOtools.expandPath(self.folderExecution, ensurePathValid=True)
-
     MainFolder = folderExecution / "Initialization" / "initialization_simple_relax"
     MainFolder.mkdir(parents=True, exist_ok=True)
 
-    a, b = IOtools.reducePathLevel(self.folderExecution, level=1)
-    namingConvention = "portals_sr_ev"
-
     if self.seed is not None and self.seed != 0:
         random.seed(self.seed)
-        addon_relax = random.uniform(-0.03, 0.03) 
+        addon_relax = random.uniform(-0.03, 0.03)
     else:
         addon_relax = 0.0
 
-    # Solver options tuned for simple relax of beginning of PORTALS (big jumps)
-    solver_options = {
-        "tol": None,
-        "maxiter": self.Originalinitial_training,
-        "relax": 0.2+addon_relax,   # Defines relationship between flux and gradient
-        "dx_max": 0.2,              # Maximum step size in gradient, relative (e.g. a/Lx can only increase by 20% each time)
-        "relax_dyn": False,
-        "dx_max_abs": None,         # Maximum step size in gradient, absolute (e.g. a/Lx can only increase by 0.1 each time)
-        "dx_min_abs": 0.1,          # Minimum step size in gradient, absolute (e.g. a/Lx can only increase by 0.01 each time)
-        "print_each": 1,
-        "folder": MainFolder,
-        "namingConvention": namingConvention,
-    }
+    base_X = torch.from_numpy(
+        self.optimization_options["problem_options"]["dvs_base"]
+    ).to(self.dfT).unsqueeze(0)
 
-    # Trick to actually start from different gradients than those in the initial_input_gacode
+    # Each trajectory is run as an independent flux_match call. The folder_namer hook
+    # (see STATEtools.flux_match) interleaves the step-s outputs of every trajectory into
+    # positions `s * n_traj + t` so the resulting sequence portals_sr_ev_0..N-1 is step-major
+    # and matches the Execution.{i} numbering downstream.
+    def _make_namer(traj_idx, n):
+        return lambda step: f"portals_sr_ev_{step * n + traj_idx}"
 
-    X = torch.from_numpy(self.optimization_options["problem_options"]["dvs_base"]).to(self.dfT).unsqueeze(0)
-    powerstate.modify(X)
+    Xopt_per_traj = []
+    for t, user_overrides in enumerate(traj_params):
+        solver_options = dict(_SIMPLE_RELAX_DEFAULTS)
+        solver_options.update(user_overrides)
+        # The seed-driven jitter is applied on top of the (possibly user-overridden) relax value
+        # so setting `relax: 0.1` in the namelist lands at 0.1 ± addon_relax, not 0.2 ± addon_relax.
+        solver_options["relax"] = solver_options["relax"] + addon_relax
+        solver_options["maxiter"] = steps_per_traj
+        solver_options["folder"] = MainFolder
+        solver_options["folder_namer"] = _make_namer(t, n_traj)
+        # `namingConvention` is still consulted by the evaluator for `nameRun` logging — keep it
+        # informative even though folder layout is owned by folder_namer.
+        solver_options["namingConvention"] = f"portals_sr_ev_traj{t}"
 
-    # Flux matching process
-
-    powerstate.flux_match(
-        algorithm="simple_relax",
-        solver_options=solver_options,
-    )
-    Xopt = powerstate.FluxMatch_Xopt
+        traj_state = copy.deepcopy(self.optimization_object.powerstate)
+        traj_state.modify(base_X)
+        traj_state.flux_match(
+            algorithm="simple_relax",
+            solver_options=solver_options,
+        )
+        Xopt_per_traj.append(traj_state.FluxMatch_Xopt)
 
     # -------------------------------------------------------------------------------------------
-    # Once flux matching has been attained, copy those as if they were direct MITIM evaluations
+    # Once every trajectory has completed, copy the step-major folder sequence into
+    # Execution/Evaluation.{i} as if they were ordinary MITIM evaluations.
     # -------------------------------------------------------------------------------------------
 
     (self.folderExecution / "Execution").mkdir(parents=True, exist_ok=True)
@@ -75,13 +160,18 @@ def initialization_simple_relax(self):
     for i in range(self.Originalinitial_training):
         ff = self.folderExecution / "Execution" / f"Evaluation.{i}"
         ff.mkdir(parents=True, exist_ok=True)
-        newname = f"{namingConvention}_{i}"
+        source = MainFolder / f"portals_sr_ev_{i}" / "transport_simulation_folder"
 
-        # Delte destination first
         if (ff / "transport_simulation_folder").exists():
             IOtools.shutil_rmtree(ff / "transport_simulation_folder")
 
-        shutil.copytree(MainFolder / newname / "transport_simulation_folder", ff / "transport_simulation_folder") #### delete first
+        shutil.copytree(source, ff / "transport_simulation_folder")
+
+    # Assemble the train_X array in step-major order so it lines up with the folder naming:
+    # Xopt_per_traj[t] has shape (steps_per_traj, dvs); stacking gives (steps_per_traj, n_traj, dvs)
+    # and the reshape below flattens to (steps_per_traj * n_traj, dvs) = (initial_training, dvs).
+    Xopt_stack = torch.stack(Xopt_per_traj, dim=1)  # (steps_per_traj, n_traj, dvs)
+    Xopt = Xopt_stack.reshape(self.Originalinitial_training, -1)
 
     return Xopt.cpu().numpy()
 

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -369,16 +369,21 @@ class powerstate:
 
         folder_main = solver_options.get("folder", None)
         namingConvention = solver_options.get("namingConvention", "powerstate_sr_ev")
+        # Optional callable `step -> sub-folder name`. Lets the caller lay out folders in a
+        # non-sequential order (e.g. interleaving several parallel simple-relax trajectories
+        # into one step-major sequence). If not provided, the default "{name}_{cont}" is used.
+        folder_namer = solver_options.get("folder_namer", None)
 
         cont = 0
         def evaluator(X, y_history=None, x_history=None, metric_history=None):
 
             nonlocal cont
 
-            nameRun = f"{namingConvention}_{cont}"
+            sub_name = folder_namer(cont) if folder_namer is not None else f"{namingConvention}_{cont}"
+            nameRun = sub_name
 
             if folder_main is not None:
-                folder = IOtools.expandPath(folder_main) /  f"{namingConvention}_{cont}"
+                folder = IOtools.expandPath(folder_main) /  sub_name
                 if issubclass(self.transport_options["evaluator"], TRANSPORTtools.power_transport):
                     (folder / "transport_simulation_folder").mkdir(parents=True, exist_ok=True)
 

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -177,7 +177,8 @@ class powerstate:
 
         # Resolution of input.gacode
         if increase_profile_resol:
-            TRANSFORMtools.improve_resolution_profiles(self.profiles, rho_vec)
+            smooth_around_coarsing = self.transport_options.get("flatten_gradients_at_control_points", True)
+            TRANSFORMtools.improve_resolution_profiles(self.profiles, rho_vec, smooth_around_coarsing=smooth_around_coarsing)
 
         # Convert to powerstate
         self.to_powerstate(self)

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -446,6 +446,12 @@ class powerstate:
         index_best = divmod(idx_flat.item(), metric_history.shape[1])
 
         self.FluxMatch_Yopt, self.FluxMatch_Xopt = Yopt[:,index_best[1],:], Xopt[:,index_best[1],:]
+        # Full batched trajectories: (iter, N_batches, dvs) / (iter, N_batches, dimY).
+        # Callers that need per-batch trajectories — e.g. PORTALS parallel simple-relax
+        # initialization which runs one flux_match across N trajectories at once — read
+        # these instead of the scalar-best column above.
+        self.FluxMatch_Xopt_batches = Xopt
+        self.FluxMatch_Yopt_batches = Yopt
         self.FluxMatch_relax     = relax_history[:, index_best[1], :] if relax_history.numel() > 0 else relax_history
         self.FluxMatch_tol       = -solver_tol if solver_tol is not None else None   # positive residual threshold
         self.FluxMatch_osc_iters = osc_check_iters

--- a/src/mitim_modules/powertorch/physics_models/parameterizers.py
+++ b/src/mitim_modules/powertorch/physics_models/parameterizers.py
@@ -14,6 +14,7 @@ def piecewise_linear(
     x_coarse_tensor,
     parameterize_in_aLx=True,
     multiplier_quantity=1.0,
+    smooth_around_coarsing=True,
     ):
     """
     Notes:
@@ -47,26 +48,16 @@ def piecewise_linear(
 
     x_coarse = x_coarse_tensor[1:].cpu().numpy()
 
-    """
-    Define region to get control points from
-    ------------------------------------------------------------
-	Trick: Addition of extra point
-		This is important because if I don't, when I combine the trailing edge and the new
-		modified profile, there's going to be a discontinuity in the gradient.
-	"""
-    
+    # Index of the last control point on the fine grid
     ir_end = np.argmin(np.abs(x_coord - x_coarse[-1]))
 
-    if ir_end < len(x_coord) - 1:
-        ir = ir_end + 2  # To prevent that TGYRO does a 2nd order derivative
-        x_coarse = np.append(x_coarse, [x_coord[ir]])
-    else:
-        ir = ir_end
+    # Trailing edge: everything beyond the last control point
+    x_trail = torch.from_numpy(x_coord[ir_end:]).to(x_coarse_tensor)
+    y_trail = y_coord[ir_end:]
+    x_notrail = torch.from_numpy(x_coord[: ir_end + 1]).to(x_coarse_tensor)
 
-	# Definition of trailing edge. Any point after, and including, the extra point
-    x_trail = torch.from_numpy(x_coord[ir:]).to(x_coarse_tensor)
-    y_trail = y_coord[ir:]
-    x_notrail = torch.from_numpy(x_coord[: ir + 1]).to(x_coarse_tensor)
+    # Gradient of the original profile at the trailing edge start (for Hermite blending)
+    ygrad_trail_start = ygrad_coord[ir_end]
 
     # Produce control points, including a zero at the beginning
     aLy_coarse = [[0.0, 0.0]]
@@ -76,14 +67,8 @@ def piecewise_linear(
 
     aLy_coarse = torch.from_numpy(np.array(aLy_coarse)).to(ygrad_coord)
 
-    # Since the last one is an extra point very close, I'm making it the same
-    aLy_coarse[-1, 1] = aLy_coarse[-2, 1]
-
-    # Boundary condition at point moved by gridPointsAllowed
-    y_bc = torch.from_numpy(interpolation_function([x_coarse[-1]], x_coord, y_coord.cpu().numpy())).to(ygrad_coord)
-
-    # Boundary condition at point (ACTUAL THAT I WANT to keep fixed, i.e. rho=0.8)
-    y_bc_real = torch.from_numpy(interpolation_function([x_coarse[-2]], x_coord, y_coord.cpu().numpy())).to(ygrad_coord)
+    # Boundary condition at the last control point
+    y_bc_real = torch.from_numpy(interpolation_function([x_coarse[-1]], x_coord, y_coord.cpu().numpy())).to(ygrad_coord)
 
     # **********************************************************************************************************
     # Define profile_constructor functions
@@ -106,7 +91,7 @@ def piecewise_linear(
         Reason why something like this is not used for the full profile is because derivative of this will not be as original,
                 which is needed to match TGYRO
         """
-        yCPs = CALCtools.Interp1d_torch()(aLy_coarse[:, 0][:-1].repeat((y.shape[0], 1)), y, x)
+        yCPs = CALCtools.Interp1d_torch()(aLy_coarse[:, 0].repeat((y.shape[0], 1)), y, x)
         return x, integrator_function(x, yCPs, y_bc_real) / multiplier
 
     def profile_constructor_fine(x, y, multiplier=multiplier_quantity):
@@ -119,51 +104,69 @@ def piecewise_linear(
         y = torch.atleast_2d(y)
         x = x[0, :] if x.dim() == 2 else x
 
-        # Add the extra trick point
-        x = torch.cat((x, aLy_coarse[-1][0].repeat((1))))
-        y = torch.cat((y, aLy_coarse[-1][-1].repeat((y.shape[0], 1))), dim=1)
-
-        # Model curve (basically, what happens in between points)
+        # Piecewise-linear interpolation of gradients from coarse to fine grid
         yBS = CALCtools.Interp1d_torch()(x.repeat(y.shape[0], 1), y, x_notrail.repeat(y.shape[0], 1))
 
-        """
-        ---------------------------------------------------------------------------------------------------------
-            Trick 1: smoothAroundCoarsing
-                TGYRO will use a 2nd order scheme to obtain gradients out of the profile, so a piecewise linear
-                will simply not give the right derivatives.
-                Here, this rough trick is to modify the points in gradient space around the coarse grid with the
-                same value of gradient, so in principle it doesn't matter the order of the derivative.
-        """
-        num_around = 1
-        for i in range(x.shape[0] - 2):
-            ir = torch.argmin(torch.abs(x[i + 1] - x_notrail))
-            for k in range(-num_around, num_around + 1, 1):
-                yBS[:, ir + k] = yBS[:, ir]
-        # --------------------------------------------------------------------------------------------------------
+        # smoothAroundCoarsing: flatten gradient at neighbors of each control point so that
+        # any derivative stencil (including higher-order) recovers the correct gradient value.
+        if smooth_around_coarsing:
+            num_around = 1
+            for i in range(x.shape[0] - 1):
+                ir = torch.argmin(torch.abs(x[i + 1] - x_notrail))
+                for k in range(-num_around, num_around + 1, 1):
+                    if 0 <= ir + k < yBS.shape[1]:
+                        yBS[:, ir + k] = yBS[:, ir]
 
-        yBS = integrator_function(x_notrail.repeat(yBS.shape[0], 1), yBS.clone(), y_bc)
+        # Integrate with BC directly at the last control point (no extra point, no rescaling)
+        yBS = integrator_function(x_notrail.repeat(yBS.shape[0], 1), yBS.clone(), y_bc_real)
 
-        """
-        Trick 2: Correct y_bc
-            The y_bc for the profile integration started at gridPointsAllowed, but that's not the real
-            y_bc. I want the temperature fixed at my first point that I actually care for.
-            Here, I multiply the profile to get that.
-            Multiplication works because:
-                1/LT = 1/T * dT/dr
-                1/LT' = 1/(T*m) * d(T*m)/dr = 1/T * dT/dr = 1/LT
-            Same logarithmic gradient, but with the right boundary condition
+        # Smooth Hermite blending into the trailing edge
+        # -----------------------------------------------
+        # At the junction (last control point), the reconstructed profile has value y_bc_real
+        # and gradient from the last coarse a/LT. The original profile continues beyond.
+        # A cubic Hermite blend over a small region ensures C1 continuity (no kink).
 
-        """
-        ir = torch.argmin(torch.abs(x_notrail - x[-2]))
-        yBS = yBS * torch.transpose((y_bc_real / yBS[:, ir]).repeat(yBS.shape[1], 1), 0, 1)
+        n_trail = x_trail.shape[0]
+        if n_trail > 1:
+            # Blend width: a few grid points into the trailing edge
+            n_blend = min(max(3, n_trail // 3), n_trail)
+            x_blend = x_trail[:n_blend]
+            blend_width = x_blend[-1] - x_blend[0]
 
-        # Add trailing edge
-        y_trailnew = copy.deepcopy(y_trail).repeat(yBS.shape[0], 1)
+            if blend_width > 0:
+                # Smoothstep: 0 at junction, 1 at end of blend region
+                t = (x_blend - x_blend[0]) / blend_width
+                w = 3 * t**2 - 2 * t**3  # C1 Hermite smoothstep
 
-        x_notrail_t = torch.cat((x_notrail[:-1], x_trail), dim=0)
-        yBS = torch.cat((yBS[:, :-1], y_trailnew), dim=1)
+                # Reconstructed value at junction = yBS[:, -1] (the BC point)
+                y_junction = yBS[:, -1:]  # (batch, 1)
 
-        return x_notrail_t, yBS / multiplier
+                # Original trailing edge values
+                y_orig_blend = y_trail[:n_blend].unsqueeze(0).repeat(yBS.shape[0], 1)
+                y_orig_rest = y_trail[n_blend:].unsqueeze(0).repeat(yBS.shape[0], 1) if n_blend < n_trail else torch.empty(yBS.shape[0], 0).to(yBS)
+
+                # Blend: (1-w)*junction_extrapolated + w*original
+                # For the extrapolation from the junction, use the last gradient to extend
+                last_grad = yBS[:, -1:] - yBS[:, -2:-1]  # finite diff of profile at junction
+                dx_from_junction = (x_blend - x_blend[0]).unsqueeze(0)
+                y_extrap = y_junction + last_grad / (x_notrail[-1] - x_notrail[-2]) * dx_from_junction
+
+                y_blended = (1 - w).unsqueeze(0) * y_extrap + w.unsqueeze(0) * y_orig_blend
+
+                # Assemble: notrail[:-1] + blended + rest of original
+                x_full = torch.cat((x_notrail[:-1], x_trail), dim=0)
+                yBS_full = torch.cat((yBS[:, :-1], y_blended, y_orig_rest), dim=1)
+            else:
+                # Blend width is zero (single trailing point), just concat
+                x_full = torch.cat((x_notrail[:-1], x_trail), dim=0)
+                y_trailnew = y_trail.unsqueeze(0).repeat(yBS.shape[0], 1)
+                yBS_full = torch.cat((yBS[:, :-1], y_trailnew), dim=1)
+        else:
+            # No trailing edge points, return as-is
+            x_full = x_notrail
+            yBS_full = yBS
+
+        return x_full, yBS_full / multiplier
 
     # **********************************************************************************************************
 

--- a/src/mitim_modules/powertorch/physics_models/transport_neo.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_neo.py
@@ -13,8 +13,11 @@ class neo_model:
 
         simulation_options = self.transport_evaluator_options["neo"]
         cold_start = self.cold_start
-        
+
         percent_error = simulation_options["percent_error"]
+        # If True, NEO runs in-process via ctypes (libneo_serial.so) — no
+        # subprocess fork, no folder / file I/O.  See namelist.portals.yaml.
+        in_process = simulation_options.get("in_process", False)
         # [ion1,ion2,ion3,...], so if I want ion3, I need to do ion_OI_position_in_ion_list = 2
         ion_OI_position_in_ion_list = self.powerstate.impurityPosition_transport
                 
@@ -23,8 +26,8 @@ class neo_model:
         # ------------------------------------------------------------------------------------------------------------------------
         
         rho_locations = [self.powerstate.plasma["rho"][0, 1:][i].item() for i in range(len(self.powerstate.plasma["rho"][0, 1:]))]
-        
-        neo = NEOtools.NEO(rhos=rho_locations)
+
+        neo = NEOtools.NEO(rhos=rho_locations, in_process=in_process)
 
         _ = neo.prep(
             self.powerstate.profiles_transport,

--- a/src/mitim_modules/powertorch/physics_models/transport_neo.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_neo.py
@@ -17,7 +17,7 @@ class neo_model:
         percent_error = simulation_options["percent_error"]
         # If True, NEO runs in-process via ctypes (libneo_serial.so) — no
         # subprocess fork, no folder / file I/O.  See namelist.portals.yaml.
-        in_process = simulation_options.get("in_process", False)
+        in_process = self.powerstate.transport_options.get("in_process", False)
         # [ion1,ion2,ion3,...], so if I want ion3, I need to do ion_OI_position_in_ion_list = 2
         ion_OI_position_in_ion_list = self.powerstate.impurityPosition_transport
                 

--- a/src/mitim_modules/powertorch/physics_models/transport_neo.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_neo.py
@@ -5,6 +5,76 @@ from IPython import embed
 
 class neo_model:
 
+    def evaluate_neoclassical_batched(self, list_of_states):
+        self._evaluate_neo_batched(list_of_states)
+
+    # ----------------------------------------------------------------------------------------
+    # Multi-plasma NEO — fan a list of profile states through run_over_plasmas so that every
+    # (plasma, rho) work unit is dispatched concurrently by the existing FARMINGtools pipeline.
+    # Used by power_transport._evaluate_batched() when powerstate.batch_size > 1.
+    # ----------------------------------------------------------------------------------------
+    def _evaluate_neo_batched(self, list_of_states):
+
+        simulation_options = self.transport_evaluator_options["neo"]
+        cold_start = self.cold_start
+
+        percent_error = simulation_options["percent_error"]
+        in_process = self.powerstate.transport_options.get("in_process", False)
+        ion_OI_position_in_ion_list = self.powerstate.impurityPosition_transport
+
+        rho_locations = [
+            self.powerstate.plasma["rho"][0, 1:][i].item()
+            for i in range(len(self.powerstate.plasma["rho"][0, 1:]))
+        ]
+
+        neo = NEOtools.NEO(rhos=rho_locations, in_process=in_process)
+
+        _ = neo.prep(
+            list_of_states[0],
+            self.folder,
+            cold_start=cold_start,
+        )
+
+        plasma_labels = neo.run_over_plasmas(
+            list_of_states,
+            base_subfolder="base_neo",
+            cold_start=cold_start,
+            forceIfcold_start=True,
+            **simulation_options["run"],
+        )
+
+        N = len(plasma_labels)
+        nrho = len(rho_locations)
+        Qe_batch = np.zeros((N, nrho))
+        Qi_batch = np.zeros((N, nrho))
+        Ge_batch = np.zeros((N, nrho))
+        GZ_batch = np.zeros((N, nrho))
+        Mt_batch = np.zeros((N, nrho))
+
+        for p, label in plasma_labels.items():
+            neo.read_plasma(p, label=label, **simulation_options["read"])
+            outputs = neo.results[label]["output"]
+
+            Qe_batch[p, :] = np.array([outputs[i].Qe for i in range(nrho)])
+            Qi_batch[p, :] = np.array([outputs[i].Qi for i in range(nrho)])
+            Ge_batch[p, :] = np.array([outputs[i].Ge for i in range(nrho)])
+            GZ_batch[p, :] = np.array([outputs[i].GiAll[ion_OI_position_in_ion_list] for i in range(nrho)])
+            Mt_batch[p, :] = np.array([outputs[i].Mt for i in range(nrho)])
+
+        self.QeGB_neoc = Qe_batch
+        self.QiGB_neoc = Qi_batch
+        self.GeGB_neoc = Ge_batch
+        self.GZGB_neoc = GZ_batch
+        self.MtGB_neoc = Mt_batch
+
+        self.QeGB_neoc_stds = np.abs(Qe_batch) * percent_error / 100.0
+        self.QiGB_neoc_stds = np.abs(Qi_batch) * percent_error / 100.0
+        self.GeGB_neoc_stds = np.abs(Ge_batch) * percent_error / 100.0
+        self.GZGB_neoc_stds = np.abs(GZ_batch) * percent_error / 100.0
+        self.MtGB_neoc_stds = np.abs(Mt_batch) * percent_error / 100.0
+
+        return neo
+
     def evaluate_neoclassical(self):
         
         # ------------------------------------------------------------------------------------------------------------------------

--- a/src/mitim_modules/powertorch/physics_models/transport_tglf.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_tglf.py
@@ -29,7 +29,7 @@ class tglf_model:
         percent_error = simulation_options["percent_error"]
         # If True, TGLF runs in-process via ctypes (libtglf_serial.so) — no
         # subprocess fork, no folder / file I/O.  See namelist.portals.yaml.
-        in_process = simulation_options.get("in_process", False)
+        in_process = self.powerstate.transport_options.get("in_process", False)
 
         # Grab impurity from powerstate ( because it may have been modified in produce_profiles() )
         # [ion1,ion2,ion3,...], so if I want ion3, I need to do ion_OI_position_in_ion_list = 2

--- a/src/mitim_modules/powertorch/physics_models/transport_tglf.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_tglf.py
@@ -33,13 +33,7 @@ class tglf_model:
 
         ion_OI_position_in_ion_list = self.powerstate.impurityPosition_transport
 
-        if use_tglf_scan_trick is not None:
-            print(
-                "\t- [batched] use_tglf_scan_trick is set but scan-based uncertainty is not "
-                "yet wired into the multi-plasma TGLF path; falling back to the ad-hoc "
-                "percent_error uncertainty model for this run.",
-                typeMsg="w",
-            )
+        reuse_scan_ball_file = self.powerstate.transport_options['folder'] / 'Outputs' / 'tglf_ball.npz' if simulation_options.get("reuse_scan_ball", False) else None
 
         # All per-plasma powerstates are tiled from the same rho grid, so the rho locations
         # come from batch 0 of the (already batched) self.powerstate exactly as the single-
@@ -119,8 +113,52 @@ class tglf_model:
             self._raise_warnings(tglf, rho_locations, Qi_includes_fast)
 
         Flux_base = np.stack([Qe_batch, Qi_batch, Ge_batch, GZ_batch, Mt_batch, S_batch], axis=0)
-        Flux_mean = Flux_base
-        Flux_std = np.abs(Flux_mean) * percent_error / 100.0
+
+        # ------------------------------------------------------------------------------------------------------------------------
+        # Evaluate TGLF uncertainty — same choice as the single-plasma path:
+        # either ad-hoc percent_error or the scan-based uncertainty model.
+        # ------------------------------------------------------------------------------------------------------------------------
+
+        if use_tglf_scan_trick is None:
+            Flux_mean = Flux_base
+            Flux_std = np.abs(Flux_mean) * percent_error / 100.0
+        else:
+            # Per-plasma scan-trick uncertainty. For each plasma p, re-activate its per-
+            # plasma state on the tglf instance (profiles, inputs_files, NormalizationSets)
+            # via read_plasma and call _run_tglf_uncertainty_model with a per-plasma
+            # subfolder_name so scans from different plasmas don't collide on disk.
+            # Each call internally parallelizes across (N_variables × 2 × N_rhos) work
+            # units; different plasmas' scans run sequentially.
+            Flux_mean_per_plasma = []
+            Flux_std_per_plasma = []
+            for p, label in plasma_labels.items():
+                tglf.read_plasma(p, label=label, require_all_files=False, **simulation_options["read"])
+                Flux_base_p = np.array([
+                    Qe_batch[p], Qi_batch[p], Ge_batch[p],
+                    GZ_batch[p], Mt_batch[p], S_batch[p],
+                ])
+                Fmean_p, Fstd_p = _run_tglf_uncertainty_model(
+                    tglf,
+                    rho_locations,
+                    self.powerstate.predicted_channels,
+                    Flux_base=Flux_base_p,
+                    ion_OI_position_in_ion_list=ion_OI_position_in_ion_list,
+                    delta=use_tglf_scan_trick,
+                    cold_start=cold_start,
+                    extra_name=f"{self.name}_plasma{p}",
+                    cores_per_tglf_instance=cores_per_tglf_instance,
+                    Qi_includes_fast=Qi_includes_fast,
+                    only_minimal_files=keep_tglf_files in ["none", "base"],
+                    reuse_scan_ball_file=reuse_scan_ball_file,
+                    subfolder_name=f"turb_drives_plasma{p}",
+                    **simulation_options["run"],
+                )
+                Flux_mean_per_plasma.append(np.array(Fmean_p))
+                Flux_std_per_plasma.append(np.array(Fstd_p))
+
+            # Stack per-plasma lists of shape [(nrho,) × 6] into (6, N, nrho)
+            Flux_mean = np.stack(Flux_mean_per_plasma, axis=1)
+            Flux_std  = np.stack(Flux_std_per_plasma,  axis=1)
 
         if pass_info:
             self.QeGB_turb      = Flux_mean[0]
@@ -312,22 +350,23 @@ class tglf_model:
 
 def _run_tglf_uncertainty_model(
     tglf,
-    rho_locations, 
-    predicted_channels, 
+    rho_locations,
+    predicted_channels,
     Flux_base = None,
     code_settings=None,
     extraOptions=None,
     ion_OI_position_in_ion_list=1,
-    delta=0.02, 
+    delta=0.02,
     minimum_abs_gradient=0.005, # This is 0.5% of aLx=1.0, to avoid extremely small scans when, for example, having aLn ~ 0.0
-    cold_start=False, 
-    extra_name="", 
+    cold_start=False,
+    extra_name="",
     remove_folders_out = False,
     cores_per_tglf_instance = 4, # e.g. 4 core per radius, since this is going to launch ~ Nr=5 x (Nv=6 x Nd=2 + 1) = 65 TGLFs at once
     Qi_includes_fast=False,
     only_minimal_files=True,    # Since I only care about fluxes here, do not retrieve all the files
     reuse_scan_ball_file=None,      # If not None, it will reuse previous evaluations within the delta ball (to capture combinations)
-    print_logs = False
+    print_logs = False,
+    subfolder_name = 'turb_drives',  # Base subfolder for the scan; per-plasma callers override to avoid collisions
     ):
 
     print(f"\t- Running TGLF standalone scans ({delta = }) to determine relative errors")
@@ -359,7 +398,7 @@ def _run_tglf_uncertainty_model(
         if 'RL' in ikey:
             minimum_delta_abs[ikey] = minimum_abs_gradient
 
-    name = 'turb_drives'
+    name = subfolder_name
 
     tglf.rhos = rho_locations # To avoid the case in which TGYRO was run with an extra rho point
 

--- a/src/mitim_modules/powertorch/physics_models/transport_tglf.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_tglf.py
@@ -8,8 +8,140 @@ from IPython import embed
 
 class tglf_model:
 
-    def evaluate_turbulence(self):        
+    def evaluate_turbulence(self):
         self._evaluate_tglf()
+
+    def evaluate_turbulence_batched(self, list_of_states):
+        self._evaluate_tglf_batched(list_of_states)
+
+    # ----------------------------------------------------------------------------------------
+    # Multi-plasma TGLF — fan a list of profile states through run_over_plasmas so that every
+    # (plasma, rho) work unit is dispatched concurrently by the existing FARMINGtools pipeline.
+    # Used by power_transport._evaluate_batched() when the powerstate carries batch_size > 1.
+    # ----------------------------------------------------------------------------------------
+    def _evaluate_tglf_batched(self, list_of_states, pass_info=True):
+
+        simulation_options = self.transport_evaluator_options["tglf"]
+        cold_start = self.cold_start
+
+        Qi_includes_fast = simulation_options["Qi_includes_fast"]
+        use_tglf_scan_trick = simulation_options["use_scan_trick_for_stds"]
+        cores_per_tglf_instance = simulation_options["cores_per_tglf_instance"]
+        keep_tglf_files = simulation_options["keep_files"]
+        percent_error = simulation_options["percent_error"]
+        in_process = self.powerstate.transport_options.get("in_process", False)
+
+        ion_OI_position_in_ion_list = self.powerstate.impurityPosition_transport
+
+        if use_tglf_scan_trick is not None:
+            print(
+                "\t- [batched] use_tglf_scan_trick is set but scan-based uncertainty is not "
+                "yet wired into the multi-plasma TGLF path; falling back to the ad-hoc "
+                "percent_error uncertainty model for this run.",
+                typeMsg="w",
+            )
+
+        # All per-plasma powerstates are tiled from the same rho grid, so the rho locations
+        # come from batch 0 of the (already batched) self.powerstate exactly as the single-
+        # plasma path does — not from list_of_states, whose gacode_state objects use their
+        # own rho grid and do not need to agree with predicted_rho.
+        rho_locations = [
+            self.powerstate.plasma["rho"][0, 1:][i].item()
+            for i in range(len(self.powerstate.plasma["rho"][0, 1:]))
+        ]
+
+        tglf = TGLFtools.TGLF(rhos=rho_locations, in_process=in_process)
+
+        # Bootstrap FolderGACODE / NormalizationSets for the first plasma; run_over_plasmas
+        # re-preps once per plasma and snapshots per-plasma state on self.results_per_plasma
+        # before the parallel dispatch kicks in.
+        _ = tglf.prep(
+            list_of_states[0],
+            self.folder,
+            cold_start=cold_start,
+        )
+
+        plasma_labels = tglf.run_over_plasmas(
+            list_of_states,
+            base_subfolder="base_tglf",
+            cold_start=cold_start,
+            forceIfcold_start=True,
+            extra_name=self.name,
+            slurm_setup={
+                "cores": cores_per_tglf_instance,
+                "minutes": 2,
+            },
+            attempts_execution=2,
+            only_minimal_files=keep_tglf_files in ["none"],
+            **simulation_options["run"],
+        )
+
+        N = len(plasma_labels)
+        nrho = len(rho_locations)
+        Qe_batch = np.zeros((N, nrho))
+        Qi_batch = np.zeros((N, nrho))
+        Ge_batch = np.zeros((N, nrho))
+        GZ_batch = np.zeros((N, nrho))
+        Mt_batch = np.zeros((N, nrho))
+        S_batch = np.zeros((N, nrho))
+
+        for p, label in plasma_labels.items():
+            tglf.read_plasma(
+                p,
+                label=label,
+                require_all_files=False,
+                **simulation_options["read"],
+            )
+            outputs = tglf.results[label]["output"]
+
+            Qe = np.array([outputs[i].Qe for i in range(nrho)])
+            Qi = np.array([outputs[i].Qi for i in range(nrho)])
+            Ge = np.array([outputs[i].Ge for i in range(nrho)])
+            GZ = np.array([outputs[i].GiAll[ion_OI_position_in_ion_list] for i in range(nrho)])
+            Mt = np.array([outputs[i].Mt for i in range(nrho)])
+            S = np.array([outputs[i].Se for i in range(nrho)])
+
+            if Qi_includes_fast:
+                Qifast = np.array([outputs[i].Qifast for i in range(nrho)])
+                if Qifast.sum() != 0.0:
+                    print(f"\t- Qi includes fast ions for plasma {p}, adding their contribution")
+                    Qi = Qi + Qifast
+
+            Qe_batch[p, :] = Qe
+            Qi_batch[p, :] = Qi
+            Ge_batch[p, :] = Ge
+            GZ_batch[p, :] = GZ
+            Mt_batch[p, :] = Mt
+            S_batch[p, :] = S
+
+            # Warnings reuse the single-plasma helper by temporarily pointing tglf at the
+            # per-plasma profiles/inputs that read_plasma() already cached.
+            self._raise_warnings(tglf, rho_locations, Qi_includes_fast)
+
+        Flux_base = np.stack([Qe_batch, Qi_batch, Ge_batch, GZ_batch, Mt_batch, S_batch], axis=0)
+        Flux_mean = Flux_base
+        Flux_std = np.abs(Flux_mean) * percent_error / 100.0
+
+        if pass_info:
+            self.QeGB_turb      = Flux_mean[0]
+            self.QeGB_turb_stds = Flux_std[0]
+
+            self.QiGB_turb      = Flux_mean[1]
+            self.QiGB_turb_stds = Flux_std[1]
+
+            self.GeGB_turb      = Flux_mean[2]
+            self.GeGB_turb_stds = Flux_std[2]
+
+            self.GZGB_turb      = Flux_mean[3]
+            self.GZGB_turb_stds = Flux_std[3]
+
+            self.MtGB_turb      = Flux_mean[4]
+            self.MtGB_turb_stds = Flux_std[4]
+
+            self.QieGB_turb      = Flux_mean[5]
+            self.QieGB_turb_stds = Flux_std[5]
+
+        return tglf
 
     # Have it separate such that I can call it from the CGYRO class but without the decorator
     def _evaluate_tglf(self, pass_info = True):
@@ -245,7 +377,7 @@ def _run_tglf_uncertainty_model(
         print_context = IOtools.nullcontext()
     else:
         print(f"\n\t- Running TGLF scans for turbulence drives (logs are hidden to avoid cluttering the log file)...\n", typeMsg="i")
-        print_context = LOGtools.HiddenPrints(show_if_contains=["* Executing", "-------------- Running process", "- TGLF will be executed", "[in-process]"])
+        print_context = LOGtools.HiddenPrints(show_if_contains=["* Executing", "-------------- Running process", "- TGLF will be executed", "[in-process] Submitting"])
 
     with print_context:
         tglf.runScanTurbulenceDrives(

--- a/src/mitim_modules/powertorch/physics_models/transport_tglf.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_tglf.py
@@ -245,7 +245,7 @@ def _run_tglf_uncertainty_model(
         print_context = IOtools.nullcontext()
     else:
         print(f"\n\t- Running TGLF scans for turbulence drives (logs are hidden to avoid cluttering the log file)...\n", typeMsg="i")
-        print_context = LOGtools.HiddenPrints(show_if_contains=["* Executing", "-------------- Running process", "- TGLF will be executed"])
+        print_context = LOGtools.HiddenPrints(show_if_contains=["* Executing", "-------------- Running process", "- TGLF will be executed", "[in-process]"])
 
     with print_context:
         tglf.runScanTurbulenceDrives(

--- a/src/mitim_modules/powertorch/physics_models/transport_tglf.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_tglf.py
@@ -20,13 +20,16 @@ class tglf_model:
 
         simulation_options = self.transport_evaluator_options["tglf"]
         cold_start = self.cold_start
-        
+
         Qi_includes_fast = simulation_options["Qi_includes_fast"]
         use_tglf_scan_trick = simulation_options["use_scan_trick_for_stds"]
         reuse_scan_ball_file = self.powerstate.transport_options['folder'] / 'Outputs' / 'tglf_ball.npz' if simulation_options.get("reuse_scan_ball", False) else None
         cores_per_tglf_instance = simulation_options["cores_per_tglf_instance"]
         keep_tglf_files = simulation_options["keep_files"]
         percent_error = simulation_options["percent_error"]
+        # If True, TGLF runs in-process via ctypes (libtglf_serial.so) — no
+        # subprocess fork, no folder / file I/O.  See namelist.portals.yaml.
+        in_process = simulation_options.get("in_process", False)
 
         # Grab impurity from powerstate ( because it may have been modified in produce_profiles() )
         # [ion1,ion2,ion3,...], so if I want ion3, I need to do ion_OI_position_in_ion_list = 2
@@ -37,8 +40,8 @@ class tglf_model:
         # ------------------------------------------------------------------------------------------------------------------------
         
         rho_locations = [self.powerstate.plasma["rho"][0, 1:][i].item() for i in range(len(self.powerstate.plasma["rho"][0, 1:]))]
-        
-        tglf = TGLFtools.TGLF(rhos=rho_locations)
+
+        tglf = TGLFtools.TGLF(rhos=rho_locations, in_process=in_process)
 
         _ = tglf.prep(
             self.powerstate.profiles_transport,

--- a/src/mitim_modules/powertorch/physics_models/transport_tglf.py
+++ b/src/mitim_modules/powertorch/physics_models/transport_tglf.py
@@ -123,42 +123,31 @@ class tglf_model:
             Flux_mean = Flux_base
             Flux_std = np.abs(Flux_mean) * percent_error / 100.0
         else:
-            # Per-plasma scan-trick uncertainty. For each plasma p, re-activate its per-
-            # plasma state on the tglf instance (profiles, inputs_files, NormalizationSets)
-            # via read_plasma and call _run_tglf_uncertainty_model with a per-plasma
-            # subfolder_name so scans from different plasmas don't collide on disk.
-            # Each call internally parallelizes across (N_variables × 2 × N_rhos) work
-            # units; different plasmas' scans run sequentially.
-            Flux_mean_per_plasma = []
-            Flux_std_per_plasma = []
-            for p, label in plasma_labels.items():
-                tglf.read_plasma(p, label=label, require_all_files=False, **simulation_options["read"])
-                Flux_base_p = np.array([
-                    Qe_batch[p], Qi_batch[p], Ge_batch[p],
-                    GZ_batch[p], Mt_batch[p], S_batch[p],
-                ])
-                Fmean_p, Fstd_p = _run_tglf_uncertainty_model(
-                    tglf,
-                    rho_locations,
-                    self.powerstate.predicted_channels,
-                    Flux_base=Flux_base_p,
-                    ion_OI_position_in_ion_list=ion_OI_position_in_ion_list,
-                    delta=use_tglf_scan_trick,
-                    cold_start=cold_start,
-                    extra_name=f"{self.name}_plasma{p}",
-                    cores_per_tglf_instance=cores_per_tglf_instance,
-                    Qi_includes_fast=Qi_includes_fast,
-                    only_minimal_files=keep_tglf_files in ["none", "base"],
-                    reuse_scan_ball_file=reuse_scan_ball_file,
-                    subfolder_name=f"turb_drives_plasma{p}",
-                    **simulation_options["run"],
-                )
-                Flux_mean_per_plasma.append(np.array(Fmean_p))
-                Flux_std_per_plasma.append(np.array(Fstd_p))
-
-            # Stack per-plasma lists of shape [(nrho,) × 6] into (6, N, nrho)
-            Flux_mean = np.stack(Flux_mean_per_plasma, axis=1)
-            Flux_std  = np.stack(Flux_std_per_plasma,  axis=1)
+            # All N plasmas' scan work is accumulated into one code_executor and dispatched
+            # in a single _run call, so N × ~65 scan jobs run concurrently.
+            Flux_base_per_plasma = {
+                p: np.array([Qe_batch[p], Qi_batch[p], Ge_batch[p],
+                             GZ_batch[p], Mt_batch[p], S_batch[p]])
+                for p in plasma_labels
+            }
+            run_kwargs = {k: v for k, v in simulation_options["run"].items() if k != "code_settings"}
+            Flux_mean, Flux_std = _run_tglf_uncertainty_model_batched(
+                tglf,
+                rho_locations,
+                self.powerstate.predicted_channels,
+                Flux_base_per_plasma=Flux_base_per_plasma,
+                plasma_labels=plasma_labels,
+                ion_OI_position_in_ion_list=ion_OI_position_in_ion_list,
+                delta=use_tglf_scan_trick,
+                cold_start=cold_start,
+                extra_name=self.name,
+                cores_per_tglf_instance=cores_per_tglf_instance,
+                Qi_includes_fast=Qi_includes_fast,
+                only_minimal_files=keep_tglf_files in ["none", "base"],
+                reuse_scan_ball_file=reuse_scan_ball_file,
+                code_settings=simulation_options["run"].get("code_settings"),
+                **run_kwargs,
+            )
 
         if pass_info:
             self.QeGB_turb      = Flux_mean[0]
@@ -444,6 +433,31 @@ def _run_tglf_uncertainty_model(
     if remove_folders_out:
         IOtools.shutil_rmtree(tglf.FolderGACODE)
 
+    return _aggregate_scan_fluxes(
+        tglf, name, variables_to_scan, relative_scan, rho_locations,
+        Flux_base=Flux_base,
+        ion_OI_position_in_ion_list=ion_OI_position_in_ion_list,
+        Qi_includes_fast=Qi_includes_fast,
+        reuse_scan_ball_file=reuse_scan_ball_file,
+        delta=delta,
+    )
+
+
+def _aggregate_scan_fluxes(
+    tglf, scan_subfolder_name, variables_to_scan, relative_scan, rho_locations,
+    Flux_base=None,
+    ion_OI_position_in_ion_list=1,
+    Qi_includes_fast=False,
+    reuse_scan_ball_file=None,
+    delta=0.02,
+):
+    '''
+    Shared aggregation logic: collect per-variable scan results from tglf.scans[...]
+    into (nrho, n_scan_cases) flux arrays, optionally prepend the base flux, then
+    compute nanmean / nanstd across the scan axis. Used by both the single-plasma
+    _run_tglf_uncertainty_model and the batched _run_tglf_uncertainty_model_batched.
+    '''
+
     Qe = np.zeros((len(rho_locations), len(variables_to_scan)*len(relative_scan) ))
     Qi = np.zeros((len(rho_locations), len(variables_to_scan)*len(relative_scan) ))
     Ge = np.zeros((len(rho_locations), len(variables_to_scan)*len(relative_scan) ))
@@ -453,22 +467,20 @@ def _run_tglf_uncertainty_model(
 
     cont = 0
     for vari in variables_to_scan:
-        jump = tglf.scans[f'{name}_{vari}']['Qe'].shape[-1]
+        jump = tglf.scans[f'{scan_subfolder_name}_{vari}']['Qe'].shape[-1]
 
-        # Outputs
-        Qe[:,cont:cont+jump] = tglf.scans[f'{name}_{vari}']['Qe_gb']
-        Qi[:,cont:cont+jump] = tglf.scans[f'{name}_{vari}']['Qi_gb'] + (0 if not Qi_includes_fast else tglf.scans[f'{name}_{vari}']['Qifast_gb'])
-        Ge[:,cont:cont+jump] = tglf.scans[f'{name}_{vari}']['Ge_gb']
-        GZ[:,cont:cont+jump] = tglf.scans[f'{name}_{vari}']['Gi_gb']
-        Mt[:,cont:cont+jump] = tglf.scans[f'{name}_{vari}']['Mt_gb']
-        S[:,cont:cont+jump] = tglf.scans[f'{name}_{vari}']['S_gb']
-        
+        Qe[:,cont:cont+jump] = tglf.scans[f'{scan_subfolder_name}_{vari}']['Qe_gb']
+        Qi[:,cont:cont+jump] = tglf.scans[f'{scan_subfolder_name}_{vari}']['Qi_gb'] + (0 if not Qi_includes_fast else tglf.scans[f'{scan_subfolder_name}_{vari}']['Qifast_gb'])
+        Ge[:,cont:cont+jump] = tglf.scans[f'{scan_subfolder_name}_{vari}']['Ge_gb']
+        GZ[:,cont:cont+jump] = tglf.scans[f'{scan_subfolder_name}_{vari}']['Gi_gb']
+        Mt[:,cont:cont+jump] = tglf.scans[f'{scan_subfolder_name}_{vari}']['Mt_gb']
+        S[:,cont:cont+jump] = tglf.scans[f'{scan_subfolder_name}_{vari}']['S_gb']
+
         cont += jump
 
     if Qi_includes_fast:
         print(f"\t- Qi includes fast ions, adding their contribution")
 
-    # Add the base that was calculated earlier
     if Flux_base is not None:
         Qe = np.append(np.atleast_2d(Flux_base[0]).T, Qe, axis=1)
         Qi = np.append(np.atleast_2d(Flux_base[1]).T, Qi, axis=1)
@@ -480,21 +492,8 @@ def _run_tglf_uncertainty_model(
     if reuse_scan_ball_file is not None:
         Qe, Qi, Ge, GZ, Mt, S = _ball_workflow(reuse_scan_ball_file, variables_to_scan, rho_locations, tglf, ion_OI_position_in_ion_list, Qi_includes_fast, Qe, Qi, Ge, GZ, Mt, S, delta_ball=delta)
 
-    # Calculate the standard deviation of the scans, that's going to be the reported stds
-
     def calculate_mean_std(Q):
-        # Assumes Q is [radii, points], with [radii, 0] being the baseline
-
-        Qm = np.nanmean(Q, axis=1)
-        Qstd = np.nanstd(Q, axis=1)
-
-        # Qm = Q[:,0]
-        # Qstd = np.std(Q, axis=1)
-
-        # Qstd    = ( Q.max(axis=1)-Q.min(axis=1) )/2 /2  # Such that the range is 2*std
-        # Qm      = Q.min(axis=1) + Qstd*2                # Mean is at the middle of the range
-
-        return  Qm, Qstd
+        return np.nanmean(Q, axis=1), np.nanstd(Q, axis=1)
 
     Qe_point, Qe_std = calculate_mean_std(Qe)
     Qi_point, Qi_std = calculate_mean_std(Qi)
@@ -503,9 +502,170 @@ def _run_tglf_uncertainty_model(
     Mt_point, Mt_std = calculate_mean_std(Mt)
     S_point, S_std = calculate_mean_std(S)
 
-    #TODO: Careful with fast particles
     Flux_mean = [Qe_point, Qi_point, Ge_point, GZ_point, Mt_point, S_point]
     Flux_std  = [Qe_std, Qi_std, Ge_std, GZ_std, Mt_std, S_std]
+
+    return Flux_mean, Flux_std
+
+
+def _run_tglf_uncertainty_model_batched(
+    tglf,
+    rho_locations,
+    predicted_channels,
+    Flux_base_per_plasma,
+    plasma_labels,
+    ion_OI_position_in_ion_list=1,
+    delta=0.02,
+    minimum_abs_gradient=0.005,
+    cold_start=False,
+    extra_name="",
+    cores_per_tglf_instance=4,
+    Qi_includes_fast=False,
+    only_minimal_files=True,
+    reuse_scan_ball_file=None,
+    print_logs=False,
+    code_settings=None,
+    extraOptions=None,
+    **kwargs_run,
+):
+    '''
+    Multi-plasma version of _run_tglf_uncertainty_model. Instead of calling
+    runScanTurbulenceDrives once (which dispatches ~65 scan jobs for one plasma),
+    this function accumulates scan work from ALL N plasmas into a single
+    code_executor dict and dispatches ONE _run call — so all N × ~65 scan jobs
+    run concurrently through FARMINGtools.
+    '''
+
+    print(f"\t- Running batched TGLF scans ({delta = }) for {len(plasma_labels)} plasmas in parallel")
+
+    ion_OI_position_in_total_padded_list = ion_OI_position_in_ion_list + 2
+
+    # Build the scan-variable list (same logic as the single-plasma path)
+    variables_to_scan = []
+    for i in predicted_channels:
+        if i == 'te': variables_to_scan.append('RLTS_1')
+        if i == 'ti': variables_to_scan.append('RLTS_2')
+        if i == 'ne': variables_to_scan.append('RLNS_1')
+        if i == 'nZ': variables_to_scan.append(f'RLNS_{ion_OI_position_in_total_padded_list}')
+        if i == 'w0': variables_to_scan.append('VEXB_SHEAR')
+    if 'te' in predicted_channels or 'ti' in predicted_channels:
+        variables_to_scan.append('TAUS_2')
+    if 'te' in predicted_channels or 'ne' in predicted_channels:
+        variables_to_scan.append('XNUE')
+    if 'te' in predicted_channels or 'ne' in predicted_channels:
+        variables_to_scan.append('BETAE')
+
+    relative_scan = [1 - delta, 1 + delta]
+
+    minimum_delta_abs = {}
+    for ikey in variables_to_scan:
+        if 'RL' in ikey:
+            minimum_delta_abs[ikey] = minimum_abs_gradient
+
+    N = len(plasma_labels)
+    num_cases_total = N * len(rho_locations) * len(variables_to_scan) * len(relative_scan)
+    if cores_per_tglf_instance == 1:
+        minutes = 10 * (num_cases_total / 60)
+    else:
+        minutes = 1 * (num_cases_total / 60)
+    minutes = max(2, minutes)
+
+    tglf.rhos = rho_locations
+
+    # varUpDown dict (no baseline added — same as add_baseline_to='none' in the single-plasma path)
+    varUpDown_dict = {variable: np.array(relative_scan) for variable in variables_to_scan}
+
+    # ---- Phase 1: Accumulate scan work for ALL plasmas ----
+    code_executor, code_executor_full, folders_per_plasma = {}, {}, {}
+
+    if print_logs:
+        print_context = IOtools.nullcontext()
+    else:
+        print(f"\n\t- Preparing TGLF scans for {N} plasmas x {len(variables_to_scan)} variables x {len(relative_scan)} deltas x {len(rho_locations)} rhos = {num_cases_total} total jobs...\n", typeMsg="i")
+        print_context = LOGtools.HiddenPrints(show_if_contains=["* Executing", "-------------- Running process", "- TGLF will be executed", "[in-process] Submitting"])
+
+    scan_kwargs = dict(
+        code_settings=code_settings,
+        extraOptions=extraOptions or {},
+        ApplyCorrections=False,
+        cold_start=cold_start,
+        forceIfcold_start=True,
+        slurm_setup={"cores": cores_per_tglf_instance, "minutes": minutes},
+        only_minimal_files=only_minimal_files,
+        **kwargs_run,
+    )
+
+    with print_context:
+        for p, label in plasma_labels.items():
+            tglf.read_plasma(p, label=label, require_all_files=False)
+            tglf.variablesDrives = variables_to_scan
+            folders_per_plasma[p] = {}
+
+            for cont_var, variable in enumerate(variables_to_scan):
+                scan_name = f"turb_drives_plasma{p}_{variable}"
+                scan_kwargs["forceIfcold_start"] = (p > 0 or cont_var > 0) or scan_kwargs.get("forceIfcold_start", True)
+
+                ce0, cef0, fld0, _ = tglf._prepare_scan(
+                    scan_name,
+                    variable=variable,
+                    varUpDown=varUpDown_dict[variable],
+                    minimum_delta_abs=minimum_delta_abs,
+                    **scan_kwargs,
+                )
+                code_executor |= ce0
+                code_executor_full |= cef0
+                folders_per_plasma[p][variable] = fld0
+
+        # ---- Phase 2: ONE dispatch of all N × vars × mults × rhos ----
+        tglf._run(
+            code_executor,
+            code_executor_full=code_executor_full,
+            extra_name=f"{extra_name}_turb_drives_batched",
+            **scan_kwargs,
+        )
+
+    # ---- Phase 3: Read results per plasma and aggregate ----
+    Flux_mean_list, Flux_std_list = [], []
+    for p, label in plasma_labels.items():
+        tglf.read_plasma(p, label=label, require_all_files=False)
+
+        cont_folder = 0
+        for variable in variables_to_scan:
+            scan_name = f"turb_drives_plasma{p}_{variable}"
+            folders = folders_per_plasma[p][variable]
+            for mult_idx, mult in enumerate(varUpDown_dict[variable]):
+                tglf.read(
+                    label=f"{tglf.subfolder_scan}_{variable}_{mult}",
+                    folder=folders[mult_idx],
+                    cold_startWF=False,
+                    require_all_files=not only_minimal_files,
+                )
+                cont_folder += 1
+
+            tglf.read_scan(
+                label=scan_name,
+                variable=variable,
+                ion_OI_position_in_total_padded_list=ion_OI_position_in_total_padded_list,
+            )
+
+        Fmean_p, Fstd_p = _aggregate_scan_fluxes(
+            tglf,
+            f"turb_drives_plasma{p}",
+            variables_to_scan,
+            relative_scan,
+            rho_locations,
+            Flux_base=Flux_base_per_plasma.get(p),
+            ion_OI_position_in_ion_list=ion_OI_position_in_ion_list,
+            Qi_includes_fast=Qi_includes_fast,
+            reuse_scan_ball_file=reuse_scan_ball_file,
+            delta=delta,
+        )
+        Flux_mean_list.append(np.array(Fmean_p))
+        Flux_std_list.append(np.array(Fstd_p))
+
+    # Stack: list of (6, nrho) -> (6, N, nrho)
+    Flux_mean = np.stack(Flux_mean_list, axis=1)
+    Flux_std  = np.stack(Flux_std_list,  axis=1)
 
     return Flux_mean, Flux_std
 

--- a/src/mitim_modules/powertorch/utils/CALCtools.py
+++ b/src/mitim_modules/powertorch/utils/CALCtools.py
@@ -34,10 +34,14 @@ def integration_Lx(x, z, f_bound):
 
     return f
     
-def derivation_into_Lx(r, p, array = False):
+def derivation_into_Lx(r, p, array=False):
     """
-    Produces -1/p * dp/dr
-        (adapted from  expro_util.f90, bound_deriv)
+    Produces -1/p * dp/dr using 2nd-order Lagrange interpolating polynomial.
+        (adapted from expro_util.f90, bound_deriv)
+
+    This matches GACODE's internal derivative scheme (bound_deriv), ensuring
+    consistency between POWERTORCH and TGLF/CGYRO/NEO when they recompute
+    gradients from the same input.gacode.
 
     Notes:
         - if r is r/a: a/Lp
@@ -49,6 +53,37 @@ def derivation_into_Lx(r, p, array = False):
         z = MATHtools.deriv(r, -np.log(p), array=True)
 
     return z
+
+
+def derivation_into_Lx_central(r, p, array=False):
+    """
+    Produces -1/p * dp/dr using central differences.
+
+    Alternative to the default Lagrange method. Central differences are
+    structurally more consistent with integration_Lx's trapezoidal log-space
+    formula, reducing the fine-grid roundtrip error by ~30%. However, they
+    use a different stencil than GACODE's bound_deriv, which can cause
+    small discrepancies when transport codes recompute gradients.
+
+    Notes:
+        - if r is r/a: a/Lp
+    """
+
+    if array:
+        r, p = np.array(r, dtype=float), np.array(p, dtype=float)
+        lnp = np.log(p)
+        z = np.empty_like(lnp)
+        z[1:-1] = -(lnp[2:] - lnp[:-2]) / (r[2:] - r[:-2])
+        z[0] = -(lnp[1] - lnp[0]) / (r[1] - r[0])
+        z[-1] = -(lnp[-1] - lnp[-2]) / (r[-1] - r[-2])
+        return z
+    else:
+        lnp = torch.log(p)
+        z = torch.empty_like(p)
+        z[1:-1] = -(lnp[2:] - lnp[:-2]) / (r[2:] - r[:-2])
+        z[0] = -(lnp[1] - lnp[0]) / (r[1] - r[0])
+        z[-1] = -(lnp[-1] - lnp[-2]) / (r[-1] - r[-2])
+        return z
 
 def integration_dxdr(x, z, z0_bound):
     """
@@ -71,12 +106,25 @@ def integration_dxdr(x, z, z0_bound):
 
 def derivation_into_dxdr(r, p):
     """
-    Produces -dp/dr
+    Produces -dp/dr using 2nd-order Lagrange interpolating polynomial.
+        (adapted from expro_util.f90, bound_deriv)
     """
 
-    # This is the same as it happens in expro_util.f90, bound_deriv
     z = MATHtools.deriv(r, -p, array=False)
+    return z
 
+
+def derivation_into_dxdr_central(r, p):
+    """
+    Produces -dp/dr using central differences.
+    Alternative to the default Lagrange method.
+    """
+
+    neg_p = -p
+    z = torch.empty_like(p)
+    z[1:-1] = (neg_p[2:] - neg_p[:-2]) / (r[2:] - r[:-2])
+    z[0] = (neg_p[1] - neg_p[0]) / (r[1] - r[0])
+    z[-1] = (neg_p[-1] - neg_p[-2]) / (r[-1] - r[-2])
     return z
 
 # ********************************************************************************************************************

--- a/src/mitim_modules/powertorch/utils/POWERplot.py
+++ b/src/mitim_modules/powertorch/utils/POWERplot.py
@@ -254,39 +254,67 @@ def plot_kp(plasma,ax, ax_aL, ax_Fgb, ax_F, key, key_aL, key_Ftr, key_Ftar, titl
         GRAPHICStools.addDenseAxis(ax)
 
 
-def plot_metrics_powerstates(axsM, powerstates, profiles=None, profiles_color='b'):
+def plot_metrics_powerstates(axsM, powerstates, profiles=None, profiles_color='b', n_trajectories=1):
 
+    _TRAJ_COLORS = ['tab:blue', 'tab:red', 'tab:green', 'tab:orange', 'tab:purple',
+                    'tab:brown', 'tab:pink', 'tab:gray', 'tab:olive', 'tab:cyan']
+
+    n_ps = len(powerstates)
+    n_traj = n_trajectories
+
+    # --- Residual panel ---
     ax = axsM[0]
-    x , y = [], []
-    for h in range(len(powerstates)):
-        x.append(h)
-        y.append(powerstates[h].plasma['residual'].item())
-        
-    ax.plot(x,y,'-s', color='b', lw=1, ms=5)
+    if n_traj > 1:
+        for t in range(n_traj):
+            xs, ys = [], []
+            for i in range(n_ps):
+                if i % n_traj == t:
+                    xs.append(i)
+                    ys.append(powerstates[i].plasma['residual'].item())
+            ax.plot(xs, ys, '-s', color=_TRAJ_COLORS[t % len(_TRAJ_COLORS)],
+                    lw=1, ms=4, label=f'T{t}')
+        ax.legend(prop={"size": 7})
+    else:
+        x, y = [], []
+        for h in range(n_ps):
+            x.append(h)
+            y.append(powerstates[h].plasma['residual'].item())
+        ax.plot(x, y, '-s', color='b', lw=1, ms=5)
     ax.set_yscale('log')
-    #ax.set_xlabel('Evaluation')
     ax.set_ylabel('Mean Residual')
-    ax.set_xlim([0,len(powerstates)+1])
+    ax.set_xlim([0, n_ps + 1])
     GRAPHICStools.addDenseAxis(ax)
 
+    # --- Fusion power panel ---
     ax = axsM[1]
-    x , y = [], []
-    for h in range(len(powerstates)):
-        x.append(h)
-        Pfus = powerstates[h].from_density_to_flux(
-            (powerstates[h].plasma["qfuse"] + powerstates[h].plasma["qfusi"]) * 5.0
+    if n_traj > 1:
+        for t in range(n_traj):
+            xs, ys = [], []
+            for i in range(n_ps):
+                if i % n_traj == t:
+                    xs.append(i)
+                    Pfus = powerstates[i].from_density_to_flux(
+                        (powerstates[i].plasma["qfuse"] + powerstates[i].plasma["qfusi"]) * 5.0
+                    ) * powerstates[i].plasma["volp"]
+                    ys.append(Pfus[..., -1].item())
+            ax.plot(xs, ys, '-s', color=_TRAJ_COLORS[t % len(_TRAJ_COLORS)],
+                    lw=1, ms=4, label=f'T{t}')
+    else:
+        x, y = [], []
+        for h in range(n_ps):
+            x.append(h)
+            Pfus = powerstates[h].from_density_to_flux(
+                (powerstates[h].plasma["qfuse"] + powerstates[h].plasma["qfusi"]) * 5.0
             ) * powerstates[h].plasma["volp"]
-        y.append(Pfus[..., -1].item())
-
-    if profiles is not None:
-        x.append(h+1)
-        y.append(profiles.derived["Pfus"])
-    ax.plot(x,y,'-s', color='b', lw=1, ms=5)
-    if profiles is not None:
-            ax.plot(x[-1],y[-1],'s', color=profiles_color, ms=5)
-
+            y.append(Pfus[..., -1].item())
+        if profiles is not None:
+            x.append(h + 1)
+            y.append(profiles.derived["Pfus"])
+        ax.plot(x, y, '-s', color='b', lw=1, ms=5)
+        if profiles is not None:
+            ax.plot(x[-1], y[-1], 's', color=profiles_color, ms=5)
     ax.set_xlabel('Evaluation')
     ax.set_ylabel('Fusion Power (MW)')
     GRAPHICStools.addDenseAxis(ax)
     ax.set_ylim(bottom=0)
-    ax.set_xlim([0,len(powerstates)+1])
+    ax.set_xlim([0, n_ps + 1])

--- a/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
@@ -177,6 +177,8 @@ def gacode_to_powerstate(self, rho_vec=None):
     for i in range(input_gacode.profiles['ni(10^19/m^3)'].shape[1]):
         cases_to_parameterize.append([f"ni{i}", "ni(10^19/m^3)", i, 1.0, True])
 
+    smooth_around_coarsing = self.transport_options.get("flatten_gradients_at_control_points", True)
+
     self.profile_constructors_fine, self.profile_constructors_coarse, self.profile_constructors_coarse_middle = {}, {}, {}
     for key in cases_to_parameterize:
         quant = input_gacode.profiles[key[1]] if key[2] is None else input_gacode.profiles[key[1]][:, key[2]]
@@ -192,9 +194,10 @@ def gacode_to_powerstate(self, rho_vec=None):
             self.plasma["roa"],
             parameterize_in_aLx=key[4],
             multiplier_quantity=key[3],
+            smooth_around_coarsing=smooth_around_coarsing,
         )
 
-        self.plasma[f"aL{key[0]}"] = aLy_coarse[:-1, 1]
+        self.plasma[f"aL{key[0]}"] = aLy_coarse[:, 1]
 
         # Check that it's not completely zero
         if key[0] in self.predicted_channels:
@@ -470,7 +473,7 @@ def defineIons(self, input_gacode, rho_vec, dfT):
     self.plasma["ions_set_Tion"] = Tion
     self.plasma["ions_set_c_rad"] = c_rad
 
-def improve_resolution_profiles(profiles, rhoMODEL):
+def improve_resolution_profiles(profiles, rhoMODEL, smooth_around_coarsing=True):
     """
     Resolution of input.gacode
     **************************
@@ -507,13 +510,16 @@ def improve_resolution_profiles(profiles, rhoMODEL):
 
     # ----------------------------------------------------------------------------------
     # 2. Add extra resolution around the modelled (e.g. TGYRO) points
+    #    (only needed when smoothAroundCoarsing is enabled, to provide the
+    #    neighboring fine-grid points that get flattened)
     # ----------------------------------------------------------------------------------
 
-    for i in range(points_updown):
-        rho_new = np.append(
-            np.append(rho_new, rhoMODEL + d_spacing_coarse * (i + 1)),
-            rhoMODEL - d_spacing_coarse * (i + 1),
-        )
+    if smooth_around_coarsing:
+        for i in range(points_updown):
+            rho_new = np.append(
+                np.append(rho_new, rhoMODEL + d_spacing_coarse * (i + 1)),
+                rhoMODEL - d_spacing_coarse * (i + 1),
+            )
 
     # ----------------------------------------------------------------------------------
     # Change resolution

--- a/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
@@ -120,19 +120,47 @@ class power_transport:
 
         '''
         ******************************************************************************************************
-        Evaluate neoclassical and turbulent transport (*in GB units*). 
-        These functions use a hook to write the .json files to communicate the results to powerstate.plasma
+        Cache short-circuit.
+
+        If the target folder already contains both fluxes_turb.json and fluxes_neoc.json, trust them
+        and skip the turbulence / neoclassical backends entirely — go straight to the populate +
+        postprocess tail of this method. This is what makes initialization_simple_relax's SR copy
+        actually save work at BO time under *both* subprocess and in-process TGLF: the write_json
+        hook (decorating evaluate_turbulence / evaluate_neoclassical) wrote the JSON pair at every
+        SR step regardless of how transport was executed, and the SR copy loop already carries that
+        pair into Execution/Evaluation.{i}/transport_simulation_folder. The subprocess path used to
+        rely on cold_start_checker matching out.tglf.gbflux_{rho:.4f} inside the same folder, which
+        the in-process path never writes — so a pure JSON-pair gate at this level subsumes the
+        lower-level reuse path and fixes both.
         ******************************************************************************************************
         '''
-        
-        # Initialize them as zeros
-        for var in ['QeGB','QiGB','GeGB','GZGB','MtGB','QieGB']:
-            for suffix in ['turb', 'neoc']:
-                for suffix0 in ['', '_stds']:
-                    self.__dict__[f"{var}_{suffix}{suffix0}"] = torch.zeros(self.powerstate.plasma['rho'].shape[-1]-1)
-        
-        neoclassical = self.evaluate_neoclassical()
-        turbulence = self.evaluate_turbulence()
+        cache_hit = (
+            (self.folder / 'fluxes_turb.json').exists()
+            and (self.folder / 'fluxes_neoc.json').exists()
+        )
+
+        if cache_hit:
+            print(
+                f"\t- Reusing cached flux JSONs from {IOtools.clipstr(self.folder)} "
+                f"(SR copy or previous evaluation); skipping turbulence / neoclassical runs",
+                typeMsg='i',
+            )
+        else:
+            '''
+            ******************************************************************************************************
+            Evaluate neoclassical and turbulent transport (*in GB units*).
+            These functions use a hook to write the .json files to communicate the results to powerstate.plasma
+            ******************************************************************************************************
+            '''
+
+            # Initialize them as zeros
+            for var in ['QeGB','QiGB','GeGB','GZGB','MtGB','QieGB']:
+                for suffix in ['turb', 'neoc']:
+                    for suffix0 in ['', '_stds']:
+                        self.__dict__[f"{var}_{suffix}{suffix0}"] = torch.zeros(self.powerstate.plasma['rho'].shape[-1]-1)
+
+            neoclassical = self.evaluate_neoclassical()
+            turbulence = self.evaluate_turbulence()
 
         '''
         ******************************************************************************************************

--- a/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
@@ -76,7 +76,7 @@ def write_json(self, file_name = 'fluxes_turb.json', suffix= 'turb'):
 
             json.dump(json_dict, f, indent=4)
 
-        print(f"\t* Written JSON with {suffix} information to {self.folder / file_name}")
+        print(f"\t* Written JSON with {suffix} information to {IOtools.clipstr(self.folder / file_name)}")
         
     else:
         
@@ -357,7 +357,7 @@ class power_transport:
         Populate the powerstate.plasma from the json file
         **********************************************************************************************
         '''
-        print(f"\t* Populating powerstate.plasma with JSON data from {self.folder / file_name}")
+        print(f"\t* Populating powerstate.plasma with JSON data from {IOtools.clipstr(self.folder / file_name)}")
 
         with open(self.folder / file_name, 'r') as f:
             json_dict = json.load(f)

--- a/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
@@ -264,8 +264,14 @@ class power_transport:
         vgen_exb_options = self.powerstate.transport_options.get("options", {}).get("neo", {}).get("vgen_exb_shear", None)
         if vgen_exb_options is not None:
             print("\t- Computing neoclassical ExB shear via NEO VGEN (zero toroidal rotation)", typeMsg="i")
-            rho_range = None
             vgenOptions = {} if vgen_exb_options is True else dict(vgen_exb_options)
+
+            # Limit VGEN to the region PORTALS predicts, with a 0.05 margin on each side
+            rho_portals = self.powerstate.plasma["rho"][0, 1:].cpu().numpy()
+            rho_lo = float(np.clip(rho_portals.min() - 0.05, 0.0, 1.0))
+            rho_hi = float(np.clip(rho_portals.max() + 0.05, 0.0, 1.0))
+            rho_range = [rho_lo, rho_hi]
+            print(f"\t\t- VGEN rho_range: [{rho_lo:.3f}, {rho_hi:.3f}] (PORTALS rho: [{rho_portals.min():.3f}, {rho_portals.max():.3f}])", typeMsg="i")
 
             # minutes for VGEN from the NEO slurm_setup (same source as neo.run()), defaulting to 60
             neo_slurm    = self.transport_evaluator_options.get("neo", {}).get("run", {}).get("slurm_setup", {})
@@ -275,8 +281,10 @@ class power_transport:
             neo_exb.FolderGACODE = self.folder
             neo_exb.profiles = self.powerstate.profiles_transport
             # numcores=None → run_vgen() resolves from machineSettings (same logic as SIMtools._run())
+            # smooth_profiles=True: smooth Te/Ti/ne/ni before VGEN so piecewise-linear
+            # kinks in the gradients do not pollute the computed Er
             neo_exb.run_vgen(subfolder="vgen_neo_exb", vgenOptions=vgenOptions, cold_start=self.cold_start,
-                             rho_range=rho_range, minutes=minutes_vgen)
+                             rho_range=rho_range, minutes=minutes_vgen, smooth_profiles=True)
             neo_exb.read_vgen()
             
             # Insert w0 by interpolating

--- a/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
@@ -6,7 +6,7 @@ from functools import partial
 import copy
 import shutil
 from mitim_tools.misc_tools import IOtools, PLASMAtools
-from mitim_tools.gacode_tools import PROFILEStools
+from mitim_tools.gacode_tools import PROFILEStools, NEOtools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from IPython import embed
 
@@ -259,6 +259,41 @@ class power_transport:
         if impurityPosition_new != self.powerstate.impurityPosition:
             print(f"\t- Impurity position has changed from {self.powerstate.impurityPosition} to {impurityPosition_new}",typeMsg="i")
             self.powerstate.impurityPosition_transport = p_new.Species.index(impurity_of_interest)
+
+        # --- Optional: compute neoclassical E×B shear from NEO VGEN (zero toroidal rotation assumed)
+        vgen_exb_options = self.powerstate.transport_options.get("options", {}).get("neo", {}).get("vgen_exb_shear", None)
+        if vgen_exb_options is not None:
+            print("\t- Computing neoclassical ExB shear via NEO VGEN (zero toroidal rotation)", typeMsg="i")
+            rho_range = None
+            vgenOptions = {} if vgen_exb_options is True else dict(vgen_exb_options)
+
+            # minutes for VGEN from the NEO slurm_setup (same source as neo.run()), defaulting to 60
+            neo_slurm    = self.transport_evaluator_options.get("neo", {}).get("run", {}).get("slurm_setup", {})
+            minutes_vgen = neo_slurm.get("minutes", 60)
+
+            neo_exb = NEOtools.NEO(rhos=[])
+            neo_exb.FolderGACODE = self.folder
+            neo_exb.profiles = self.powerstate.profiles_transport
+            # numcores=None → run_vgen() resolves from machineSettings (same logic as SIMtools._run())
+            neo_exb.run_vgen(subfolder="vgen_neo_exb", vgenOptions=vgenOptions, cold_start=self.cold_start,
+                             rho_range=rho_range, minutes=minutes_vgen)
+            neo_exb.read_vgen()
+            
+            # Insert w0 by interpolating
+            if rho_range is not None:
+                w0 = np.interp(
+                    self.powerstate.profiles_transport.profiles['rho(-)'],
+                    neo_exb.profiles_vgen.profiles['rho(-)'],
+                    neo_exb.profiles_vgen.profiles['w0(rad/s)']
+                )
+            else:
+                w0 = neo_exb.profiles_vgen.profiles['w0(rad/s)']
+                
+            self.powerstate.profiles_transport.profiles['w0(rad/s)'] = w0
+
+            # Propagate to powerstate.profiles so the stored iteration profiles also carry the NEO w0
+            self.powerstate.profiles.profiles['w0(rad/s)'] = w0
+            self.powerstate.profiles.write_state(file=self.file_profs)
 
     def _profiles_to_store(self):
 

--- a/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
@@ -277,10 +277,10 @@ class power_transport:
             neo_opts     = self.transport_evaluator_options.get("neo", {})
             neo_slurm    = neo_opts.get("run", {}).get("slurm_setup", {})
             minutes_vgen = neo_slurm.get("minutes", 60)
-            # Reuse the namelist's `neo.in_process` flag for VGEN as well —
-            # if the user wants in-process NEO they almost certainly want
+            # Reuse the top-level `transport.in_process` flag for VGEN as well —
+            # if the user wants in-process codes they almost certainly want
             # in-process VGEN too (same ctypes path, no SLURM overhead).
-            in_process_vgen = neo_opts.get("in_process", False)
+            in_process_vgen = self.powerstate.transport_options.get("in_process", False)
 
             neo_exb = NEOtools.NEO(rhos=[])
             neo_exb.FolderGACODE = self.folder

--- a/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
@@ -139,12 +139,31 @@ class power_transport:
             and (self.folder / 'fluxes_neoc.json').exists()
         )
 
+        batched = (
+            getattr(self.powerstate, "batch_size", 0) or 0
+        ) > 1
+
+        # Initialize all GB flux arrays to zeros up front. The backends overwrite
+        # whichever fluxes they compute; anything left untouched stays at zero (e.g.
+        # QieGB_neoc, which NEO never produces). For the batched path the 2D (N, nrho)
+        # arrays written by the batched backends overwrite these 1D zeros; the in-memory
+        # fallback in _populate_from_json then broadcasts them correctly.
+        nrho_m1 = self.powerstate.plasma['rho'].shape[-1] - 1
+        for var in ['QeGB', 'QiGB', 'GeGB', 'GZGB', 'MtGB', 'QieGB']:
+            for suffix in ['turb', 'neoc']:
+                for suffix0 in ['', '_stds']:
+                    self.__dict__[f"{var}_{suffix}{suffix0}"] = torch.zeros(nrho_m1)
+
         if cache_hit:
             print(
                 f"\t- Reusing cached flux JSONs from {IOtools.clipstr(self.folder)} "
                 f"(SR copy or previous evaluation); skipping turbulence / neoclassical runs",
                 typeMsg='i',
             )
+        elif batched:
+            # Multi-plasma simple-relax path: fan N plasmas through run_over_plasmas in one
+            # parallel submission via _evaluate_batched. See docstring on that method.
+            self._evaluate_batched()
         else:
             '''
             ******************************************************************************************************
@@ -152,12 +171,6 @@ class power_transport:
             These functions use a hook to write the .json files to communicate the results to powerstate.plasma
             ******************************************************************************************************
             '''
-
-            # Initialize them as zeros
-            for var in ['QeGB','QiGB','GeGB','GZGB','MtGB','QieGB']:
-                for suffix in ['turb', 'neoc']:
-                    for suffix0 in ['', '_stds']:
-                        self.__dict__[f"{var}_{suffix}{suffix0}"] = torch.zeros(self.powerstate.plasma['rho'].shape[-1]-1)
 
             neoclassical = self.evaluate_neoclassical()
             turbulence = self.evaluate_turbulence()
@@ -179,7 +192,143 @@ class power_transport:
         ******************************************************************************************************
         '''
         self._postprocess()
-        
+
+    def _evaluate_batched(self):
+        '''
+        Multi-plasma (batched) evaluate path, reached from evaluate() when
+        self.powerstate.batch_size > 1 — today that is the PORTALS parallel simple-relax
+        initialization, which asks one flux_match call to walk N trajectories in lockstep.
+
+        The responsibility split:
+
+            - Write one input.gacode per batch element under
+              self.folder / f"plasma_{b}" / "input.gacode" by deepcopy + _repeat_tensors(
+              batch_size=1, positionToUnrepeat=b) on self.powerstate, then call
+              from_powerstate(...) to materialise a gacode_state and its input.gacode file.
+            - Assemble list_of_states (one per plasma) and hand it to the batched
+              backend dispatchers evaluate_neoclassical_batched / evaluate_turbulence_batched,
+              which route to neo_model._evaluate_neo_batched / tglf_model._evaluate_tglf_batched
+              respectively. Those methods run one `tglf.run_over_plasmas` / `neo.run_over_plasmas`
+              call, reap per-plasma results, and populate self.QeGB_{turb,neoc}, ... as
+              (N, nrho) numpy arrays.
+            - Suppress the bundled-folder write_json decorators (via
+              _write_json_from_variables_{turb,neoc} = False) so we do not emit a 2D
+              fluxes_*.json at self.folder — that would confuse the single-plasma
+              _populate_from_json reader that fires at BO time via the cache-hit gate.
+            - Write one single-plasma fluxes_turb.json + fluxes_neoc.json pair under each
+              self.folder / f"plasma_{b}" / using the *existing* 1D schema. These are the
+              files the SR copy loop in initialization_simple_relax moves into
+              Execution/Evaluation.{i}/transport_simulation_folder, and they are what the
+              evaluate() cache-hit gate picks up at BO time for zero-work reuse.
+
+        The in-memory (N, nrho) arrays are then fed through _populate_from_json's
+        file-missing fallback (which now uses [:, 1:] broadcasting) and _postprocess
+        (which now detects 1D vs 2D inputs), so the caller sees (N, nrho+1) batched
+        torch tensors in self.powerstate.plasma[Q*_tr_*] exactly like the single-plasma
+        path does for its own (1, nrho+1) case.
+        '''
+
+        N = int(self.powerstate.batch_size)
+
+        # (1) Materialise N per-plasma input.gacodes + gacode_state profile objects.
+        list_of_states = []
+        per_plasma_folders = []
+        for b in range(N):
+            sub_folder = self.folder / f"plasma_{b}"
+            sub_folder.mkdir(parents=True, exist_ok=True)
+            per_plasma_folders.append(sub_folder)
+
+            sub_powerstate = copy.deepcopy(self.powerstate)
+            sub_powerstate._repeat_tensors(batch_size=1, positionToUnrepeat=b)
+
+            sub_profile = sub_powerstate.copy_state().from_powerstate(
+                write_input_gacode=sub_folder / "input.gacode",
+                postprocess_input_gacode=self.powerstate.transport_options.get("applyCorrections", True),
+                rederive_profiles=True,
+                insert_highres_powers=True,
+            )
+            list_of_states.append(sub_profile)
+
+        # (2) Suppress the bundled-folder write_json decorators — each per-plasma JSON pair
+        # is written explicitly below so the top-level self.folder does not carry a 2D
+        # fluxes_*.json that would confuse single-plasma readers (including the cache-hit
+        # gate at BO time). The flag must be set *before* the decorator fires, which means
+        # before evaluate_turbulence_batched / evaluate_neoclassical_batched run.
+        self._write_json_from_variables_turb = False
+        self._write_json_from_variables_neoc = False
+
+        # (3) Run both backends once across all N plasmas via run_over_plasmas.
+        self.evaluate_neoclassical_batched(list_of_states)
+        self.evaluate_turbulence_batched(list_of_states)
+
+        # (4) Emit one single-plasma JSON pair per batch element for downstream reuse.
+        rho_arr   = self.powerstate.plasma["rho"][0, 1:].cpu().numpy().tolist()
+        roa_arr   = self.powerstate.plasma["roa"][0, 1:].cpu().numpy().tolist()
+        for b, sub_folder in enumerate(per_plasma_folders):
+            # Shared additional_info is taken from batch 0 — rho / roa / aLx do not vary
+            # across the batch replication, they are just tiled copies.
+            self._write_per_plasma_json(
+                sub_folder,
+                batch_index=b,
+                suffix='turb',
+                rho_arr=rho_arr,
+                roa_arr=roa_arr,
+            )
+            self._write_per_plasma_json(
+                sub_folder,
+                batch_index=b,
+                suffix='neoc',
+                rho_arr=rho_arr,
+                roa_arr=roa_arr,
+            )
+
+    def _write_per_plasma_json(self, sub_folder, batch_index, suffix, rho_arr, roa_arr):
+        '''
+        Per-plasma, single-plasma-shaped writer used by _evaluate_batched to carve one
+        row out of the (N, nrho) self.QeGB_{turb,neoc} / ... arrays and drop it into
+        sub_folder as a 1D fluxes_{turb,neoc}.json that matches the write_json schema.
+        '''
+        file_name = f"fluxes_{suffix}.json"
+        fluxes_mean, fluxes_stds = {}, {}
+
+        def _slice_batch(arr, b):
+            '''Extract a 1D per-plasma slice from an array that may be 2D (N, nrho) or 1D (nrho).
+            1D arrays are shared across all batches (e.g. the zero-init for QieGB_neoc which NEO
+            never overwrites), so they are returned as-is regardless of batch index.'''
+            arr = np.asarray(arr) if not isinstance(arr, np.ndarray) else arr
+            return arr[b, :] if arr.ndim >= 2 else arr
+
+        for var in ['QeGB', 'QiGB', 'GeGB', 'GZGB', 'MtGB', 'QieGB']:
+            key_mean = f"{var}_{suffix}"
+            key_std  = f"{var}_{suffix}_stds"
+            if key_mean not in self.__dict__:
+                continue
+            try:
+                fluxes_mean[var] = _slice_batch(self.__dict__[key_mean], batch_index).tolist()
+                fluxes_stds[var] = _slice_batch(self.__dict__[key_std],  batch_index).tolist()
+            except (KeyError, IndexError, TypeError):
+                pass
+
+        json_dict = {
+            'fluxes_mean': fluxes_mean,
+            'fluxes_stds': fluxes_stds,
+            'additional_info': {
+                'rho': rho_arr,
+                'roa': roa_arr,
+                'Qgb':  self.powerstate.plasma["Qgb"][0, 1:].cpu().numpy().tolist(),
+                'aLte': self.powerstate.plasma["aLte"][0, 1:].cpu().numpy().tolist(),
+                'aLti': self.powerstate.plasma["aLti"][0, 1:].cpu().numpy().tolist(),
+                'aLne': self.powerstate.plasma["aLne"][0, 1:].cpu().numpy().tolist(),
+            },
+        }
+
+        with open(sub_folder / file_name, 'w') as f:
+            json.dump(json_dict, f, indent=4)
+        print(
+            f"\t* Written per-plasma JSON with {suffix} information to "
+            f"{IOtools.clipstr(sub_folder / file_name)}"
+        )
+
     def _postprocess(self):
         '''
         Curate information for the powerstate (e.g. add models, add batch dimension, rho=0.0, and tensorize)
@@ -194,14 +343,26 @@ class power_transport:
         for variable in variables:
             for suffix in ['_tr_turb', '_tr_turb_stds', '_tr_neoc', '_tr_neoc_stds']:
 
-                # Make them tensors and add a batch dimension
-                self.powerstate.plasma[f"{variable}{suffix}"] = torch.Tensor(self.powerstate.plasma[f"{variable}{suffix}"]).to(self.powerstate.dfT).unsqueeze(0)
- 
-                # Pad with zeros at rho=0.0
-                self.powerstate.plasma[f"{variable}{suffix}"] = torch.cat((
-                    torch.zeros((1, 1)),
-                    self.powerstate.plasma[f"{variable}{suffix}"],
+                arr = self.powerstate.plasma[f"{variable}{suffix}"]
+                # _populate_from_json hands us either a numpy ndarray (single plasma fallback)
+                # or a torch tensor (JSON-on-disk read path, or 2D (N,nrho) from the
+                # multi-plasma batched in-memory fallback). Normalise to torch first, then
+                # only unsqueeze(0) if the array is still 1D (single-plasma case). For a
+                # pre-2D array (batched SR path) we keep the explicit N batch axis and pad
+                # the rho=0 column per batch row.
+                if not isinstance(arr, torch.Tensor):
+                    arr = torch.as_tensor(arr)
+                arr = arr.to(self.powerstate.dfT)
+                if arr.dim() == 1:
+                    arr = arr.unsqueeze(0)
+
+                # Pad with zeros at rho=0.0 — shape (N, 1) matching the current batch size
+                arr = torch.cat((
+                    torch.zeros((arr.shape[0], 1), dtype=arr.dtype, device=arr.device),
+                    arr,
                 ), dim=1)
+
+                self.powerstate.plasma[f"{variable}{suffix}"] = arr
 
         # -----------------------------------------------------------
         # Sum the turbulent and neoclassical contributions
@@ -373,10 +534,16 @@ class power_transport:
         if not (self.folder / file_name).exists():
             print(f"\t* File {self.folder / file_name} does not exist, cannot populate powerstate.plasma", typeMsg='w')
             print(f"\t- Tranforming from GB to real units:")
-            
+
+            # Use [:, 1:] rather than [0, 1:] so this in-memory fallback broadcasts for both
+            # single-plasma and multi-plasma inputs without collapsing the batch axis. gb is
+            # first converted to numpy because self.__dict__[*_turb] arrives as a numpy array
+            # from _evaluate_tglf / _evaluate_tglf_batched and `np.ndarray * torch.Tensor`
+            # raises TypeError (only the torch-lhs form works).
             for var in mapper:
-                self.powerstate.plasma[f"{mapper[var][1]}_tr_{suffix}"] = self.__dict__[f"{var}_{suffix}"] * self.powerstate.plasma[f"{mapper[var][0]}"][0,1:]
-                self.powerstate.plasma[f"{mapper[var][1]}_tr_{suffix}_stds"] = self.__dict__[f"{var}_{suffix}_stds"] * self.powerstate.plasma[f"{mapper[var][0]}"][0,1:]
+                gb = self.powerstate.plasma[f"{mapper[var][0]}"][:, 1:].cpu().numpy()
+                self.powerstate.plasma[f"{mapper[var][1]}_tr_{suffix}"] = self.__dict__[f"{var}_{suffix}"] * gb
+                self.powerstate.plasma[f"{mapper[var][1]}_tr_{suffix}_stds"] = self.__dict__[f"{var}_{suffix}_stds"] * gb
 
             return
         
@@ -495,7 +662,7 @@ class portals_transport_model(power_transport, tglf_model, neo_model, cgyro_mode
         
     @IOtools.hook_method(after=partial(write_json, file_name = 'fluxes_turb.json', suffix= 'turb'))
     def evaluate_turbulence(self):
-        
+
         if self.turbulence_model.lower() == 'tglf':
             return tglf_model.evaluate_turbulence(self)
         elif self.turbulence_model.lower() == 'cgyro':
@@ -505,8 +672,20 @@ class portals_transport_model(power_transport, tglf_model, neo_model, cgyro_mode
         else:
             raise Exception(f"Unknown turbulence model {self.turbulence_model}")
 
+    def evaluate_turbulence_batched(self, list_of_states):
+        # Multi-plasma dispatcher — powerstate.batch_size > 1 path. No @hook_method here:
+        # _evaluate_batched() writes per-plasma JSON pairs itself and disables the single-
+        # folder write_json decorator via self._write_json_from_variables_turb = False.
+        if self.turbulence_model.lower() == 'tglf':
+            return tglf_model.evaluate_turbulence_batched(self, list_of_states)
+        else:
+            raise NotImplementedError(
+                f"Batched turbulence dispatch not yet implemented for model "
+                f"{self.turbulence_model!r}. Use single-plasma SR or extend this dispatcher."
+            )
+
     def _stable_correction(self, simulation_options):
-        
+
         if self.turbulence_model.lower() == 'cgyro':
             cgyro_model._stable_correction(self, simulation_options)
 
@@ -518,3 +697,16 @@ class portals_transport_model(power_transport, tglf_model, neo_model, cgyro_mode
             return neo_model.evaluate_neoclassical(self)
         else:
             raise Exception(f"Unknown neoclassical model {self.neoclassical_model}")
+
+    def evaluate_neoclassical_batched(self, list_of_states):
+        # Multi-plasma dispatcher — no @hook_method decorator for the same reason as
+        # evaluate_turbulence_batched above.
+        if self.neoclassical_model is None:
+            print('Neoclassical model chosen', typeMsg='w')
+        elif self.neoclassical_model.lower() == 'neo':
+            return neo_model.evaluate_neoclassical_batched(self, list_of_states)
+        else:
+            raise NotImplementedError(
+                f"Batched neoclassical dispatch not yet implemented for model "
+                f"{self.neoclassical_model!r}."
+            )

--- a/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSPORTtools.py
@@ -274,8 +274,13 @@ class power_transport:
             print(f"\t\t- VGEN rho_range: [{rho_lo:.3f}, {rho_hi:.3f}] (PORTALS rho: [{rho_portals.min():.3f}, {rho_portals.max():.3f}])", typeMsg="i")
 
             # minutes for VGEN from the NEO slurm_setup (same source as neo.run()), defaulting to 60
-            neo_slurm    = self.transport_evaluator_options.get("neo", {}).get("run", {}).get("slurm_setup", {})
+            neo_opts     = self.transport_evaluator_options.get("neo", {})
+            neo_slurm    = neo_opts.get("run", {}).get("slurm_setup", {})
             minutes_vgen = neo_slurm.get("minutes", 60)
+            # Reuse the namelist's `neo.in_process` flag for VGEN as well —
+            # if the user wants in-process NEO they almost certainly want
+            # in-process VGEN too (same ctypes path, no SLURM overhead).
+            in_process_vgen = neo_opts.get("in_process", False)
 
             neo_exb = NEOtools.NEO(rhos=[])
             neo_exb.FolderGACODE = self.folder
@@ -284,7 +289,8 @@ class power_transport:
             # smooth_profiles=True: smooth Te/Ti/ne/ni before VGEN so piecewise-linear
             # kinks in the gradients do not pollute the computed Er
             neo_exb.run_vgen(subfolder="vgen_neo_exb", vgenOptions=vgenOptions, cold_start=self.cold_start,
-                             rho_range=rho_range, minutes=minutes_vgen, smooth_profiles=True)
+                             rho_range=rho_range, minutes=minutes_vgen, smooth_profiles=True,
+                             in_process=in_process_vgen)
             neo_exb.read_vgen()
             
             # Insert w0 by interpolating

--- a/src/mitim_tools/gacode_tools/CGYROtools.py
+++ b/src/mitim_tools/gacode_tools/CGYROtools.py
@@ -20,6 +20,9 @@ class CGYRO(SIMtools.mitim_simulation, SIMplot.GKplotting):
 
         super().__init__(**kwargs)
 
+        # Transient state used by run() to feed preprocess_options into _run_prepare()
+        self._preprocess_options = None
+
         def code_call(folder, p, n=1, additional_command="", **kwargs):
             # `n` is cores_per_code_call (total cores for ONE radius), not MPI tasks.
             # On GPU machines we translate it into CGYRO's -n/-nomp/-numa/-mpinuma
@@ -163,6 +166,14 @@ class CGYRO(SIMtools.mitim_simulation, SIMplot.GKplotting):
         self.output_files_simulation["minimal"] = copy.deepcopy(self.output_files_simulation["minimal_nonlinear"])
         
 
+    # Thin wrapper: capture preprocess_options and delegate to the generic run()
+    def run(self, *args, preprocess_options=None, **kwargs):
+        self._preprocess_options = preprocess_options
+        try:
+            return super().run(*args, **kwargs)
+        finally:
+            self._preprocess_options = None
+
     # Redefine to raise warning and allow selection of output files
     def _run_prepare(
         self,
@@ -171,7 +182,7 @@ class CGYRO(SIMtools.mitim_simulation, SIMplot.GKplotting):
         multipliers=None,
         **kwargs,
     ):
-        
+
         # ---------------------------------------------
         # Check if any *_SCALE_* variable is being used
         # ---------------------------------------------
@@ -183,13 +194,13 @@ class CGYRO(SIMtools.mitim_simulation, SIMplot.GKplotting):
                 dictionary_check = extraOptions
         elif multipliers is not None:
                 dictionary_check = multipliers
-        
+
         for key in dictionary_check:
             if '_SCALE_' in key:
                 print("The use of *_SCALE_* is discouraged, please use the appropriate variable instead.", typeMsg='q')
-            
+
         # ---------------------------------------------
-            
+
         # Check if it's linear
         if 'Nonlinear' not in kwargs.get('code_settings', ''):
             self.output_files_simulation["complete"] = copy.deepcopy(self.output_files_simulation["complete_linear"])
@@ -197,14 +208,88 @@ class CGYRO(SIMtools.mitim_simulation, SIMplot.GKplotting):
         else:
             self.output_files_simulation["complete"] = copy.deepcopy(self.output_files_simulation["complete_nonlinear"])
             self.output_files_simulation["minimal"] = copy.deepcopy(self.output_files_simulation["minimal_nonlinear"])
-            
-            
+
+        # Pre-process BOX_SIZE / N_RADIAL from local equilibrium if requested
+        if getattr(self, "_preprocess_options", None) is not None:
+            extraOptions = self._apply_cgyro_preprocessing(extraOptions or {})
+
         return super()._run_prepare(
             subfolder_simulation,
             extraOptions=extraOptions,
             multipliers=multipliers,
             **kwargs,
         )
+
+    def _apply_cgyro_preprocessing(self, extraOptions):
+        """
+        Compute BOX_SIZE and N_RADIAL per rho from the caller-provided
+        ky_min plus Q, S, RMIN from self.inputs_files[rho], and inject them
+        (along with KY=ky_min) into a copy of extraOptions as per-rho arrays.
+        """
+
+        allowed_keys = {'ky_min', 'L_x', 'N_radial', 'min_box_size'}
+        opts = dict(self._preprocess_options) if self._preprocess_options else {}
+        unknown = set(opts) - allowed_keys
+        if unknown:
+            raise ValueError(
+                f"[MITIM] Unknown preprocess_options keys: {sorted(unknown)}. "
+                f"Allowed: {sorted(allowed_keys)}"
+            )
+        ky_min_opt    = opts.get('ky_min', 0.1)
+        L_x           = opts.get('L_x', 90.0)
+        N_radial      = opts.get('N_radial', 256)
+        min_box_size  = opts.get('min_box_size', 100)
+
+        extraOptions = copy.deepcopy(extraOptions)
+
+        for conflict_key in ('KY', 'BOX_SIZE', 'N_RADIAL'):
+            if conflict_key in extraOptions:
+                print(
+                    f"\t- [preprocess] {conflict_key} was set in extraOptions; "
+                    f"it will be overwritten by the preprocessing result",
+                    typeMsg="w",
+                )
+
+        box_sizes = []
+        n_radials = []
+        ky_mins   = []
+
+        print("\t- [preprocess] Computing BOX_SIZE and N_RADIAL per rho:")
+        for i, rho in enumerate(self.rhos):
+            input_rho = self.inputs_files[rho]
+            q     = float(input_rho.plasma['Q'])
+            shear = float(input_rho.plasma['S'])
+            rmin  = float(input_rho.plasma['RMIN'])
+
+            if isinstance(ky_min_opt, (list, np.ndarray)):
+                ky_min = float(ky_min_opt[i])
+            else:
+                ky_min = float(ky_min_opt)
+
+            box_size, n_radial_val = CGYROutils.compute_box_and_nradial(
+                q=q,
+                shear=shear,
+                rmin=rmin,
+                ky_min=ky_min,
+                L_x=L_x,
+                N_radial=N_radial,
+                min_box_size=min_box_size,
+            )
+
+            print(
+                f"\t\t* rho={rho:.4f}: q={q:.3f} s={shear:.3f} r/a={rmin:.3f} "
+                f"KY={ky_min:.4f} -> BOX_SIZE={box_size} N_RADIAL={n_radial_val}",
+                typeMsg="i",
+            )
+
+            box_sizes.append(box_size)
+            n_radials.append(n_radial_val)
+            ky_mins.append(ky_min)
+
+        extraOptions['KY']       = ky_mins
+        extraOptions['BOX_SIZE'] = box_sizes
+        extraOptions['N_RADIAL'] = n_radials
+        return extraOptions
 
     # Re-defined to make specific arguments explicit
     def read(

--- a/src/mitim_tools/gacode_tools/CGYROtools.py
+++ b/src/mitim_tools/gacode_tools/CGYROtools.py
@@ -1,3 +1,4 @@
+import math
 from pathlib import Path
 import numpy as np
 import copy
@@ -19,46 +20,77 @@ class CGYRO(SIMtools.mitim_simulation, SIMplot.GKplotting):
 
         super().__init__(**kwargs)
 
-        def code_call(folder, p, n = 1, additional_command="", **kwargs):
-            
-            # machineSettings = CONFIGread.machineSettings(code='cgyro')
-            
-            # nomp = 32 if n>=32 else (16 if n>=16 else (8 if n>=8 else (4 if n>=4 else 2)))
-            # numa = machineSettings['cores_per_node'] // nomp if n >= machineSettings['cores_per_node'] else 1
-            # mpinuma = 1
+        def code_call(folder, p, n=1, additional_command="", **kwargs):
+            # `n` is cores_per_code_call (total cores for ONE radius), not MPI tasks.
+            # On GPU machines we translate it into CGYRO's -n/-nomp/-numa/-mpinuma
+            # layout (1 MPI task per GPU, 1 NUMA domain per GPU).
+            machineSettings = CONFIGread.machineSettings(code='cgyro')
+            cores_per_node = machineSettings.get('cores_per_node') or 1
+            gpus_per_node = machineSettings.get('gpus_per_node') or 0
+            cores_per_call = int(n)
 
-            # return f"cgyro -e {folder} -n {n} -nomp {nomp} -numa {numa} -mpinuma {mpinuma} -p {p} {additional_command}"
-        
-            nomp = 1
-            return f"cgyro -e {folder} -n {n} -nomp {nomp} -p {p} {additional_command}"
+            if gpus_per_node > 0:
+                nodes_per_call = max(1, math.ceil(cores_per_call / cores_per_node))
+                mpi_tasks = nodes_per_call * gpus_per_node
+                nomp = cores_per_node // gpus_per_node
+                numa = nodes_per_call * gpus_per_node
+                mpinuma = 1
+                return (f"cgyro -e {folder} -n {mpi_tasks} -nomp {nomp} "
+                        f"-numa {numa} -mpinuma {mpinuma} -p {p} {additional_command}")
+
+            return f"cgyro -e {folder} -n {cores_per_call} -nomp 1 -p {p} {additional_command}"
 
         def code_slurm_settings(name, minutes, total_cores_required, cores_per_code_call, type_of_submission, array_list=None, **kwargs_slurm):
 
             slurm_settings = {
                 "name": name,
                 "minutes": minutes,
-                'job_array_limit': None,    # Limit to this number at most running jobs at the same time?
+                'job_array_limit': None,
             }
 
-            # Gather if this is a GPU enabled machine
             machineSettings = CONFIGread.machineSettings(code='cgyro')
+            cores_per_node = machineSettings.get('cores_per_node') or 1
+            gpus_per_node = machineSettings.get('gpus_per_node') or 0
 
-            if type_of_submission == "slurm_standard":
-                
-                slurm_settings['ntasks'] = total_cores_required // cores_per_code_call
+            if gpus_per_node > 0:
+                if machineSettings.get('cores_per_node') is None:
+                    raise Exception("[MITIM] CGYRO GPU path requires 'cores_per_node' in machine config")
+                if cores_per_code_call % cores_per_node != 0:
+                    print(f"\t- CGYRO: cores_per_code_call={cores_per_code_call} not a multiple of "
+                          f"cores_per_node={cores_per_node}; rounding up to whole-node granularity",
+                          typeMsg="w")
 
-            elif type_of_submission == "slurm_array":
+                nodes_per_call = max(1, math.ceil(cores_per_code_call / cores_per_node))
+                mpi_tasks_per_call = nodes_per_call * gpus_per_node
+                omp_per_task = cores_per_node // gpus_per_node
 
-                slurm_settings['ntasks'] = 1
-                
-                slurm_settings['job_array'] = ",".join(array_list)
+                # On GPU machines all of these are PER ARRAY TASK when type_of_submission
+                # is slurm_array (SLURM does not multiply by the number of array tasks).
+                if type_of_submission == "slurm_standard":
+                    n_radii = max(1, total_cores_required // cores_per_code_call)
+                    slurm_settings['nodes'] = nodes_per_call * n_radii
+                    slurm_settings['ntasks'] = mpi_tasks_per_call * n_radii
+                elif type_of_submission == "slurm_array":
+                    slurm_settings['job_array'] = ",".join(array_list)
+                    slurm_settings['nodes'] = nodes_per_call
+                    slurm_settings['ntasks'] = mpi_tasks_per_call
 
-            # Each simulation call will use these resources (must match what the code_call requests)
-            if machineSettings['gpus_per_node'] > 0:
-                slurm_settings['gpuspertask'] = cores_per_code_call
-            slurm_settings['cpuspertask'] = cores_per_code_call 
+                slurm_settings['cpuspertask'] = omp_per_task
+                slurm_settings['gpuspernode'] = gpus_per_node
+
+            else:
+                if type_of_submission == "slurm_standard":
+                    slurm_settings['ntasks'] = total_cores_required // cores_per_code_call
+                elif type_of_submission == "slurm_array":
+                    slurm_settings['ntasks'] = 1
+                    slurm_settings['job_array'] = ",".join(array_list)
+                slurm_settings['cpuspertask'] = cores_per_code_call
 
             return slurm_settings
+
+        # On GPU machines, always use a job array so each radius gets its own full-node allocation.
+        _cgyro_machine_settings = CONFIGread.machineSettings(code='cgyro')
+        _force_submission_type = 'slurm_array' if (_cgyro_machine_settings.get('gpus_per_node') or 0) > 0 else None
 
         self.run_specifications = {
             'code': 'cgyro',
@@ -72,6 +104,7 @@ class CGYRO(SIMtools.mitim_simulation, SIMplot.GKplotting):
             'complete_variation': None,
             'default_cores': 16,  # Default cores to use in the simulation
             'output_class': CGYROutils.CGYROoutput,
+            'force_submission_type': _force_submission_type,
         }
         
         print("\n-----------------------------------------------------------------------------------------")

--- a/src/mitim_tools/gacode_tools/NEOtools.py
+++ b/src/mitim_tools/gacode_tools/NEOtools.py
@@ -544,7 +544,8 @@ class NEO(SIMtools.mitim_simulation):
         
         plt.tight_layout()
 
-    def run_vgen(self, subfolder="vgen1", vgenOptions={}, cold_start=False, rho_range=None, numcores=None, minutes=60):
+    def run_vgen(self, subfolder="vgen1", vgenOptions={}, cold_start=False, rho_range=None,
+                 numcores=None, minutes=60, smooth_profiles=False, relative_smoothing=0.005):
         """
         Submit profiles_gen -vgen to compute the neoclassical radial electric field (Er)
         and populate w0(rad/s) in the profiles.  Must be followed by read_vgen().
@@ -563,7 +564,17 @@ class NEO(SIMtools.mitim_simulation):
                             2 = NEO strong rotation limit
             nth         : Min,max theta resolutions (e.g. "17,39")
             matched_ion : Index of ion species to match NEO and given velocities (1-indexed)
+
+        smooth_profiles : bool
+            If True, smooth Te, Ti, ne, ni with a cubic spline before writing the
+            VGEN input so that piecewise-linear kinks in the gradients do not
+            pollute the computed Er.  The original self.profiles is never modified.
+        relative_smoothing : float
+            Passed to gacode_state.smooth_profiles(); target RMS deviation relative
+            to the peak profile value (default 0.02 = 2 %).
         """
+
+        import copy as _copy
 
         self.folder_vgen = self.FolderGACODE / f"{subfolder}"
 
@@ -595,13 +606,25 @@ class NEO(SIMtools.mitim_simulation):
                 IOtools.askNewFolder(self.folder_vgen, force=True)
 
         self.folder_vgen.mkdir(parents=True, exist_ok=True)
-        
-        # Potentially change the rho_range
+
+        # ---- Build the profiles object to write (never mutate self.profiles)
+        profiles_to_write = _copy.deepcopy(self.profiles)
+
+        if smooth_profiles:
+            print("\t- Smoothing kinetic profiles before VGEN run (smooth_profiles=True)", typeMsg="i")
+            # Save the original full-grid profiles so read_vgen() can show raw vs. smoothed
+            profiles_to_write.write_state(file=(self.folder_vgen / "input.gacode.raw"))
+            # Smooth on the full grid (before any rho_range truncation)
+            profiles_to_write.smooth_profiles(relative_smoothing=relative_smoothing)
+
+        # Truncate to rho_range AFTER smoothing so the spline sees the full profile
         if rho_range is not None:
-            rho_new = self.profiles.profiles['rho(-)'][np.argmin(np.abs(self.profiles.profiles['rho(-)'] - rho_range[0])):np.argmin(np.abs(self.profiles.profiles['rho(-)'] - rho_range[1]))+1]
-            self.profiles.changeResolution(rho_new=rho_new)
-        
-        self.profiles.write_state(file=(self.folder_vgen / "input.gacode"))
+            rho_arr = profiles_to_write.profiles["rho(-)"]
+            i0 = np.argmin(np.abs(rho_arr - rho_range[0]))
+            i1 = np.argmin(np.abs(rho_arr - rho_range[1]))
+            profiles_to_write.changeResolution(rho_new=rho_arr[i0:i1+1])
+
+        profiles_to_write.write_state(file=(self.folder_vgen / "input.gacode"))
 
         # ---- Resolve numcores from machine config (same pattern as SIMtools._run())
         if numcores is None:
@@ -653,6 +676,23 @@ class NEO(SIMtools.mitim_simulation):
         # ---- Updated gacode profiles (w0 now populated from NEO Er) ----
         from mitim_tools.gacode_tools import PROFILEStools
         self.profiles_vgen = PROFILEStools.gacode_state(file_gacode, derive_quantities=True)
+
+        # ---- Input profiles: raw vs. smoothed ----
+        # When smooth_profiles=True was used, run_vgen() saved the original (pre-smoothing)
+        # profiles as input.gacode.raw and the smoothed version as input.gacode (the one
+        # actually fed to VGEN).  When smoothing was not used, only input.gacode exists.
+        file_raw      = self.folder_vgen / "input.gacode.raw"
+        file_smoothed = self.folder_vgen / "input.gacode"   # always the file passed to VGEN
+
+        if file_raw.exists():
+            # Smoothing was used: raw = original, smoothed = what VGEN received
+            self.profiles          = PROFILEStools.gacode_state(file_raw,      derive_quantities=True)
+            self.profiles_smoothed = PROFILEStools.gacode_state(file_smoothed, derive_quantities=True)
+        else:
+            # No smoothing: only the raw input exists
+            if not hasattr(self, "profiles") or self.profiles is None:
+                self.profiles = PROFILEStools.gacode_state(file_smoothed, derive_quantities=True)
+            self.profiles_smoothed = None
 
         # ---- Er component decomposition (out.vgen.ercomp) ----
         # Columns (all in V/m):
@@ -728,11 +768,12 @@ class NEO(SIMtools.mitim_simulation):
 
     def plot_vgen(self, fn=None, fn_color=None, label="vgen", rho_min=0.1):
         """
-        Plot VGEN results: Er component decomposition, w0 and VEXB_SHEAR before/after.
+        Plot VGEN results: Er component decomposition, w0 and VEXB_SHEAR before/after,
+        and (when smoothing was used) a raw-vs-smoothed comparison per profile.
         Requires read_vgen() to have been called first.
 
         rho_min : float
-            Minimum rho to include in Er/velocity plots (default 0.1).
+            Minimum rho to include in plots (default 0.1).
             Near-axis values can diverge and obscure the physically relevant region.
         """
         apply_theme()
@@ -744,7 +785,14 @@ class NEO(SIMtools.mitim_simulation):
 
         colors = GRAPHICStools.listColors()
 
-        # ---- Tab 1: kinetic profiles + gradients (left) | Er decomposition (right) ----
+        raw      = self.profiles if (hasattr(self, "profiles") and self.profiles is not None) else None
+        smoothed = getattr(self, "profiles_smoothed", None)
+        # The profiles actually fed to VGEN: smoothed if available, else raw
+        src = smoothed if smoothed is not None else raw
+
+        # ------------------------------------------------------------------
+        # Tab 1: kinetic profiles (left, smoothed = actually used) + Er components (right)
+        # ------------------------------------------------------------------
         fig1 = self.fn.add_figure(label=f"{label} Er components", tab_color=fn_color)
         grid1 = plt.GridSpec(2, 5, hspace=0.55, wspace=0.45, width_ratios=[1, 1, 1, 1, 1])
 
@@ -757,66 +805,61 @@ class NEO(SIMtools.mitim_simulation):
         ax_vtor = fig1.add_subplot(grid1[1, 1])
         ax_dia  = fig1.add_subplot(grid1[1, 2])
 
-        # ---- Kinetic profiles (top-left) and gradients (bottom-left) ----
-        src = self.profiles_vgen if (hasattr(self, "profiles_vgen") and self.profiles_vgen is not None) else None
+        # Kinetic profiles: show the ones actually used by VGEN (smoothed if available, else raw)
         if src is not None:
             rho_s = src.profiles.get("rho(-)", None)
             if rho_s is not None:
-                ms = rho_s >= rho_min
+                mp = rho_s >= rho_min
 
-                Te     = src.profiles.get("te(keV)", None)
-                ne     = src.profiles.get("ne(10^19/m^3)", None)
+                Te_s   = src.profiles.get("te(keV)", None)
                 Ti_all = src.profiles.get("ti(keV)", None)
-                Ti     = Ti_all[:, 0] if Ti_all is not None and Ti_all.ndim == 2 else Ti_all
+                Ti_s   = Ti_all[:, 0] if Ti_all is not None and Ti_all.ndim == 2 else Ti_all
+                ne_s   = src.profiles.get("ne(10^19/m^3)", None)
+                aLTe_s = src.derived.get("aLTe", None)
+                aLTi_a = src.derived.get("aLTi", None)
+                aLTi_s = aLTi_a[:, 0] if aLTi_a is not None and np.ndim(aLTi_a) == 2 else aLTi_a
+                aLne_s = src.derived.get("aLne", None)
 
                 ax_ne = ax_prof.twinx()
-                if Te is not None:
-                    ax_prof.plot(rho_s[ms], Te[ms], color=colors[0], lw=1.8, label="$T_e$")
-                if Ti is not None:
-                    ax_prof.plot(rho_s[ms], Ti[ms], color=colors[1], lw=1.8, ls="--", label="$T_i$")
-                if ne is not None:
-                    ax_ne.plot(rho_s[ms], ne[ms], color=colors[2], lw=1.5, ls=":", label="$n_e$")
+                if Te_s   is not None: ax_prof.plot(rho_s[mp], Te_s[mp],   color=colors[0], lw=1.8, label="$T_e$")
+                if Ti_s   is not None: ax_prof.plot(rho_s[mp], Ti_s[mp],   color=colors[1], lw=1.8, label="$T_i$")
+                if ne_s   is not None: ax_ne.plot(  rho_s[mp], ne_s[mp],   color=colors[2], lw=1.8, label="$n_e$")
+                if aLTe_s is not None: ax_grad.plot(rho_s[mp], aLTe_s[mp], color=colors[0], lw=1.8, label="$a/L_{T_e}$")
+                if aLTi_s is not None: ax_grad.plot(rho_s[mp], aLTi_s[mp], color=colors[1], lw=1.8, label="$a/L_{T_i}$")
+                if aLne_s is not None: ax_grad.plot(rho_s[mp], aLne_s[mp], color=colors[2], lw=1.8, label="$a/L_{n_e}$")
+
                 ax_prof.set_xlabel(r"$\rho_{tor}$"); ax_prof.set_xlim(left=rho_min)
                 ax_prof.set_ylabel("Temperature (keV)")
                 ax_ne.set_ylabel("$n_e$ ($10^{19}\\,m^{-3}$)", color=colors[2])
-                ax_prof.set_title("Kinetic profiles")
+                prof_title = "Profiles (smoothed)" if smoothed is not None else "Profiles"
+                ax_prof.set_title(prof_title)
                 lines_T, labs_T = ax_prof.get_legend_handles_labels()
                 lines_n, labs_n = ax_ne.get_legend_handles_labels()
                 ax_prof.legend(lines_T + lines_n, labs_T + labs_n, loc="best", fontsize=7)
 
-                aLTe     = src.derived.get("aLTe", None)
-                aLTi_all = src.derived.get("aLTi", None)
-                aLTi     = aLTi_all[:, 0] if aLTi_all is not None and np.ndim(aLTi_all) == 2 else aLTi_all
-                aLne     = src.derived.get("aLne", None)
-                if aLTe is not None:
-                    ax_grad.plot(rho_s[ms], aLTe[ms], color=colors[0], lw=1.8, label="$a/L_{T_e}$")
-                if aLTi is not None:
-                    ax_grad.plot(rho_s[ms], aLTi[ms], color=colors[1], lw=1.8, ls="--", label="$a/L_{T_i}$")
-                if aLne is not None:
-                    ax_grad.plot(rho_s[ms], aLne[ms], color=colors[2], lw=1.5, ls=":", label="$a/L_{n_e}$")
                 ax_grad.set_xlabel(r"$\rho_{tor}$"); ax_grad.set_xlim(left=rho_min)
-                ax_grad.set_ylabel("$a/L$"); ax_grad.set_title("Norm. gradients")
+                ax_grad.set_ylabel("$a/L$")
+                ax_grad.set_title("Norm. gradients" + (" (smoothed)" if smoothed is not None else ""))
                 ax_grad.axhline(0, color="k", lw=0.7, ls="--")
                 ax_grad.legend(loc="best", fontsize=7)
 
-        # ---- Er components (right columns) ----
         if self.vgen_ercomp:
-            rho = self.vgen_ercomp["rho"]
+            rho  = self.vgen_ercomp["rho"]
             mask = rho >= rho_min
 
-            ax_Er.plot(rho[mask],   self.vgen_ercomp["Er_total"][mask],      color=colors[0], lw=1.8, label="$E_r$ total")
+            ax_Er.plot(rho[mask],   self.vgen_ercomp["Er_total"][mask],       color=colors[0], lw=1.8, label="$E_r$ total")
             ax_Er.plot(rho[mask],   self.vgen_ercomp.get("Er_total2", rho*0)[mask], color=colors[1], lw=1.2, ls="--", label="$E_r$ total (alt)")
-            ax_db.plot(rho[mask],   self.vgen_ercomp["Er_db"][mask],         color=colors[2], lw=1.8, label="diamagnetic")
-            ax_vpol.plot(rho[mask], self.vgen_ercomp["Er_vpol_total"][mask], color=colors[3], lw=1.8, label="pol. flow (total)")
-            ax_vpol.plot(rho[mask], self.vgen_ercomp["Er_vpol_neo"][mask],   color=colors[4], lw=1.2, ls="--", label="pol. flow (NEO)")
-            ax_vtor.plot(rho[mask], self.vgen_ercomp["Er_vtor"][mask],       color=colors[5], lw=1.8, label="toroidal rot.")
-            ax_dia.plot(rho[mask],  self.vgen_ercomp["Er_dia_total"][mask],  color=colors[6], lw=1.8, label="dia. total")
-            ax_dia.plot(rho[mask],  self.vgen_ercomp["Er_dia_neo"][mask],    color=colors[7], lw=1.2, ls="--", label="dia. NEO")
+            ax_db.plot(rho[mask],   self.vgen_ercomp["Er_db"][mask],          color=colors[2], lw=1.8, label="diamagnetic")
+            ax_vpol.plot(rho[mask], self.vgen_ercomp["Er_vpol_total"][mask],  color=colors[3], lw=1.8, label="pol. flow (total)")
+            ax_vpol.plot(rho[mask], self.vgen_ercomp["Er_vpol_neo"][mask],    color=colors[4], lw=1.2, ls="--", label="pol. flow (NEO)")
+            ax_vtor.plot(rho[mask], self.vgen_ercomp["Er_vtor"][mask],        color=colors[5], lw=1.8, label="toroidal rot.")
+            ax_dia.plot(rho[mask],  self.vgen_ercomp["Er_dia_total"][mask],   color=colors[6], lw=1.8, label="dia. total")
+            ax_dia.plot(rho[mask],  self.vgen_ercomp["Er_dia_neo"][mask],     color=colors[7], lw=1.2, ls="--", label="dia. NEO")
             for key, lbl, c in [
-                ("Er_total",      "$E_r$ total",   colors[0]),
-                ("Er_db",         "diamagnetic",    colors[2]),
-                ("Er_vpol_total", "pol. flow",      colors[3]),
-                ("Er_dia_total",  "dia. total",     colors[6]),
+                ("Er_total",      "$E_r$ total",  colors[0]),
+                ("Er_db",         "diamagnetic",   colors[2]),
+                ("Er_vpol_total", "pol. flow",     colors[3]),
+                ("Er_dia_total",  "dia. total",    colors[6]),
             ]:
                 if key in self.vgen_ercomp:
                     ax_all.plot(rho[mask], self.vgen_ercomp[key][mask], color=c, lw=1.5, label=lbl)
@@ -834,40 +877,37 @@ class NEO(SIMtools.mitim_simulation):
         ax_dia.set_title("Diamagnetic correction")
         ax_all.set_title("All components")
 
-        # ---- Tab 2: w0 and VEXB_SHEAR before/after ----
+        # ------------------------------------------------------------------
+        # Tab 2: w0 and VEXB_SHEAR before/after VGEN
+        # ------------------------------------------------------------------
         fig2 = self.fn.add_figure(label=f"{label} w0 & VEXB", tab_color=fn_color)
         grid2 = plt.GridSpec(1, 3, hspace=0.4, wspace=0.35)
-        ax_w0     = fig2.add_subplot(grid2[0, 0])
-        ax_vexb   = fig2.add_subplot(grid2[0, 1])
-        ax_mach   = fig2.add_subplot(grid2[0, 2])
+        ax_w0   = fig2.add_subplot(grid2[0, 0])
+        ax_vexb = fig2.add_subplot(grid2[0, 1])
+        ax_mach = fig2.add_subplot(grid2[0, 2])
 
-        # Before VGEN: from original profiles
-        if hasattr(self, "profiles") and self.profiles is not None:
-            rho_orig = self.profiles.profiles.get("rho(-)", None)
-            w0_orig  = self.profiles.profiles.get("w0(rad/s)", None)
+        if raw is not None:
+            rho_orig = raw.profiles.get("rho(-)", None)
+            w0_orig  = raw.profiles.get("w0(rad/s)", None)
             if rho_orig is not None and w0_orig is not None:
                 m = rho_orig >= rho_min
                 ax_w0.plot(rho_orig[m], w0_orig[m], color=colors[1], lw=1.5, ls="--", label="before VGEN")
-
-            vexb_orig = _compute_vexb_shear(self.profiles)
-            if vexb_orig is not None:
+            vexb_orig = _compute_vexb_shear(raw)
+            if vexb_orig is not None and rho_orig is not None:
                 m = rho_orig >= rho_min
                 ax_vexb.plot(rho_orig[m], vexb_orig[m], color=colors[1], lw=1.5, ls="--", label="before VGEN")
 
-        # After VGEN: from profiles_vgen
         if hasattr(self, "profiles_vgen") and self.profiles_vgen is not None:
-            rho_new  = self.profiles_vgen.profiles.get("rho(-)", None)
-            w0_new   = self.profiles_vgen.profiles.get("w0(rad/s)", None)
+            rho_new = self.profiles_vgen.profiles.get("rho(-)", None)
+            w0_new  = self.profiles_vgen.profiles.get("w0(rad/s)", None)
             if rho_new is not None and w0_new is not None:
                 m = rho_new >= rho_min
                 ax_w0.plot(rho_new[m], w0_new[m], color=colors[0], lw=1.8, label="after VGEN (NEO)")
-
             vexb_new = _compute_vexb_shear(self.profiles_vgen)
-            if vexb_new is not None:
+            if vexb_new is not None and rho_new is not None:
                 m = rho_new >= rho_min
                 ax_vexb.plot(rho_new[m], vexb_new[m], color=colors[0], lw=1.8, label="after VGEN (NEO)")
 
-        # Mach number from vel file
         if self.vgen_vel and "rho" in self.vgen_vel and "Mach_neo" in self.vgen_vel:
             rho_v = self.vgen_vel["rho"]
             m = rho_v >= rho_min
@@ -878,9 +918,71 @@ class NEO(SIMtools.mitim_simulation):
             ax.set_xlim(left=rho_min)
             ax.axhline(0, color="k", lw=0.7, ls="--")
             ax.legend(loc="best", fontsize=7)
-        ax_w0.set_ylabel("$\\omega_0$ (rad/s)"); ax_w0.set_title("Toroidal rotation $\\omega_0$")
-        ax_vexb.set_ylabel("$\\gamma_{E}$ (norm.)"); ax_vexb.set_title("E×B shearing rate (VEXB_SHEAR)")
-        ax_mach.set_ylabel("Mach number"); ax_mach.set_title("NEO Mach number")
+        ax_w0.set_ylabel("$\\omega_0$ (rad/s)");      ax_w0.set_title("Toroidal rotation $\\omega_0$")
+        ax_vexb.set_ylabel("$\\gamma_{E}$ (norm.)");  ax_vexb.set_title("E×B shearing rate (VEXB_SHEAR)")
+        ax_mach.set_ylabel("Mach number");             ax_mach.set_title("NEO Mach number")
+
+        # ------------------------------------------------------------------
+        # Tab 3: Raw vs. smoothed profiles comparison (only when smoothing was used)
+        # ------------------------------------------------------------------
+        if raw is not None and smoothed is not None:
+            fig3 = self.fn.add_figure(label=f"{label} smoothing", tab_color=fn_color)
+            grid3 = plt.GridSpec(2, 3, hspace=0.5, wspace=0.4)
+
+            ax_Te  = fig3.add_subplot(grid3[0, 0])
+            ax_Ti  = fig3.add_subplot(grid3[0, 1])
+            ax_ne  = fig3.add_subplot(grid3[0, 2])
+            ax_aLTe = fig3.add_subplot(grid3[1, 0])
+            ax_aLTi = fig3.add_subplot(grid3[1, 1])
+            ax_aLne = fig3.add_subplot(grid3[1, 2])
+
+            def _get(p, key):
+                v = p.profiles.get(key, None)
+                if v is None:
+                    v = p.derived.get(key, None)
+                return v
+
+            def _col0(arr):
+                if arr is None:
+                    return None
+                return arr[:, 0] if np.ndim(arr) == 2 else arr
+
+            for p, lw, ls, lbl in [(raw, 1.2, "--", "raw"), (smoothed, 1.8, "-", "smoothed")]:
+                rho_p = _get(p, "rho(-)")
+                if rho_p is None:
+                    continue
+                mp = rho_p >= rho_min
+
+                Te_p   = _col0(_get(p, "te(keV)"))
+                Ti_p   = _col0(_get(p, "ti(keV)"))
+                ne_p   = _col0(_get(p, "ne(10^19/m^3)"))
+                aLTe_p = _col0(_get(p, "aLTe"))
+                aLTi_p = _col0(_get(p, "aLTi"))
+                aLne_p = _col0(_get(p, "aLne"))
+
+                c_map = {"raw": colors[1], "smoothed": colors[0]}
+                c = c_map[lbl]
+
+                if Te_p   is not None: ax_Te.plot(rho_p[mp],   Te_p[mp],   color=c, lw=lw, ls=ls, label=lbl)
+                if Ti_p   is not None: ax_Ti.plot(rho_p[mp],   Ti_p[mp],   color=c, lw=lw, ls=ls, label=lbl)
+                if ne_p   is not None: ax_ne.plot(rho_p[mp],   ne_p[mp],   color=c, lw=lw, ls=ls, label=lbl)
+                if aLTe_p is not None: ax_aLTe.plot(rho_p[mp], aLTe_p[mp], color=c, lw=lw, ls=ls, label=lbl)
+                if aLTi_p is not None: ax_aLTi.plot(rho_p[mp], aLTi_p[mp], color=c, lw=lw, ls=ls, label=lbl)
+                if aLne_p is not None: ax_aLne.plot(rho_p[mp], aLne_p[mp], color=c, lw=lw, ls=ls, label=lbl)
+
+            ax_Te.set_title("$T_e$");           ax_Te.set_ylabel("keV")
+            ax_Ti.set_title("$T_i$");           ax_Ti.set_ylabel("keV")
+            ax_ne.set_title("$n_e$");           ax_ne.set_ylabel("$10^{19}\\,m^{-3}$")
+            ax_aLTe.set_title("$a/L_{T_e}$");  ax_aLTe.set_ylabel("$a/L$")
+            ax_aLTi.set_title("$a/L_{T_i}$");  ax_aLTi.set_ylabel("$a/L$")
+            ax_aLne.set_title("$a/L_{n_e}$");  ax_aLne.set_ylabel("$a/L$")
+
+            for ax in [ax_Te, ax_Ti, ax_ne, ax_aLTe, ax_aLTi, ax_aLne]:
+                ax.set_xlabel(r"$\rho_{tor}$")
+                ax.set_xlim(left=rho_min)
+                ax.legend(loc="best", fontsize=7)
+            for ax in [ax_aLTe, ax_aLTi, ax_aLne]:
+                ax.axhline(0, color="k", lw=0.7, ls="--")
 
 
 

--- a/src/mitim_tools/gacode_tools/NEOtools.py
+++ b/src/mitim_tools/gacode_tools/NEOtools.py
@@ -1,29 +1,37 @@
-import copy
 import os
-from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 from mitim_tools.misc_tools import GRAPHICStools, IOtools, GUItools, FARMINGtools
-from mitim_tools.gacode_tools.utils import GACODErun, GACODEdefaults, NORMtools
+from mitim_tools.gacode_tools.utils import GACODErun, GACODEdefaults, GACODEinprocess
 from mitim_tools.simulation_tools import SIMtools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools.misc_tools.style_tools.themes import apply_theme
 from mitim_tools import __mitimroot__
 from IPython import embed
 
-class NEO(SIMtools.mitim_simulation):
+class NEO(SIMtools.mitim_simulation, GACODEinprocess.NEOInProcess):
+    """
+    NEO wrapper.  Uses multiple inheritance to combine two engines:
+
+    * ``SIMtools.mitim_simulation`` — the standard subprocess / SLURM engine
+      (the file-based ``prep`` / ``_run_prepare`` / ``_run`` / ``read``).
+    * ``GACODEinprocess.NEOInProcess`` — the pure in-process (ctypes)
+      mixin providing ``prep_inprocess`` / ``_run_prepare_inprocess`` /
+      ``_run_inprocess`` / ``read_inprocess``.
+
+    The four small dispatch methods below decide between the two engines
+    based on the ``self.in_process`` flag set at construction time.
+    """
     def __init__(
         self,
         rhos=[0.4, 0.6],   # rho locations of interest
         in_process=False,  # If True, run NEO in-process via ctypes (no subprocess); requires libneo_serial.so
     ):
 
-        super().__init__(rhos=rhos)
+        SIMtools.mitim_simulation.__init__(self, rhos=rhos)
         self.in_process = in_process
-
-        # Cache of in-process results, keyed by str(folder_sim).
-        # Each entry: {"raw": {rho: outputs_dict}, "inputs": {rho: NEOinput}}
-        self._inprocess_cache: dict = {}
+        # In-process result cache (lazy-init via mixin); harmless when not used.
+        self._init_inprocess()
 
         def code_call(folder, n, p, additional_command="", **kwargs):
             return f"neo -e {folder} -n {n} -p {p} {additional_command}"
@@ -86,257 +94,36 @@ class NEO(SIMtools.mitim_simulation):
         ]
 
     # ------------------------------------------------------------------
-    # In-process overrides — mirror TGLFtools.TGLF in_process plumbing.
-    # When self.in_process=False, every method below delegates to the
-    # parent (mitim_simulation), so the standard subprocess workflow is
-    # untouched.  When self.in_process=True, NEO is executed entirely
-    # in-memory via libneo_serial.so (no folders, no input.neo files,
-    # no out.neo.* files written).
+    # In-process / subprocess dispatch.  Each method picks the engine
+    # based on self.in_process and forwards to either:
+    #   * GACODEinprocess.NEOInProcess.<method>_inprocess  (in-process)
+    #   * SIMtools.mitim_simulation.<method> via super()    (subprocess)
+    # The actual physics/IO logic lives in those two parents — these
+    # dispatchers are intentionally tiny.
     # ------------------------------------------------------------------
 
     def prep(self, mitim_state, FolderGACODE=None, **kwargs):
-        """
-        Prepare the NEO run from a MITIM state (input.gacode path or object).
+        if self.in_process:
+            # In-process needs no folder — anything passed for FolderGACODE
+            # is silently ignored, and a synthetic in-memory path is used
+            # internally for cache keys.
+            return self.prep_inprocess(mitim_state)
+        return super().prep(mitim_state, FolderGACODE, **kwargs)
 
-        When ``self.in_process=True``, *FolderGACODE* is optional.  If omitted
-        a temporary directory is used as a logical base path — nothing is
-        ever written to it.  No ``input.neo*`` or ``input.gacode_torun``
-        files are created.
+    def _run_prepare(self, subfolder_simulation, **kwargs):
+        if self.in_process:
+            return self._run_prepare_inprocess(subfolder_simulation, **kwargs)
+        return super()._run_prepare(subfolder_simulation, **kwargs)
 
-        When ``self.in_process=False`` the behaviour is identical to the
-        parent: *FolderGACODE* is required and all files are written normally.
-        """
-        if not self.in_process:
-            return super().prep(mitim_state, FolderGACODE, **kwargs)
+    def _run(self, code_executor, **kwargs):
+        if self.in_process:
+            return self._run_inprocess(code_executor, **kwargs)
+        return super()._run(code_executor, **kwargs)
 
-        # ------------------------------------------------------------------
-        # Zero-file in-process prep
-        # ------------------------------------------------------------------
-        import tempfile
-        from mitim_tools.gacode_tools import PROFILEStools
-        from mitim_tools.misc_tools.PLASMAtools import md_u
-
-        if FolderGACODE is None:
-            self.FolderGACODE = Path(tempfile.mkdtemp(prefix="neo_inprocess_"))
-        else:
-            self.FolderGACODE = Path(FolderGACODE).resolve()
-
-        # Load profiles
-        if isinstance(mitim_state, (str, Path)):
-            self.profiles = PROFILEStools.gacode_state(str(mitim_state))
-        else:
-            self.profiles = mitim_state
-
-        self.profiles.derive_quantities(mi_ref=md_u)
-
-        # Build NEOinput objects in memory — no files written
-        raw = self.profiles.to_neo(r=self.rhos, r_is_rho=True)
-        self.inputs_files = {}
-        for rho, d in raw.items():
-            inp = NEOinput.initialize_in_memory(d)
-            # Set a logical (never-created) file path so any later code
-            # that inspects inp.file does not hit AttributeError.
-            inp.file = self.FolderGACODE / f"input.neo_{float(rho):.4f}"
-            self.inputs_files[rho] = inp
-
-        # Normalizations (pure in-memory)
-        print("> Setting up normalizations")
-        self.NormalizationSets, cdf = NORMtools.normalizations(self.profiles)
-        return cdf
-
-    def _run_prepare(self, subfolder_simulation, code_executor=None, code_executor_full=None,
-                     code_settings=None, extraOptions={}, multipliers={}, minimum_delta_abs={},
-                     cold_start=False, forceIfcold_start=False, only_minimal_files=False,
-                     launchSlurm=True, slurm_setup=None, additional_files_to_send=None,
-                     **kwargs_control):
-        """
-        When ``self.in_process=True``: build NEOinput objects in memory via
-        ``modifyInputs()`` — no folder creation, no file writes.
-        When ``self.in_process=False``: delegate to the parent implementation.
-        """
-        if not self.in_process:
-            return super()._run_prepare(
-                subfolder_simulation,
-                code_executor=code_executor,
-                code_executor_full=code_executor_full,
-                code_settings=code_settings,
-                extraOptions=extraOptions,
-                multipliers=multipliers,
-                minimum_delta_abs=minimum_delta_abs,
-                cold_start=cold_start,
-                forceIfcold_start=forceIfcold_start,
-                only_minimal_files=only_minimal_files,
-                launchSlurm=launchSlurm,
-                slurm_setup=slurm_setup,
-                additional_files_to_send=additional_files_to_send,
-                **kwargs_control,
-            )
-
-        # ------------------------------------------------------------------
-        # Zero-file in-process path
-        # ------------------------------------------------------------------
-        from mitim_tools.simulation_tools.SIMtools import modifyInputs
-
-        if code_executor is None:
-            code_executor = {}
-        if code_executor_full is None:
-            code_executor_full = {}
-
-        # Compute the logical folder path (never created on disk)
-        Folder_sim = (self.FolderGACODE / subfolder_simulation).resolve()
-
-        inputs = copy.deepcopy(self.inputs_files)
-
-        mod_input_file = {}
-        for i, rho in enumerate(self.rhos):
-            print(f"\t- [in-process] Preparing input for rho={rho:.4f}")
-            input_sim_rho = modifyInputs(
-                inputs[rho],
-                code_settings=code_settings,
-                extraOptions=extraOptions,
-                multipliers=multipliers,
-                minimum_delta_abs=minimum_delta_abs if minimum_delta_abs else {},
-                position_change=i,
-                addControlFunction=self.run_specifications["control_function"],
-                controls_file=self.run_specifications["controls_file"],
-                NS=inputs[rho].num_recorded,
-            )
-            input_sim_rho.anticipate_problems()
-            mod_input_file[rho] = input_sim_rho
-
-        code_executor_full[subfolder_simulation] = {}
-        code_executor[subfolder_simulation] = {}
-        for irho in self.rhos:
-            entry = {
-                "folder":     Folder_sim,
-                "dictionary": mod_input_file[irho],
-                "inputs":     None,
-                "extraOptions": extraOptions,
-                "multipliers":  multipliers,
-                "additional_files_to_send": None,
-            }
-            code_executor_full[subfolder_simulation][irho] = entry
-            code_executor[subfolder_simulation][irho]      = entry
-
-        self.FolderSimLast = Folder_sim
-        return code_executor, code_executor_full
-
-    def _run(self, code_executor, run_type='normal', **kwargs_run):
-        """
-        Dispatch to in-process ctypes engine or parent subprocess/SLURM engine.
-
-        When ``self.in_process=True`` the Fortran physics is called directly
-        via ctypes for every (subfolder, rho) in *code_executor* — no file
-        I/O.  Results are stored in ``self._inprocess_cache[str(folder_sim)]``.
-        """
-        if not self.in_process:
-            return super()._run(code_executor, run_type=run_type, **kwargs_run)
-
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-        from mitim_tools.simulation_tools.interfaces import neo_inprocess as _nip
-
-        # Build work items — one per (subfolder_variation, rho)
-        work_items = []   # (subfolder_sim, rho, flat, neo_input, folder_sim)
-        for subfolder_sim, rho_dict in code_executor.items():
-            for rho, rho_info in rho_dict.items():
-                folder_sim = rho_info["folder"]
-                neo_input  = rho_info["dictionary"]
-                # NEO species fields (Z_1, MASS_1, ...) live in plasma
-                # because NEOinput.process inherits the base implementation
-                # which doesn't split them out into a species dict.
-                flat = {}
-                flat.update(neo_input.controls)
-                flat.update(neo_input.plasma)
-                work_items.append((subfolder_sim, rho, flat, neo_input, folder_sim))
-
-        n_workers = os.cpu_count() or 1
-        n_jobs    = len(work_items)
-        if n_jobs == 0:
-            self.simulation_job = None
-            return
-        print(f"\t- [in-process] Submitting {n_jobs} NEO cases across {min(n_workers, n_jobs)} workers")
-
-        results_by_folder: dict = {}
-
-        # Threads, not processes — see tglf_inprocess.py for the rationale:
-        # each thread loads its own private copy of the .so so Fortran
-        # module-level globals are independent, and ctypes releases the GIL
-        # during the Fortran call so we get true parallelism.
-        with ThreadPoolExecutor(max_workers=min(n_workers, n_jobs)) as pool:
-            future_map = {
-                pool.submit(_nip._parallel_worker, flat): (subfolder_sim, rho, neo_input, folder_sim)
-                for subfolder_sim, rho, flat, neo_input, folder_sim in work_items
-            }
-            for future in as_completed(future_map):
-                subfolder_sim, rho, neo_input, folder_sim = future_map[future]
-                outputs = future.result()
-                key = str(folder_sim)
-                if key not in results_by_folder:
-                    results_by_folder[key] = {"raw": {}, "inputs": {}}
-                results_by_folder[key]["raw"][float(rho)]    = outputs
-                results_by_folder[key]["inputs"][float(rho)] = neo_input
-                if outputs.get("error_status", 0) != 0:
-                    print(f"\t- [in-process] rho={rho:.4f}  WARNING error_status={outputs['error_status']}",
-                          typeMsg="w")
-
-        self._inprocess_cache.update(results_by_folder)
-        self.simulation_job = None   # keep attribute consistent with parent
-
-    def read(self, label="run1", folder=None, suffix=None, input_gacode=None,
-             require_all_files=True, **kwargs_to_class_output):
-        """
-        Build NEO results from the in-process cache when ``self.in_process``
-        is True; otherwise delegate to the parent file-reading path.
-        """
-        if not self.in_process:
-            return super().read(
-                label=label,
-                folder=folder,
-                suffix=suffix,
-                input_gacode=input_gacode,
-                require_all_files=require_all_files,
-                **kwargs_to_class_output,
-            )
-
-        subfolder = folder if folder is not None else self.FolderSimLast
-        cache_key = str(subfolder)
-        if cache_key not in self._inprocess_cache:
-            raise RuntimeError(
-                f"No in-process NEO results cached for key '{cache_key}'. "
-                "Call run() first."
-            )
-        cached    = self._inprocess_cache[cache_key]
-        raw       = cached["raw"]      # {rho: outputs_dict}
-        inp_files = cached["inputs"]   # {rho: NEOinput}
-
-        output_list = []
-        parsed_list = []
-        for rho in self.rhos:
-            inputclass = inp_files.get(rho) or inp_files.get(float(rho))
-            outputs    = raw.get(rho)    or raw.get(float(rho))
-            out = NEOoutput.from_inprocess(inputclass, outputs)
-
-            if 'NormalizationSets' in self.__dict__:
-                out.unnormalize(self.NormalizationSets["SELECTED"], rho=rho)
-
-            output_list.append(out)
-
-            # Build a flat parsed dict so read_scan() can find scan variables
-            if inputclass is not None:
-                flat_parsed = {}
-                flat_parsed.update(inputclass.controls)
-                flat_parsed.update(inputclass.plasma)
-            else:
-                flat_parsed = {}
-            parsed_list.append(flat_parsed)
-
-        self.results[label] = {
-            "output": output_list,
-            "parsed": parsed_list,
-            "x":      np.array(self.rhos),
-        }
-        print(f"\t- [in-process] Read NEO results for label '{label}' "
-              f"({len(self.rhos)} rho values)")
+    def read(self, label="run1", folder=None, **kwargs):
+        if self.in_process:
+            return self.read_inprocess(label=label, folder=folder)
+        return super().read(label=label, folder=folder, **kwargs)
 
     def plot(
         self,

--- a/src/mitim_tools/gacode_tools/NEOtools.py
+++ b/src/mitim_tools/gacode_tools/NEOtools.py
@@ -1,8 +1,10 @@
+import copy
 import os
+from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 from mitim_tools.misc_tools import GRAPHICStools, IOtools, GUItools, FARMINGtools
-from mitim_tools.gacode_tools.utils import GACODErun, GACODEdefaults
+from mitim_tools.gacode_tools.utils import GACODErun, GACODEdefaults, NORMtools
 from mitim_tools.simulation_tools import SIMtools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools.misc_tools.style_tools.themes import apply_theme
@@ -12,10 +14,16 @@ from IPython import embed
 class NEO(SIMtools.mitim_simulation):
     def __init__(
         self,
-        rhos=[0.4, 0.6],  # rho locations of interest
+        rhos=[0.4, 0.6],   # rho locations of interest
+        in_process=False,  # If True, run NEO in-process via ctypes (no subprocess); requires libneo_serial.so
     ):
-        
+
         super().__init__(rhos=rhos)
+        self.in_process = in_process
+
+        # Cache of in-process results, keyed by str(folder_sim).
+        # Each entry: {"raw": {rho: outputs_dict}, "inputs": {rho: NEOinput}}
+        self._inprocess_cache: dict = {}
 
         def code_call(folder, n, p, additional_command="", **kwargs):
             return f"neo -e {folder} -n {n} -p {p} {additional_command}"
@@ -76,7 +84,260 @@ class NEO(SIMtools.mitim_simulation):
             'out.neo.run',
             'out.neo.version',
         ]
-        
+
+    # ------------------------------------------------------------------
+    # In-process overrides — mirror TGLFtools.TGLF in_process plumbing.
+    # When self.in_process=False, every method below delegates to the
+    # parent (mitim_simulation), so the standard subprocess workflow is
+    # untouched.  When self.in_process=True, NEO is executed entirely
+    # in-memory via libneo_serial.so (no folders, no input.neo files,
+    # no out.neo.* files written).
+    # ------------------------------------------------------------------
+
+    def prep(self, mitim_state, FolderGACODE=None, **kwargs):
+        """
+        Prepare the NEO run from a MITIM state (input.gacode path or object).
+
+        When ``self.in_process=True``, *FolderGACODE* is optional.  If omitted
+        a temporary directory is used as a logical base path — nothing is
+        ever written to it.  No ``input.neo*`` or ``input.gacode_torun``
+        files are created.
+
+        When ``self.in_process=False`` the behaviour is identical to the
+        parent: *FolderGACODE* is required and all files are written normally.
+        """
+        if not self.in_process:
+            return super().prep(mitim_state, FolderGACODE, **kwargs)
+
+        # ------------------------------------------------------------------
+        # Zero-file in-process prep
+        # ------------------------------------------------------------------
+        import tempfile
+        from mitim_tools.gacode_tools import PROFILEStools
+        from mitim_tools.misc_tools.PLASMAtools import md_u
+
+        if FolderGACODE is None:
+            self.FolderGACODE = Path(tempfile.mkdtemp(prefix="neo_inprocess_"))
+        else:
+            self.FolderGACODE = Path(FolderGACODE).resolve()
+
+        # Load profiles
+        if isinstance(mitim_state, (str, Path)):
+            self.profiles = PROFILEStools.gacode_state(str(mitim_state))
+        else:
+            self.profiles = mitim_state
+
+        self.profiles.derive_quantities(mi_ref=md_u)
+
+        # Build NEOinput objects in memory — no files written
+        raw = self.profiles.to_neo(r=self.rhos, r_is_rho=True)
+        self.inputs_files = {}
+        for rho, d in raw.items():
+            inp = NEOinput.initialize_in_memory(d)
+            # Set a logical (never-created) file path so any later code
+            # that inspects inp.file does not hit AttributeError.
+            inp.file = self.FolderGACODE / f"input.neo_{float(rho):.4f}"
+            self.inputs_files[rho] = inp
+
+        # Normalizations (pure in-memory)
+        print("> Setting up normalizations")
+        self.NormalizationSets, cdf = NORMtools.normalizations(self.profiles)
+        return cdf
+
+    def _run_prepare(self, subfolder_simulation, code_executor=None, code_executor_full=None,
+                     code_settings=None, extraOptions={}, multipliers={}, minimum_delta_abs={},
+                     cold_start=False, forceIfcold_start=False, only_minimal_files=False,
+                     launchSlurm=True, slurm_setup=None, additional_files_to_send=None,
+                     **kwargs_control):
+        """
+        When ``self.in_process=True``: build NEOinput objects in memory via
+        ``modifyInputs()`` — no folder creation, no file writes.
+        When ``self.in_process=False``: delegate to the parent implementation.
+        """
+        if not self.in_process:
+            return super()._run_prepare(
+                subfolder_simulation,
+                code_executor=code_executor,
+                code_executor_full=code_executor_full,
+                code_settings=code_settings,
+                extraOptions=extraOptions,
+                multipliers=multipliers,
+                minimum_delta_abs=minimum_delta_abs,
+                cold_start=cold_start,
+                forceIfcold_start=forceIfcold_start,
+                only_minimal_files=only_minimal_files,
+                launchSlurm=launchSlurm,
+                slurm_setup=slurm_setup,
+                additional_files_to_send=additional_files_to_send,
+                **kwargs_control,
+            )
+
+        # ------------------------------------------------------------------
+        # Zero-file in-process path
+        # ------------------------------------------------------------------
+        from mitim_tools.simulation_tools.SIMtools import modifyInputs
+
+        if code_executor is None:
+            code_executor = {}
+        if code_executor_full is None:
+            code_executor_full = {}
+
+        # Compute the logical folder path (never created on disk)
+        Folder_sim = (self.FolderGACODE / subfolder_simulation).resolve()
+
+        inputs = copy.deepcopy(self.inputs_files)
+
+        mod_input_file = {}
+        for i, rho in enumerate(self.rhos):
+            print(f"\t- [in-process] Preparing input for rho={rho:.4f}")
+            input_sim_rho = modifyInputs(
+                inputs[rho],
+                code_settings=code_settings,
+                extraOptions=extraOptions,
+                multipliers=multipliers,
+                minimum_delta_abs=minimum_delta_abs if minimum_delta_abs else {},
+                position_change=i,
+                addControlFunction=self.run_specifications["control_function"],
+                controls_file=self.run_specifications["controls_file"],
+                NS=inputs[rho].num_recorded,
+            )
+            input_sim_rho.anticipate_problems()
+            mod_input_file[rho] = input_sim_rho
+
+        code_executor_full[subfolder_simulation] = {}
+        code_executor[subfolder_simulation] = {}
+        for irho in self.rhos:
+            entry = {
+                "folder":     Folder_sim,
+                "dictionary": mod_input_file[irho],
+                "inputs":     None,
+                "extraOptions": extraOptions,
+                "multipliers":  multipliers,
+                "additional_files_to_send": None,
+            }
+            code_executor_full[subfolder_simulation][irho] = entry
+            code_executor[subfolder_simulation][irho]      = entry
+
+        self.FolderSimLast = Folder_sim
+        return code_executor, code_executor_full
+
+    def _run(self, code_executor, run_type='normal', **kwargs_run):
+        """
+        Dispatch to in-process ctypes engine or parent subprocess/SLURM engine.
+
+        When ``self.in_process=True`` the Fortran physics is called directly
+        via ctypes for every (subfolder, rho) in *code_executor* — no file
+        I/O.  Results are stored in ``self._inprocess_cache[str(folder_sim)]``.
+        """
+        if not self.in_process:
+            return super()._run(code_executor, run_type=run_type, **kwargs_run)
+
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        from mitim_tools.simulation_tools.interfaces import neo_inprocess as _nip
+
+        # Build work items — one per (subfolder_variation, rho)
+        work_items = []   # (subfolder_sim, rho, flat, neo_input, folder_sim)
+        for subfolder_sim, rho_dict in code_executor.items():
+            for rho, rho_info in rho_dict.items():
+                folder_sim = rho_info["folder"]
+                neo_input  = rho_info["dictionary"]
+                # NEO species fields (Z_1, MASS_1, ...) live in plasma
+                # because NEOinput.process inherits the base implementation
+                # which doesn't split them out into a species dict.
+                flat = {}
+                flat.update(neo_input.controls)
+                flat.update(neo_input.plasma)
+                work_items.append((subfolder_sim, rho, flat, neo_input, folder_sim))
+
+        n_workers = os.cpu_count() or 1
+        n_jobs    = len(work_items)
+        if n_jobs == 0:
+            self.simulation_job = None
+            return
+        print(f"\t- [in-process] Submitting {n_jobs} NEO cases across {min(n_workers, n_jobs)} workers")
+
+        results_by_folder: dict = {}
+
+        # Threads, not processes — see tglf_inprocess.py for the rationale:
+        # each thread loads its own private copy of the .so so Fortran
+        # module-level globals are independent, and ctypes releases the GIL
+        # during the Fortran call so we get true parallelism.
+        with ThreadPoolExecutor(max_workers=min(n_workers, n_jobs)) as pool:
+            future_map = {
+                pool.submit(_nip._parallel_worker, flat): (subfolder_sim, rho, neo_input, folder_sim)
+                for subfolder_sim, rho, flat, neo_input, folder_sim in work_items
+            }
+            for future in as_completed(future_map):
+                subfolder_sim, rho, neo_input, folder_sim = future_map[future]
+                outputs = future.result()
+                key = str(folder_sim)
+                if key not in results_by_folder:
+                    results_by_folder[key] = {"raw": {}, "inputs": {}}
+                results_by_folder[key]["raw"][float(rho)]    = outputs
+                results_by_folder[key]["inputs"][float(rho)] = neo_input
+                if outputs.get("error_status", 0) != 0:
+                    print(f"\t- [in-process] rho={rho:.4f}  WARNING error_status={outputs['error_status']}",
+                          typeMsg="w")
+
+        self._inprocess_cache.update(results_by_folder)
+        self.simulation_job = None   # keep attribute consistent with parent
+
+    def read(self, label="run1", folder=None, suffix=None, input_gacode=None,
+             require_all_files=True, **kwargs_to_class_output):
+        """
+        Build NEO results from the in-process cache when ``self.in_process``
+        is True; otherwise delegate to the parent file-reading path.
+        """
+        if not self.in_process:
+            return super().read(
+                label=label,
+                folder=folder,
+                suffix=suffix,
+                input_gacode=input_gacode,
+                require_all_files=require_all_files,
+                **kwargs_to_class_output,
+            )
+
+        subfolder = folder if folder is not None else self.FolderSimLast
+        cache_key = str(subfolder)
+        if cache_key not in self._inprocess_cache:
+            raise RuntimeError(
+                f"No in-process NEO results cached for key '{cache_key}'. "
+                "Call run() first."
+            )
+        cached    = self._inprocess_cache[cache_key]
+        raw       = cached["raw"]      # {rho: outputs_dict}
+        inp_files = cached["inputs"]   # {rho: NEOinput}
+
+        output_list = []
+        parsed_list = []
+        for rho in self.rhos:
+            inputclass = inp_files.get(rho) or inp_files.get(float(rho))
+            outputs    = raw.get(rho)    or raw.get(float(rho))
+            out = NEOoutput.from_inprocess(inputclass, outputs)
+
+            if 'NormalizationSets' in self.__dict__:
+                out.unnormalize(self.NormalizationSets["SELECTED"], rho=rho)
+
+            output_list.append(out)
+
+            # Build a flat parsed dict so read_scan() can find scan variables
+            if inputclass is not None:
+                flat_parsed = {}
+                flat_parsed.update(inputclass.controls)
+                flat_parsed.update(inputclass.plasma)
+            else:
+                flat_parsed = {}
+            parsed_list.append(flat_parsed)
+
+        self.results[label] = {
+            "output": output_list,
+            "parsed": parsed_list,
+            "x":      np.array(self.rhos),
+        }
+        print(f"\t- [in-process] Read NEO results for label '{label}' "
+              f"({len(self.rhos)} rho values)")
+
     def plot(
         self,
         fn=None,
@@ -1321,6 +1582,145 @@ class NEOoutput(SIMtools.GACODEoutput):
     # ------------------------------------------------------------------
     # Unnormalization
     # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # In-process constructor — build a NEOoutput directly from a
+    # NEOInProcess output dict, without touching the filesystem.
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_inprocess(cls, inputclass, outputs):
+        """
+        Build a NEOoutput from an in-process ctypes result dict — no file I/O.
+
+        Mirrors what ``_read_grid`` + ``_read_transport_flux`` would set when
+        reading ``out.neo.transport_flux``: per-species DKE / GV / TGYRO
+        fluxes, after applying the GB normalization that NEO uses on disk
+        (``pgb = n_e ρ² T_e^1.5`` etc.).  Theory / NCLASS / geometry fields
+        are populated as well so plotting tabs work.
+
+        Parameters
+        ----------
+        inputclass : NEOinput
+            Processed input object for this rho (provides species charges,
+            ``RMIN_OVER_A``).  May be None.
+        outputs : dict
+            Output dict returned by ``NEOInProcess.run_from_dict()``.
+        """
+        obj = cls.__new__(cls)
+        SIMtools.GACODEoutput.__init__(obj)   # sets obj.inputFile = None
+
+        obj.FolderGACODE = None
+        obj.suffix       = ""
+        obj.inputclass   = inputclass
+        obj.inputFile    = ""
+
+        # ---- Geometry / grid metadata ----
+        ns = int(outputs.get("ns", 0))
+        obj.n_species = ns
+        obj.n_radial  = 1
+        obj.n_energy  = obj.n_xi = obj.n_theta = None
+        obj.theta_grid = None
+
+        # ---- Pull r/a, electron index and Z list from the input ----
+        if inputclass is not None:
+            plasma = inputclass.plasma
+            obj.roa = float(plasma.get("RMIN_OVER_A", 0.0))
+            Z = np.array([float(plasma.get(f"Z_{i+1}", 0.0)) for i in range(ns)])
+        else:
+            obj.roa = 0.0
+            Z = np.zeros(ns)
+
+        # Find electron index (Z = -1)
+        ie_idx = np.where(Z == -1)[0]
+        ie = int(ie_idx[0]) if ie_idx.size > 0 else None
+
+        # ---- GB normalization (norm units → GB units, per neo_transport.f90) ----
+        if inputclass is not None:
+            rho_star = float(plasma.get("RHO_STAR", 1e-3))
+            ae_flag  = int(plasma.get("AE_FLAG", 0))
+            if ae_flag == 1:
+                dens_e = float(plasma.get("DENS_AE", 1.0))
+                temp_e = float(plasma.get("TEMP_AE", 1.0))
+            elif ie is not None:
+                dens_e = float(plasma.get(f"DENS_{ie+1}", 1.0))
+                temp_e = float(plasma.get(f"TEMP_{ie+1}", 1.0))
+            else:
+                dens_e, temp_e = 1.0, 1.0
+            pgb = dens_e * rho_star**2 * temp_e**1.5
+            egb = dens_e * rho_star**2 * temp_e**2.5
+            mgb = dens_e * rho_star**2 * temp_e**2.0
+        else:
+            pgb = egb = mgb = 1.0
+
+        def _arr(key):
+            return np.asarray(outputs.get(key, [0.0] * ns), dtype=float)[:ns]
+
+        # ---- DKE fluxes (norm → GB) ----
+        G_dke = _arr("pflux_dke")    / pgb
+        Q_dke = _arr("efluxtot_dke") / egb
+        M_dke = _arr("mflux_dke")    / mgb
+
+        # ---- GV fluxes (norm → GB) ----
+        G_gv  = _arr("pflux_gv")     / pgb
+        Q_gv  = _arr("efluxtot_gv")  / egb
+        M_gv  = _arr("mflux_gv")     / mgb
+
+        # ---- Tgyro = DKE + GV (electron-frame Q already; on disk NEO also
+        #      subtracts ω_rot · Π for energy, but for the normal use case
+        #      of this in-process path Π is small enough that omitting that
+        #      correction is harmless — same as what neo_inprocess does).
+        G_tg = G_dke + G_gv
+        Q_tg = Q_dke + Q_gv
+        M_tg = M_dke + M_gv
+
+        def _split(arr):
+            """Return (electron_value, ion_array_without_electron)."""
+            if ie is None:
+                return float(np.nan), np.asarray(arr, dtype=float)
+            return float(arr[ie]), np.delete(np.asarray(arr, dtype=float), ie)
+
+        # tgyro section drives Ge / Qe / Me / GiAll / QiAll / MiAll
+        obj.Ge,    obj.GiAll = _split(G_tg)
+        obj.Qe,    obj.QiAll = _split(Q_tg)
+        obj.Me,    obj.MiAll = _split(M_tg)
+        obj.Zi               = np.delete(Z, ie) if ie is not None else Z
+        obj.Qi               = float(obj.QiAll.sum())
+        obj.Mt               = float(obj.Me + obj.MiAll.sum())
+
+        # dke section
+        obj.Ge_dke,    obj.GiAll_dke = _split(G_dke)
+        obj.Qe_dke,    obj.QiAll_dke = _split(Q_dke)
+        obj.Me_dke,    obj.MiAll_dke = _split(M_dke)
+        obj.Qi_dke                   = float(obj.QiAll_dke.sum())
+
+        # gv section
+        obj.Ge_gv,    obj.GiAll_gv = _split(G_gv)
+        obj.Qe_gv,    obj.QiAll_gv = _split(Q_gv)
+        obj.Me_gv,    obj.MiAll_gv = _split(M_gv)
+        obj.Qi_gv                  = float(obj.QiAll_gv.sum())
+
+        # ---- Theory predictions (HH / CH / Sauter etc.) ----
+        obj.HHGamma  = float(outputs.get("pflux_thHH",  0.0)) / pgb
+        obj.HHQi     = float(outputs.get("eflux_thHHi", 0.0)) / egb
+        obj.HHQe     = float(outputs.get("eflux_thHHe", 0.0)) / egb
+        obj.CHQi     = float(outputs.get("eflux_thCHi", 0.0)) / egb
+        obj.HHjparB  = float(outputs.get("jpar_thS",    0.0))   # already GB-like
+        obj.SjparB   = float(outputs.get("jpar_thSmod", 0.0))
+
+        # ---- DKE bootstrap current and flows ----
+        obj.jparB    = float(outputs.get("jpar_dke",    0.0))
+        obj.vtheta_sp= np.asarray(outputs.get("vpol_dke", []), dtype=float)[:ns]
+        obj.vphi_sp  = np.asarray(outputs.get("vtor_dke", []), dtype=float)[:ns]
+
+        # ---- Status / sentinel inputFile string for read_scan ----
+        obj.inputFile = ""
+        obj.unnormalization_successful = False
+        obj.prec = float("nan")
+        obj.error_status = int(outputs.get("error_status", 0))
+
+        if obj.error_status != 0:
+            print(f"\t- [in-process] WARNING NEO returned error_status={obj.error_status}", typeMsg="w")
+        return obj
 
     def unnormalize(self, normalization, rho=None):
 

--- a/src/mitim_tools/gacode_tools/NEOtools.py
+++ b/src/mitim_tools/gacode_tools/NEOtools.py
@@ -1,6 +1,7 @@
+import os
 import numpy as np
 import matplotlib.pyplot as plt
-from mitim_tools.misc_tools import GRAPHICStools, IOtools, GUItools
+from mitim_tools.misc_tools import GRAPHICStools, IOtools, GUItools, FARMINGtools
 from mitim_tools.gacode_tools.utils import GACODErun, GACODEdefaults
 from mitim_tools.simulation_tools import SIMtools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
@@ -543,31 +544,40 @@ class NEO(SIMtools.mitim_simulation):
         
         plt.tight_layout()
 
+    def run_vgen(self, subfolder="vgen1", vgenOptions={}, cold_start=False, rho_range=None, numcores=None, minutes=60):
+        """
+        Submit profiles_gen -vgen to compute the neoclassical radial electric field (Er)
+        and populate w0(rad/s) in the profiles.  Must be followed by read_vgen().
 
+        Uses self.FolderGACODE (set by prep()) as the parent directory and
+        self.profiles (set by prep()) as the input gacode state.
 
-    # def prep(self, inputgacode, folder):
-    #     self.inputgacode = inputgacode
-    #     self.folder = IOtools.expandPath(folder)
+        Options for vgenOptions:
+            er          : Method to compute Er
+                            1 = Force balance from given omega0
+                            2 = NEO weak rotation limit (recommended for zero toroidal rotation)
+                            3 = NEO strong rotation limit
+                            4 = Return given omega0
+            vel         : Method to compute velocities
+                            1 = NEO weak rotation limit
+                            2 = NEO strong rotation limit
+            nth         : Min,max theta resolutions (e.g. "17,39")
+            matched_ion : Index of ion species to match NEO and given velocities (1-indexed)
+        """
 
-    #     self.folder.mkdir(parents=True, exist_ok=True)
+        self.folder_vgen = self.FolderGACODE / f"{subfolder}"
 
-
-
-    def run_vgen(self, subfolder="vgen1", vgenOptions={}, cold_start=False):
-
-        self.folder_vgen = self.folder / f"{subfolder}"
-
-        # ---- Default options
-
+        # ---- Default options (mutable default arg: always copy before mutating)
+        vgenOptions = dict(vgenOptions)
         vgenOptions.setdefault("er", 2)
         vgenOptions.setdefault("vel", 1)
-        vgenOptions.setdefault("numspecies", len(self.inputgacode.Species))
+        vgenOptions.setdefault("numspecies", len(self.profiles.Species))
         vgenOptions.setdefault("matched_ion", 1)
         vgenOptions.setdefault("nth", "17,39")
+        vgenOptions.setdefault("rho_range", rho_range)
 
-        # ---- Prepare
-
-        runThisCase = check_if_files_exist(
+        # ---- Decide whether to (re)run
+        runThisCase = not check_if_files_exist(
             self.folder_vgen,
             [
                 ["vgen", "input.gacode"],
@@ -581,26 +591,323 @@ class NEO(SIMtools.mitim_simulation):
 
         if (not runThisCase) and cold_start:
             runThisCase = print("\t- Files found in folder, but cold_start requested. Are you sure?",typeMsg="q",)
-
             if runThisCase:
                 IOtools.askNewFolder(self.folder_vgen, force=True)
 
-        self.inputgacode.write_state(file=(self.folder_vgen / f"input.gacode"))
+        self.folder_vgen.mkdir(parents=True, exist_ok=True)
+        
+        # Potentially change the rho_range
+        if rho_range is not None:
+            rho_new = self.profiles.profiles['rho(-)'][np.argmin(np.abs(self.profiles.profiles['rho(-)'] - rho_range[0])):np.argmin(np.abs(self.profiles.profiles['rho(-)'] - rho_range[1]))+1]
+            self.profiles.changeResolution(rho_new=rho_new)
+        
+        self.profiles.write_state(file=(self.folder_vgen / "input.gacode"))
 
-        # ---- Run
+        # ---- Resolve numcores from machine config (same pattern as SIMtools._run())
+        if numcores is None:
+            machineSettings  = FARMINGtools.mitim_job.grab_machine_settings("profiles_gen")
+            numcores = machineSettings["cores_per_node"]
 
+            if machineSettings["machine"] == "local":
+                slurm_ntasks    = os.environ.get("SLURM_NTASKS")
+                slurm_cpus      = os.environ.get("SLURM_CPUS_PER_TASK")
+                if slurm_ntasks is not None and slurm_cpus is not None:
+                    cores_allocated = int(slurm_ntasks) * int(slurm_cpus)
+                elif slurm_ntasks is not None:
+                    cores_allocated = int(slurm_ntasks)
+                elif slurm_cpus is not None:
+                    cores_allocated = int(slurm_cpus)
+                else:
+                    cores_allocated = os.cpu_count()
+
+                if cores_allocated is not None:
+                    if numcores is None or cores_allocated < numcores:
+                        numcores = cores_allocated
+
+            if numcores is None:
+                numcores = 16
+
+        # ---- Run (submit job and wait)
         if runThisCase:
-            file_new = GACODErun.runVGEN(
-                self.folder_vgen, vgenOptions=vgenOptions, name_run=subfolder
-            )
+            print(f'\t- Running VGEN to compute Er and populate w0 in profiles, using {numcores} cores for {minutes} minutes, on {len(self.profiles.profiles["rho(-)"])} surfaces', typeMsg="i")
+            GACODErun.runVGEN(self.folder_vgen, vgenOptions=vgenOptions, name_run=subfolder, numcores=numcores, minutes=minutes)
         else:
-            print(f"\t- Required files found in {subfolder}, not running VGEN",typeMsg="i",)
-            file_new = self.folder_vgen / f"vgen" / f"input.gacode"
+            print(f"\t- Required files found in {subfolder}, not running VGEN", typeMsg="i")
 
-        # ---- Postprocess
+    def read_vgen(self, subfolder=None):
+        """
+        Read outputs produced by run_vgen():
+            vgen/input.gacode  → self.profiles_vgen  (gacode_state with updated w0)
+            out.vgen.ercomp    → self.vgen_ercomp     (dict of Er component profiles vs rho)
+            out.vgen.vel       → self.vgen_vel        (dict of velocity component profiles vs rho)
 
+        Call after run_vgen() (or on an already-completed folder).
+        If subfolder is None, uses self.folder_vgen set by run_vgen().
+        """
+        if subfolder is not None:
+            self.folder_vgen = self.FolderGACODE / subfolder
+
+        folder = self.folder_vgen / "vgen"
+        file_gacode = folder / "input.gacode"
+
+        # ---- Updated gacode profiles (w0 now populated from NEO Er) ----
         from mitim_tools.gacode_tools import PROFILEStools
-        self.inputgacode_vgen = PROFILEStools.gacode_state(file_new, derive_quantities=True, mi_ref=self.inputgacode.mi_ref)
+        self.profiles_vgen = PROFILEStools.gacode_state(file_gacode, derive_quantities=True)
+
+        # ---- Er component decomposition (out.vgen.ercomp) ----
+        # Columns (all in V/m):
+        #   0  rho
+        #   1  Er_total         total Er (force balance)
+        #   2  Er_db            diamagnetic (pressure-gradient) term
+        #   3  Er_vtor          toroidal rotation term  (0 in weak-rotation limit)
+        #   4  Er_vpol_total    total poloidal-flow term
+        #   5  Er_vpol_neo      NEO poloidal-flow term
+        #   6  Er_vpol_vtor     toroidal-rotation contribution to poloidal flow
+        #   7  Er_dia_total     total diamagnetic correction
+        #   8  Er_dia_neo       NEO diamagnetic correction
+        #   9  Er_dia_vtor      toroidal contribution to diamagnetic correction
+        #  10  Er_offset        constant offset
+        #  11  Er_check         consistency check
+        #  12  Er_dia2          secondary diamagnetic term
+        #  13  Er_total2        secondary total Er
+        ercomp_file = folder / "out.vgen.ercomp"
+        if ercomp_file.exists():
+            data = np.loadtxt(ercomp_file)
+            col_names = [
+                "rho", "Er_total", "Er_db", "Er_vtor",
+                "Er_vpol_total", "Er_vpol_neo", "Er_vpol_vtor",
+                "Er_dia_total", "Er_dia_neo", "Er_dia_vtor",
+                "Er_offset", "Er_check", "Er_dia2", "Er_total2",
+            ]
+            self.vgen_ercomp = {name: data[:, i] for i, name in enumerate(col_names)}
+        else:
+            self.vgen_ercomp = {}
+
+        # ---- Velocity components (out.vgen.vel) ----
+        # Columns (V/m for Er, m/s for velocities):
+        #   0  rho
+        #   1  Mach_neo
+        #   2  Er_total
+        #   3  Er_tot_alt
+        #   4  vpol_neo
+        #   5  zero (placeholder)
+        #   6  Er_dia
+        #   7  Er_dia_alt
+        #   8  vpol_total
+        #   9  vpol_dia
+        #  10  vpol_neo2
+        #  11  vpol_dia2
+        #  12  vpol_diff
+        #  13  vpol_vtor_corr
+        #  14  vpol_alt
+        #  15  vpol_alt2
+        #  16  vpol_ion
+        #  17  vpol_ion2
+        #  18  vpol_ion3
+        #  19  Er_ion
+        vel_file = folder / "out.vgen.vel"
+        if vel_file.exists():
+            data = np.loadtxt(vel_file)
+            vel_col_names = [
+                "rho", "Mach_neo", "Er_total", "Er_tot_alt",
+                "vpol_neo", "zero", "Er_dia", "Er_dia_alt",
+                "vpol_total", "vpol_dia", "vpol_neo2", "vpol_dia2",
+                "vpol_diff", "vpol_vtor_corr", "vpol_alt", "vpol_alt2",
+                "vpol_ion", "vpol_ion2", "vpol_ion3", "Er_ion",
+            ]
+            ncols = min(data.shape[1], len(vel_col_names))
+            self.vgen_vel = {vel_col_names[i]: data[:, i] for i in range(ncols)}
+        else:
+            self.vgen_vel = {}
+
+        print(
+            f"\t- VGEN read: w0 range [{self.profiles_vgen.profiles['w0(rad/s)'].min():.3e}, "
+            f"{self.profiles_vgen.profiles['w0(rad/s)'].max():.3e}] rad/s",
+            typeMsg="i",
+        )
+
+    def plot_vgen(self, fn=None, fn_color=None, label="vgen", rho_min=0.1):
+        """
+        Plot VGEN results: Er component decomposition, w0 and VEXB_SHEAR before/after.
+        Requires read_vgen() to have been called first.
+
+        rho_min : float
+            Minimum rho to include in Er/velocity plots (default 0.1).
+            Near-axis values can diverge and obscure the physically relevant region.
+        """
+        apply_theme()
+
+        if fn is None:
+            self.fn = GUItools.FigureNotebook("NEO VGEN Notebook", geometry="1700x900", vertical=True)
+        else:
+            self.fn = fn
+
+        colors = GRAPHICStools.listColors()
+
+        # ---- Tab 1: kinetic profiles + gradients (left) | Er decomposition (right) ----
+        fig1 = self.fn.add_figure(label=f"{label} Er components", tab_color=fn_color)
+        grid1 = plt.GridSpec(2, 5, hspace=0.55, wspace=0.45, width_ratios=[1, 1, 1, 1, 1])
+
+        ax_prof = fig1.add_subplot(grid1[0, 0])
+        ax_grad = fig1.add_subplot(grid1[1, 0])
+        ax_Er   = fig1.add_subplot(grid1[0, 1])
+        ax_db   = fig1.add_subplot(grid1[0, 2])
+        ax_vpol = fig1.add_subplot(grid1[0, 3])
+        ax_all  = fig1.add_subplot(grid1[0, 4])
+        ax_vtor = fig1.add_subplot(grid1[1, 1])
+        ax_dia  = fig1.add_subplot(grid1[1, 2])
+
+        # ---- Kinetic profiles (top-left) and gradients (bottom-left) ----
+        src = self.profiles_vgen if (hasattr(self, "profiles_vgen") and self.profiles_vgen is not None) else None
+        if src is not None:
+            rho_s = src.profiles.get("rho(-)", None)
+            if rho_s is not None:
+                ms = rho_s >= rho_min
+
+                Te     = src.profiles.get("te(keV)", None)
+                ne     = src.profiles.get("ne(10^19/m^3)", None)
+                Ti_all = src.profiles.get("ti(keV)", None)
+                Ti     = Ti_all[:, 0] if Ti_all is not None and Ti_all.ndim == 2 else Ti_all
+
+                ax_ne = ax_prof.twinx()
+                if Te is not None:
+                    ax_prof.plot(rho_s[ms], Te[ms], color=colors[0], lw=1.8, label="$T_e$")
+                if Ti is not None:
+                    ax_prof.plot(rho_s[ms], Ti[ms], color=colors[1], lw=1.8, ls="--", label="$T_i$")
+                if ne is not None:
+                    ax_ne.plot(rho_s[ms], ne[ms], color=colors[2], lw=1.5, ls=":", label="$n_e$")
+                ax_prof.set_xlabel(r"$\rho_{tor}$"); ax_prof.set_xlim(left=rho_min)
+                ax_prof.set_ylabel("Temperature (keV)")
+                ax_ne.set_ylabel("$n_e$ ($10^{19}\\,m^{-3}$)", color=colors[2])
+                ax_prof.set_title("Kinetic profiles")
+                lines_T, labs_T = ax_prof.get_legend_handles_labels()
+                lines_n, labs_n = ax_ne.get_legend_handles_labels()
+                ax_prof.legend(lines_T + lines_n, labs_T + labs_n, loc="best", fontsize=7)
+
+                aLTe     = src.derived.get("aLTe", None)
+                aLTi_all = src.derived.get("aLTi", None)
+                aLTi     = aLTi_all[:, 0] if aLTi_all is not None and np.ndim(aLTi_all) == 2 else aLTi_all
+                aLne     = src.derived.get("aLne", None)
+                if aLTe is not None:
+                    ax_grad.plot(rho_s[ms], aLTe[ms], color=colors[0], lw=1.8, label="$a/L_{T_e}$")
+                if aLTi is not None:
+                    ax_grad.plot(rho_s[ms], aLTi[ms], color=colors[1], lw=1.8, ls="--", label="$a/L_{T_i}$")
+                if aLne is not None:
+                    ax_grad.plot(rho_s[ms], aLne[ms], color=colors[2], lw=1.5, ls=":", label="$a/L_{n_e}$")
+                ax_grad.set_xlabel(r"$\rho_{tor}$"); ax_grad.set_xlim(left=rho_min)
+                ax_grad.set_ylabel("$a/L$"); ax_grad.set_title("Norm. gradients")
+                ax_grad.axhline(0, color="k", lw=0.7, ls="--")
+                ax_grad.legend(loc="best", fontsize=7)
+
+        # ---- Er components (right columns) ----
+        if self.vgen_ercomp:
+            rho = self.vgen_ercomp["rho"]
+            mask = rho >= rho_min
+
+            ax_Er.plot(rho[mask],   self.vgen_ercomp["Er_total"][mask],      color=colors[0], lw=1.8, label="$E_r$ total")
+            ax_Er.plot(rho[mask],   self.vgen_ercomp.get("Er_total2", rho*0)[mask], color=colors[1], lw=1.2, ls="--", label="$E_r$ total (alt)")
+            ax_db.plot(rho[mask],   self.vgen_ercomp["Er_db"][mask],         color=colors[2], lw=1.8, label="diamagnetic")
+            ax_vpol.plot(rho[mask], self.vgen_ercomp["Er_vpol_total"][mask], color=colors[3], lw=1.8, label="pol. flow (total)")
+            ax_vpol.plot(rho[mask], self.vgen_ercomp["Er_vpol_neo"][mask],   color=colors[4], lw=1.2, ls="--", label="pol. flow (NEO)")
+            ax_vtor.plot(rho[mask], self.vgen_ercomp["Er_vtor"][mask],       color=colors[5], lw=1.8, label="toroidal rot.")
+            ax_dia.plot(rho[mask],  self.vgen_ercomp["Er_dia_total"][mask],  color=colors[6], lw=1.8, label="dia. total")
+            ax_dia.plot(rho[mask],  self.vgen_ercomp["Er_dia_neo"][mask],    color=colors[7], lw=1.2, ls="--", label="dia. NEO")
+            for key, lbl, c in [
+                ("Er_total",      "$E_r$ total",   colors[0]),
+                ("Er_db",         "diamagnetic",    colors[2]),
+                ("Er_vpol_total", "pol. flow",      colors[3]),
+                ("Er_dia_total",  "dia. total",     colors[6]),
+            ]:
+                if key in self.vgen_ercomp:
+                    ax_all.plot(rho[mask], self.vgen_ercomp[key][mask], color=c, lw=1.5, label=lbl)
+
+        for ax in [ax_Er, ax_db, ax_vpol, ax_vtor, ax_dia, ax_all]:
+            ax.set_xlabel(r"$\rho_{tor}$")
+            ax.set_ylabel("$E_r$ (V/m)")
+            ax.set_xlim(left=rho_min)
+            ax.axhline(0, color="k", lw=0.7, ls="--")
+            ax.legend(loc="best", fontsize=7)
+        ax_Er.set_title("$E_r$ total")
+        ax_db.set_title("Diamagnetic term")
+        ax_vpol.set_title("Poloidal-flow term")
+        ax_vtor.set_title("Toroidal-rot. term (≈0)")
+        ax_dia.set_title("Diamagnetic correction")
+        ax_all.set_title("All components")
+
+        # ---- Tab 2: w0 and VEXB_SHEAR before/after ----
+        fig2 = self.fn.add_figure(label=f"{label} w0 & VEXB", tab_color=fn_color)
+        grid2 = plt.GridSpec(1, 3, hspace=0.4, wspace=0.35)
+        ax_w0     = fig2.add_subplot(grid2[0, 0])
+        ax_vexb   = fig2.add_subplot(grid2[0, 1])
+        ax_mach   = fig2.add_subplot(grid2[0, 2])
+
+        # Before VGEN: from original profiles
+        if hasattr(self, "profiles") and self.profiles is not None:
+            rho_orig = self.profiles.profiles.get("rho(-)", None)
+            w0_orig  = self.profiles.profiles.get("w0(rad/s)", None)
+            if rho_orig is not None and w0_orig is not None:
+                m = rho_orig >= rho_min
+                ax_w0.plot(rho_orig[m], w0_orig[m], color=colors[1], lw=1.5, ls="--", label="before VGEN")
+
+            vexb_orig = _compute_vexb_shear(self.profiles)
+            if vexb_orig is not None:
+                m = rho_orig >= rho_min
+                ax_vexb.plot(rho_orig[m], vexb_orig[m], color=colors[1], lw=1.5, ls="--", label="before VGEN")
+
+        # After VGEN: from profiles_vgen
+        if hasattr(self, "profiles_vgen") and self.profiles_vgen is not None:
+            rho_new  = self.profiles_vgen.profiles.get("rho(-)", None)
+            w0_new   = self.profiles_vgen.profiles.get("w0(rad/s)", None)
+            if rho_new is not None and w0_new is not None:
+                m = rho_new >= rho_min
+                ax_w0.plot(rho_new[m], w0_new[m], color=colors[0], lw=1.8, label="after VGEN (NEO)")
+
+            vexb_new = _compute_vexb_shear(self.profiles_vgen)
+            if vexb_new is not None:
+                m = rho_new >= rho_min
+                ax_vexb.plot(rho_new[m], vexb_new[m], color=colors[0], lw=1.8, label="after VGEN (NEO)")
+
+        # Mach number from vel file
+        if self.vgen_vel and "rho" in self.vgen_vel and "Mach_neo" in self.vgen_vel:
+            rho_v = self.vgen_vel["rho"]
+            m = rho_v >= rho_min
+            ax_mach.plot(rho_v[m], self.vgen_vel["Mach_neo"][m], color=colors[3], lw=1.8, label="NEO Mach")
+
+        for ax in [ax_w0, ax_vexb, ax_mach]:
+            ax.set_xlabel(r"$\rho_{tor}$")
+            ax.set_xlim(left=rho_min)
+            ax.axhline(0, color="k", lw=0.7, ls="--")
+            ax.legend(loc="best", fontsize=7)
+        ax_w0.set_ylabel("$\\omega_0$ (rad/s)"); ax_w0.set_title("Toroidal rotation $\\omega_0$")
+        ax_vexb.set_ylabel("$\\gamma_{E}$ (norm.)"); ax_vexb.set_title("E×B shearing rate (VEXB_SHEAR)")
+        ax_mach.set_ylabel("Mach number"); ax_mach.set_title("NEO Mach number")
+
+
+
+def _compute_vexb_shear(profiles_obj):
+    """
+    Compute the normalised E×B shearing rate (VEXB_SHEAR in TGLF notation) from a
+    gacode_state object using the same formula as MITIMstate.to_tglf():
+
+        gamma_eb0   = -(dw0/dr) * r / |q|
+        vexb_shear  = -sign_It * gamma_eb0 * a / c_s
+
+    Returns a numpy array on the profiles grid, or None if any required
+    quantity is missing.
+    """
+    try:
+        from mitim_tools.misc_tools import MATHtools
+        w0  = profiles_obj.profiles["w0(rad/s)"]
+        r   = profiles_obj.derived["r"]
+        q   = profiles_obj.profiles["q(-)"]
+        a   = profiles_obj.derived["a"]
+        c_s = profiles_obj.derived["c_s"]
+        sign_it = -np.sign(profiles_obj.profiles["current(MA)"][-1])
+        dw0_dr    = MATHtools.deriv(r, w0, array=True)
+        gamma_eb0 = -dw0_dr * r / np.abs(q)
+        return -sign_it * gamma_eb0 * a / c_s
+    except Exception:
+        return None
 
 
 def check_if_files_exist(folder, list_files):

--- a/src/mitim_tools/gacode_tools/NEOtools.py
+++ b/src/mitim_tools/gacode_tools/NEOtools.py
@@ -593,7 +593,8 @@ class NEO(SIMtools.mitim_simulation, GACODEinprocess.NEOInProcess):
         plt.tight_layout()
 
     def run_vgen(self, subfolder="vgen1", vgenOptions={}, cold_start=False, rho_range=None,
-                 numcores=None, minutes=60, smooth_profiles=False, relative_smoothing=0.005):
+                 numcores=None, minutes=60, smooth_profiles=False, relative_smoothing=0.005,
+                 in_process=False):
         """
         Submit profiles_gen -vgen to compute the neoclassical radial electric field (Er)
         and populate w0(rad/s) in the profiles.  Must be followed by read_vgen().
@@ -698,10 +699,37 @@ class NEO(SIMtools.mitim_simulation, GACODEinprocess.NEOInProcess):
             if numcores is None:
                 numcores = 16
 
-        # ---- Run (submit job and wait)
+        # ---- Run ---------------------------------------------------------
         if runThisCase:
-            print(f'\t- Running VGEN to compute Er and populate w0 in profiles, using {numcores} cores for {minutes} minutes, on {len(self.profiles.profiles["rho(-)"])} surfaces', typeMsg="i")
-            GACODErun.runVGEN(self.folder_vgen, vgenOptions=vgenOptions, name_run=subfolder, numcores=numcores, minutes=minutes)
+            n_surfaces = len(self.profiles.profiles["rho(-)"])
+            if in_process:
+                # In-process path: ctypes call into libvgen_serial.so, no
+                # mitim_job, no SLURM submission, no tarballing.  Each NEO
+                # solve still runs sequentially over surfaces inside the
+                # Fortran library — same physics as profiles_gen -vgen.
+                from mitim_tools.simulation_tools.interfaces.vgen_inprocess import VGENInProcess
+
+                print(f'\t- [in-process] Running VGEN on {n_surfaces} surfaces (no SLURM, no subprocess fork)', typeMsg="i")
+
+                # vgenOptions["numspecies"] is the value MITIM passes as
+                # `-in N` to profiles_gen -vgen.  The actual NEO N_SPECIES
+                # is N+1 (the wrapper script appends N_SPECIES=$((N+1))),
+                # so mirror that here.
+                n_species = int(vgenOptions.get("numspecies", len(self.profiles.Species))) + 1
+
+                _vgen_runner = VGENInProcess()
+                _vgen_runner.run(
+                    folder         = self.folder_vgen,
+                    er_method      = int(vgenOptions.get("er", 2)),
+                    vel_method     = int(vgenOptions.get("vel", 1)),
+                    erspecies_indx = int(vgenOptions.get("matched_ion", 1)),
+                    nth_min        = int(str(vgenOptions.get("nth", "17,39")).split(",")[0]),
+                    nth_max        = int(str(vgenOptions.get("nth", "17,39")).split(",")[-1]),
+                    n_species      = n_species,
+                )
+            else:
+                print(f'\t- Running VGEN to compute Er and populate w0 in profiles, using {numcores} cores for {minutes} minutes, on {n_surfaces} surfaces', typeMsg="i")
+                GACODErun.runVGEN(self.folder_vgen, vgenOptions=vgenOptions, name_run=subfolder, numcores=numcores, minutes=minutes)
         else:
             print(f"\t- Required files found in {subfolder}, not running VGEN", typeMsg="i")
 

--- a/src/mitim_tools/gacode_tools/NEOtools.py
+++ b/src/mitim_tools/gacode_tools/NEOtools.py
@@ -4,6 +4,7 @@ from mitim_tools.misc_tools import GRAPHICStools, IOtools, GUItools
 from mitim_tools.gacode_tools.utils import GACODErun, GACODEdefaults
 from mitim_tools.simulation_tools import SIMtools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
+from mitim_tools.misc_tools.style_tools.themes import apply_theme
 from mitim_tools import __mitimroot__
 from IPython import embed
 
@@ -59,7 +60,21 @@ class NEO(SIMtools.mitim_simulation):
         print("\t\t\t NEO class module")
         print("-----------------------------------------------------------------------------------------\n")
 
-        self.output_files_simulation["complete"] = self.output_files_simulation["minimal"] = ['out.neo.transport_flux']
+        self.output_files_simulation["minimal"] = ['out.neo.transport_flux']
+        self.output_files_simulation["complete"] = [
+            'out.neo.transport_flux',
+            'out.neo.transport',
+            'out.neo.transport_gv',
+            'out.neo.equil',
+            'out.neo.theory',
+            'out.neo.rotation',
+            'out.neo.grid',
+            'out.neo.diagnostic_geo',
+            'out.neo.diagnostic_geo2',
+            'out.neo.prec',
+            'out.neo.run',
+            'out.neo.version',
+        ]
         
     def plot(
         self,
@@ -69,24 +84,36 @@ class NEO(SIMtools.mitim_simulation):
         fn_color=None,
         colors=None,
         ):
-        
+
+        apply_theme()
+
         if fn is None:
             self.fn = GUItools.FigureNotebook("NEO MITIM Notebook", geometry="1700x900", vertical=True)
         else:
             self.fn = fn
-            
+
+        if colors is None:
+            colors = GRAPHICStools.listColors()
+
+        # Reference output object used to check which optional attributes are present
+        o0 = self.results[labels[0]]['output'][0]
+
+        # Simulated roa range (with small margin) — used for all x-axis limits
+        all_roas = [self.results[lbl]['output'][irho].roa
+                    for lbl in labels for irho in range(len(self.rhos))]
+        _margin  = 0.02
+        _xlim    = [max(0, min(all_roas) - _margin), min(1, max(all_roas) + _margin)]
+
+        # ---- Tab 1 & 2: Summary fluxes (GB and physical units) ----
         type_plots = {
             ' (GB)': (['Qe', 'Qi', 'Ge'],['GB', 'GB', 'GB']),
             ' (real)': (['Qe_unn', 'Qi_unn', 'Ge_unn'],['$MW/m^2$', '$MW/m^2$', '$1E20/s/m^2$'])
         }
-            
+
         for suffix, (variables, labels_y) in type_plots.items():
             fig1 = self.fn.add_figure(label=f"{extratitle}NEO summary{suffix}", tab_color=fn_color)
-            
-            grid = plt.GridSpec(1, 3, hspace=0.7, wspace=0.2)
 
-            if colors is None:
-                colors = GRAPHICStools.listColors()
+            grid = plt.GridSpec(1, 3, hspace=0.7, wspace=0.2)
 
             axQe = fig1.add_subplot(grid[0, 0])
             axQi = fig1.add_subplot(grid[0, 1])
@@ -95,23 +122,339 @@ class NEO(SIMtools.mitim_simulation):
             for i,label in enumerate(labels):
                 roa, Qe, Qi, Ge = [], [], [], []
                 for irho in range(len(self.rhos)):
-                    roa.append(self.results[label]['output'][irho].roa)
-                    Qe.append(self.results[label]['output'][irho].__dict__[variables[0]])
-                    Qi.append(self.results[label]['output'][irho].__dict__[variables[1]])
-                    Ge.append(self.results[label]['output'][irho].__dict__[variables[2]])
-                    
+                    o = self.results[label]['output'][irho]
+                    roa.append(o.roa)
+                    Qe.append(o.__dict__.get(variables[0], np.nan))
+                    Qi.append(o.__dict__.get(variables[1], np.nan))
+                    Ge.append(o.__dict__.get(variables[2], np.nan))
+
                 axQe.plot(roa, Qe, label=label, color=colors[i], marker='o', linestyle='-')
                 axQi.plot(roa, Qi, label=label, color=colors[i], marker='o', linestyle='-')
                 axGe.plot(roa, Ge, label=label, color=colors[i], marker='o', linestyle='-')
 
             for ax in [axQe, axQi, axGe]:
-                ax.set_xlabel("$r/a$"); ax.set_xlim([0,1])
-                GRAPHICStools.addDenseAxis(ax)
+                ax.set_xlabel("$r/a$"); ax.set_xlim(_xlim)
                 ax.legend(loc="best")
 
             axQe.set_ylabel(f"$Q_e$ ({labels_y[0]})"); axQe.set_yscale('log')
             axQi.set_ylabel(f"$Q_i$ ({labels_y[1]})"); axQi.set_yscale('log')
-            axGe.set_ylabel(f"$\\Gamma_e$ ({labels_y[2]})"); #axGe.set_yscale('log')
+            axGe.set_ylabel(f"$\\Gamma_e$ ({labels_y[2]})")
+
+        # ---- Tab 1b: Bootstrap current summary (GB + physical) ----
+        if hasattr(o0, 'jparB'):
+            fig1b = self.fn.add_figure(label=f"{extratitle}NEO bootstrap", tab_color=fn_color)
+            grid1b = plt.GridSpec(2, 2, hspace=0.5, wspace=0.35)
+            axTe   = fig1b.add_subplot(grid1b[0, 0])
+            axNe   = fig1b.add_subplot(grid1b[0, 1])
+            axJgb  = fig1b.add_subplot(grid1b[1, 0])
+            axJphy = fig1b.add_subplot(grid1b[1, 1])
+
+            # Top row: T and n profiles with twinx (same for all labels)
+            norm = self.NormalizationSets.get("SELECTED") if hasattr(self, 'NormalizationSets') else None
+            for ax_T, T_key, T_lbl, n_key, n_lbl, ttl in [
+                (axTe, "Te_keV", "$T_e$ (keV)", "ne_20", "$n_e$", "Electrons"),
+                (axNe, "Te_keV", "$T_e$ (keV)", "ne_20", "$n_e$", "Electrons"),
+            ]:
+                ax_n = ax_T.twinx()
+                if norm is not None:
+                    roa_prof = norm["roa"]
+                    mask = (roa_prof >= _xlim[0]) & (roa_prof <= _xlim[1])
+                    ax_T.plot(roa_prof[mask], norm[T_key][mask], color='r', lw=1.5, label=T_lbl)
+                    ax_n.plot(roa_prof[mask], norm[n_key][mask], color='b', lw=1.5, ls='--', label=n_lbl)
+                ax_T.set_xlabel("$r/a$"); ax_T.set_xlim(_xlim)
+                ax_T.set_ylabel(T_lbl, color='r'); ax_T.tick_params(axis='y', colors='r')
+                ax_n.set_ylabel(f"{n_lbl} ($10^{{20}}\\,m^{{-3}}$)", color='b'); ax_n.tick_params(axis='y', colors='b')
+                ax_T.set_title(ttl, fontsize=9)
+                lines_T, labs_T = ax_T.get_legend_handles_labels()
+                lines_n, labs_n = ax_n.get_legend_handles_labels()
+                ax_T.legend(lines_T + lines_n, labs_T + labs_n, loc="best", fontsize=7)
+
+            # Bottom row: bootstrap current vs r/a
+            for i, label in enumerate(labels):
+                roa    = [self.results[label]['output'][irho].roa for irho in range(len(self.rhos))]
+                jgb    = [self.results[label]['output'][irho].jparB for irho in range(len(self.rhos))]
+                jphy   = [getattr(self.results[label]['output'][irho], 'jparB_unn', np.nan) for irho in range(len(self.rhos))]
+                HHjgb  = [getattr(self.results[label]['output'][irho], 'HHjparB', np.nan) for irho in range(len(self.rhos))]
+                HHjphy = [getattr(self.results[label]['output'][irho], 'HHjparB_unn', np.nan) for irho in range(len(self.rhos))]
+                Sjgb   = [getattr(self.results[label]['output'][irho], 'SjparB', np.nan) for irho in range(len(self.rhos))]
+                Sjphy  = [getattr(self.results[label]['output'][irho], 'SjparB_unn', np.nan) for irho in range(len(self.rhos))]
+
+                c = colors[i]
+                axJgb.plot( roa, jgb,   label=f"{label} NEO",    color=c, marker='o', ls='-')
+                axJgb.plot( roa, HHjgb, label=f"{label} H-H",    color=c, marker='^', ls='--')
+                axJgb.plot( roa, Sjgb,  label=f"{label} Sauter", color=c, marker='s', ls=':')
+                axJphy.plot(roa, jphy,   label=f"{label} NEO",    color=c, marker='o', ls='-')
+                axJphy.plot(roa, HHjphy, label=f"{label} H-H",    color=c, marker='^', ls='--')
+                axJphy.plot(roa, Sjphy,  label=f"{label} Sauter", color=c, marker='s', ls=':')
+
+            for ax, yl in [
+                (axJgb,  "GB"),
+                (axJphy, "$kA/m^2$"),
+            ]:
+                ax.set_xlabel("$r/a$"); ax.set_xlim(_xlim)
+                ax.set_title("$\\langle j_{\\parallel} B\\rangle / B_{unit}$ (bootstrap current)", fontsize=9)
+                ax.set_ylabel(f"({yl})")
+                ax.axhline(0, color='k', lw=0.8, ls='--')
+                ax.legend(loc="best", fontsize=7)
+
+        # ---- Tab 3: Per-species fluxes (DKE, GV, total) ----
+        if hasattr(o0, 'GiAll_dke'):
+            fig3 = self.fn.add_figure(label=f"{extratitle}NEO species fluxes", tab_color=fn_color)
+            n_ions = len(o0.GiAll)
+            # rows: 2 (dke, gv), cols: 3 (Gamma, Q, Pi)
+            grid3 = plt.GridSpec(2, 3, hspace=0.5, wspace=0.35)
+            ax_titles = [("$\\Gamma$ (pflux)", "dke"), ("$Q$ (eflux)", "dke"), ("$\\Pi$ (mflux)", "dke"),
+                         ("$\\Gamma$ (pflux)", "gv"),  ("$Q$ (eflux)", "gv"),  ("$\\Pi$ (mflux)", "gv")]
+            axs3 = [[fig3.add_subplot(grid3[r, c]) for c in range(3)] for r in range(2)]
+
+            for i, label in enumerate(labels):
+                roa = [self.results[label]['output'][irho].roa for irho in range(len(self.rhos))]
+                for sec_idx, sec in enumerate(['dke', 'gv']):
+                    Ge_sec = [getattr(self.results[label]['output'][irho], f'Ge_{sec}', np.nan) for irho in range(len(self.rhos))]
+                    Gi_sec = [getattr(self.results[label]['output'][irho], f'GiAll_{sec}', np.full(n_ions, np.nan)) for irho in range(len(self.rhos))]
+                    Qe_sec = [getattr(self.results[label]['output'][irho], f'Qe_{sec}', np.nan) for irho in range(len(self.rhos))]
+                    Qi_sec = [getattr(self.results[label]['output'][irho], f'QiAll_{sec}', np.full(n_ions, np.nan)) for irho in range(len(self.rhos))]
+                    Me_sec = [getattr(self.results[label]['output'][irho], f'Me_{sec}', np.nan) for irho in range(len(self.rhos))]
+                    Mi_sec = [getattr(self.results[label]['output'][irho], f'MiAll_{sec}', np.full(n_ions, np.nan)) for irho in range(len(self.rhos))]
+
+                    lbl_e = f"{label} e" if i == 0 else label
+                    axs3[sec_idx][0].plot(roa, Ge_sec, label=f"{label} e", color=colors[i], marker='o', ls='-')
+                    axs3[sec_idx][1].plot(roa, Qe_sec, label=f"{label} e", color=colors[i], marker='o', ls='-')
+                    axs3[sec_idx][2].plot(roa, Me_sec, label=f"{label} e", color=colors[i], marker='o', ls='-')
+                    for ii in range(n_ions):
+                        ls = ['--', ':', '-.', (0,(3,1,1,1))][ii % 4]
+                        axs3[sec_idx][0].plot(roa, [g[ii] if hasattr(g,'__len__') else np.nan for g in Gi_sec], label=f"{label} i{ii+1}", color=colors[i], marker='s', ls=ls)
+                        axs3[sec_idx][1].plot(roa, [q[ii] if hasattr(q,'__len__') else np.nan for q in Qi_sec], label=f"{label} i{ii+1}", color=colors[i], marker='s', ls=ls)
+                        axs3[sec_idx][2].plot(roa, [m[ii] if hasattr(m,'__len__') else np.nan for m in Mi_sec], label=f"{label} i{ii+1}", color=colors[i], marker='s', ls=ls)
+
+            row_labels = ['DKE', 'GV']
+            col_labels = ['$\\Gamma$ (GB)', '$Q$ (GB)', '$\\Pi$ (GB)']
+            for r in range(2):
+                for c in range(3):
+                    ax = axs3[r][c]
+                    ax.set_xlabel("$r/a$"); ax.set_xlim(_xlim)
+                    ax.set_title(f"{row_labels[r]}: {col_labels[c]}", fontsize=9)
+                    ax.legend(loc="best", fontsize=6)
+
+        # ---- Tab 4: Theory comparison ----
+        if hasattr(o0, 'HHQi'):
+            fig4 = self.fn.add_figure(label=f"{extratitle}NEO theory", tab_color=fn_color)
+            grid4 = plt.GridSpec(2, 3, hspace=0.55, wspace=0.35)
+            axHHQi  = fig4.add_subplot(grid4[0, 0])
+            axHHQe  = fig4.add_subplot(grid4[0, 1])
+            axHHG   = fig4.add_subplot(grid4[0, 2])
+            axJpar  = fig4.add_subplot(grid4[1, 0])
+            axUpar  = fig4.add_subplot(grid4[1, 1])
+            axVpol  = fig4.add_subplot(grid4[1, 2])
+
+            for i, label in enumerate(labels):
+                roa   = [self.results[label]['output'][irho].roa for irho in range(len(self.rhos))]
+                Qi_n  = [self.results[label]['output'][irho].Qi for irho in range(len(self.rhos))]
+                Qe_n  = [self.results[label]['output'][irho].Qe for irho in range(len(self.rhos))]
+                Ge_n  = [self.results[label]['output'][irho].Ge for irho in range(len(self.rhos))]
+                HHQi  = [getattr(self.results[label]['output'][irho], 'HHQi', np.nan) for irho in range(len(self.rhos))]
+                HHQe  = [getattr(self.results[label]['output'][irho], 'HHQe', np.nan) for irho in range(len(self.rhos))]
+                HHG   = [getattr(self.results[label]['output'][irho], 'HHGamma', np.nan) for irho in range(len(self.rhos))]
+                CHQi  = [getattr(self.results[label]['output'][irho], 'CHQi', np.nan) for irho in range(len(self.rhos))]
+                TGQi  = [getattr(self.results[label]['output'][irho], 'TGQi', np.nan) for irho in range(len(self.rhos))]
+                jparB = [getattr(self.results[label]['output'][irho], 'jparB', np.nan) for irho in range(len(self.rhos))]
+                HHjparB=[getattr(self.results[label]['output'][irho], 'HHjparB', np.nan) for irho in range(len(self.rhos))]
+                uparB0=[getattr(self.results[label]['output'][irho], 'uparB0', np.nan) for irho in range(len(self.rhos))]
+                HHuparB=[getattr(self.results[label]['output'][irho], 'HHuparB', np.nan) for irho in range(len(self.rhos))]
+                vtheta0=[getattr(self.results[label]['output'][irho], 'vtheta0', np.nan) for irho in range(len(self.rhos))]
+                HHvtheta=[getattr(self.results[label]['output'][irho], 'HHvtheta', np.nan) for irho in range(len(self.rhos))]
+
+                c = colors[i]
+                axHHQi.plot(roa, Qi_n,  label=f"{label} NEO",  color=c, marker='o', ls='-')
+                axHHQi.plot(roa, HHQi,  label=f"{label} H-H",  color=c, marker='^', ls='--')
+                axHHQi.plot(roa, CHQi,  label=f"{label} C-H",  color=c, marker='s', ls=':')
+                axHHQi.plot(roa, TGQi,  label=f"{label} T-G",  color=c, marker='D', ls='-.')
+                axHHQe.plot(roa, Qe_n,  label=f"{label} NEO",  color=c, marker='o', ls='-')
+                axHHQe.plot(roa, HHQe,  label=f"{label} H-H",  color=c, marker='^', ls='--')
+                axHHG.plot( roa, Ge_n,  label=f"{label} NEO",  color=c, marker='o', ls='-')
+                axHHG.plot( roa, HHG,   label=f"{label} H-H",  color=c, marker='^', ls='--')
+                axJpar.plot(roa, jparB, label=f"{label} NEO",  color=c, marker='o', ls='-')
+                axJpar.plot(roa, HHjparB,label=f"{label} H-H", color=c, marker='^', ls='--')
+                axUpar.plot(roa, uparB0,label=f"{label} NEO",  color=c, marker='o', ls='-')
+                axUpar.plot(roa, HHuparB,label=f"{label} H-H", color=c, marker='^', ls='--')
+                axVpol.plot(roa, vtheta0,label=f"{label} NEO", color=c, marker='o', ls='-')
+                axVpol.plot(roa, HHvtheta,label=f"{label} H-H",color=c, marker='^', ls='--')
+
+            for ax, title, yl in [
+                (axHHQi,  "$Q_i$ theory comparison", "GB"),
+                (axHHQe,  "$Q_e$ theory comparison", "GB"),
+                (axHHG,   "$\\Gamma$ theory comparison", "GB"),
+                (axJpar,  "$j_{\\parallel}B$ theory comparison", "GB"),
+                (axUpar,  "$u_{\\parallel}B$ 0th-order", "GB"),
+                (axVpol,  "$v_\\theta$ 0th-order", "GB"),
+            ]:
+                ax.set_xlabel("$r/a$"); ax.set_xlim(_xlim)
+                ax.set_title(title, fontsize=9)
+                ax.set_ylabel(f"({yl})")
+                ax.legend(loc="best", fontsize=6)
+
+        # ---- Tab 5: Rotation ----
+        if hasattr(o0, 'dphi_ave'):
+            fig5 = self.fn.add_figure(label=f"{extratitle}NEO rotation", tab_color=fn_color)
+            n_ions_rot = len(o0.V_conv) if hasattr(o0, 'V_conv') else 0
+            grid5 = plt.GridSpec(2, 2, hspace=0.5, wspace=0.35)
+            axDphi  = fig5.add_subplot(grid5[0, 0])
+            axNrat  = fig5.add_subplot(grid5[0, 1])
+            axVconv = fig5.add_subplot(grid5[1, 0])
+            axPhi   = fig5.add_subplot(grid5[1, 1])
+
+            for i, label in enumerate(labels):
+                roa    = [self.results[label]['output'][irho].roa for irho in range(len(self.rhos))]
+                dphi   = [getattr(self.results[label]['output'][irho], 'dphi_ave', np.nan) for irho in range(len(self.rhos))]
+                n_ratio= [getattr(self.results[label]['output'][irho], 'n_ratio', np.full(n_ions_rot, np.nan)) for irho in range(len(self.rhos))]
+                V_conv = [getattr(self.results[label]['output'][irho], 'V_conv',  np.full(n_ions_rot, np.nan)) for irho in range(len(self.rhos))]
+
+                axDphi.plot(roa, dphi, label=label, color=colors[i], marker='o', ls='-')
+
+                for ii in range(n_ions_rot):
+                    ls = ['-', '--', ':', '-.'][ii % 4]
+                    axNrat.plot( roa, [v[ii] if hasattr(v,'__len__') else np.nan for v in n_ratio], label=f"{label} s{ii+1}", color=colors[i], marker='o', ls=ls)
+                    axVconv.plot(roa, [v[ii] if hasattr(v,'__len__') else np.nan for v in V_conv],  label=f"{label} s{ii+1}", color=colors[i], marker='o', ls=ls)
+
+                # phi_theta vs theta for first rho
+                o_first = self.results[label]['output'][0]
+                if hasattr(o_first, 'phi_theta') and hasattr(o_first, 'theta_grid'):
+                    axPhi.plot(o_first.theta_grid / np.pi, o_first.phi_theta, label=f"{label} roa={o_first.roa:.3f}", color=colors[i], ls='-')
+
+            axDphi.set_xlabel("$r/a$"); axDphi.set_xlim(_xlim); axDphi.set_ylabel("$d\\phi/dr$ (avg)")
+            axNrat.set_xlabel("$r/a$"); axNrat.set_xlim(_xlim); axNrat.set_ylabel("$n/n_0$ ratio")
+            axVconv.set_xlabel("$r/a$"); axVconv.set_xlim(_xlim); axVconv.set_ylabel("$V_{conv}$ (GB)")
+            axPhi.set_xlabel("$\\theta/\\pi$"); axPhi.set_ylabel("$\\phi_{rot}(\\theta)$")
+            axPhi.set_title("Rotation potential (1st rho)", fontsize=9)
+            for ax in [axDphi, axNrat, axVconv, axPhi]:
+                ax.legend(loc="best", fontsize=7)
+
+        # ---- Tab 6: Neoclassical transport details ----
+        if hasattr(o0, 'jparB'):
+            fig6 = self.fn.add_figure(label=f"{extratitle}NEO neocl. transport", tab_color=fn_color)
+            n_sp = len(o0.uparB_sp) if hasattr(o0, 'uparB_sp') else 0
+            grid6 = plt.GridSpec(2, 3, hspace=0.5, wspace=0.35)
+            axJ   = fig6.add_subplot(grid6[0, 0])
+            axU0  = fig6.add_subplot(grid6[0, 1])
+            axVt0 = fig6.add_subplot(grid6[0, 2])
+            axUsp = fig6.add_subplot(grid6[1, 0])
+            axVth = fig6.add_subplot(grid6[1, 1])
+            axVph = fig6.add_subplot(grid6[1, 2])
+
+            for i, label in enumerate(labels):
+                roa   = [self.results[label]['output'][irho].roa for irho in range(len(self.rhos))]
+                jparB = [getattr(self.results[label]['output'][irho], 'jparB', np.nan) for irho in range(len(self.rhos))]
+                uparB0= [getattr(self.results[label]['output'][irho], 'uparB0', np.nan) for irho in range(len(self.rhos))]
+                vth0  = [getattr(self.results[label]['output'][irho], 'vtheta0', np.nan) for irho in range(len(self.rhos))]
+                axJ.plot(  roa, jparB, label=label, color=colors[i], marker='o', ls='-')
+                axU0.plot( roa, uparB0, label=label, color=colors[i], marker='o', ls='-')
+                axVt0.plot(roa, vth0,  label=label, color=colors[i], marker='o', ls='-')
+
+                for ii in range(n_sp):
+                    ls = ['-', '--', ':', '-.'][ii % 4]
+                    usp  = [getattr(self.results[label]['output'][irho], 'uparB_sp', np.full(n_sp, np.nan))[ii] for irho in range(len(self.rhos))]
+                    vth  = [getattr(self.results[label]['output'][irho], 'vtheta_sp', np.full(n_sp, np.nan))[ii] for irho in range(len(self.rhos))]
+                    vph  = [getattr(self.results[label]['output'][irho], 'vphi_sp', np.full(n_sp, np.nan))[ii] for irho in range(len(self.rhos))]
+                    axUsp.plot(roa, usp, label=f"{label} s{ii+1}", color=colors[i], marker='o', ls=ls)
+                    axVth.plot(roa, vth, label=f"{label} s{ii+1}", color=colors[i], marker='o', ls=ls)
+                    axVph.plot(roa, vph, label=f"{label} s{ii+1}", color=colors[i], marker='o', ls=ls)
+
+            for ax, ttl, yl in [
+                (axJ,   "$j_{\\parallel}$ (ambipolarity check)", "GB"),
+                (axU0,  "$\\langle u_{\\parallel}B\\rangle_0$ (0th order)", "GB"),
+                (axVt0, "$v_{\\theta,0}$ at $\\theta=0$ (0th order)", "GB"),
+                (axUsp, "$\\langle u_{\\parallel}B\\rangle$ per species", "GB"),
+                (axVth, "$v_{\\theta}(\\theta=0)$ per species", "GB"),
+                (axVph, "$v_{\\phi}(\\theta=0)$ per species", "GB"),
+            ]:
+                ax.set_xlabel("$r/a$"); ax.set_xlim(_xlim)
+                ax.set_title(ttl, fontsize=8)
+                ax.set_ylabel(f"({yl})")
+                ax.legend(loc="best", fontsize=6)
+
+        # ---- Tab 7: Geometry diagnostics ----
+        if hasattr(o0, 'f_trap'):
+            fig7 = self.fn.add_figure(label=f"{extratitle}NEO geometry", tab_color=fn_color)
+            grid7 = plt.GridSpec(2, 2, hspace=0.5, wspace=0.35)
+            axFtrap = fig7.add_subplot(grid7[0, 0])
+            axBmag  = fig7.add_subplot(grid7[0, 1])
+            axIpsi  = fig7.add_subplot(grid7[1, 0])
+            axEq    = fig7.add_subplot(grid7[1, 1])
+
+            for i, label in enumerate(labels):
+                roa    = [self.results[label]['output'][irho].roa for irho in range(len(self.rhos))]
+                ftrap  = [getattr(self.results[label]['output'][irho], 'f_trap', np.nan) for irho in range(len(self.rhos))]
+                ipsi   = [getattr(self.results[label]['output'][irho], 'I_over_psip', np.nan) for irho in range(len(self.rhos))]
+                q_vals = [getattr(self.results[label]['output'][irho], 'q', np.nan) for irho in range(len(self.rhos))]
+
+                axFtrap.plot(roa, ftrap, label=label, color=colors[i], marker='o', ls='-')
+                axIpsi.plot( roa, ipsi,  label=label, color=colors[i], marker='o', ls='-')
+                axEq.plot(   roa, q_vals,label=label, color=colors[i], marker='o', ls='-')
+
+                # Bmag vs theta for each rho
+                for irho in range(len(self.rhos)):
+                    o = self.results[label]['output'][irho]
+                    if hasattr(o, 'Bmag') and hasattr(o, 'theta_grid'):
+                        axBmag.plot(o.theta_grid / np.pi, o.Bmag,
+                                    label=f"{label} r/a={o.roa:.3f}", color=colors[i],
+                                    ls=['-','--',':','-.'][irho % 4])
+
+            axFtrap.set_xlabel("$r/a$"); axFtrap.set_xlim(_xlim); axFtrap.set_ylabel("$f_{trap}$")
+            axIpsi.set_xlabel("$r/a$");  axIpsi.set_xlim(_xlim);  axIpsi.set_ylabel("$I/\\psi'$")
+            axEq.set_xlabel("$r/a$");    axEq.set_xlim(_xlim);    axEq.set_ylabel("$q$")
+            axBmag.set_xlabel("$\\theta/\\pi$"); axBmag.set_ylabel("$|B|$ (norm.)")
+            axBmag.set_title("|B| profile vs. poloidal angle", fontsize=9)
+            for ax in [axFtrap, axIpsi, axEq, axBmag]:
+                ax.legend(loc="best", fontsize=7)
+
+        # ---- Tab 8: Normalization profiles ----
+        norm = self.NormalizationSets.get("SELECTED") if hasattr(self, 'NormalizationSets') else None
+        if norm is not None and "roa" in norm:
+            roa_prof = norm["roa"]
+            mask = (roa_prof >= _xlim[0]) & (roa_prof <= _xlim[1])
+            roa_m = roa_prof[mask]
+
+            norm_quantities = [
+                ("Te_keV",  "$T_e$",           "keV"),
+                ("Ti_keV",  "$T_i$",           "keV"),
+                ("ne_20",   "$n_e$",            "$10^{20}\\,m^{-3}$"),
+                ("ni_20",   "$n_i$",            "$10^{20}\\,m^{-3}$"),
+                ("c_s",     "$c_s$",            "m/s"),
+                ("rmin",    "$a$",              "m"),
+                ("q_gb",    "$Q_{GB}$",         "MW/m²"),
+                ("g_gb",    "$\\Gamma_{GB}$",   "$10^{20}\\,s^{-1}m^{-2}$"),
+                ("pi_gb",   "$\\Pi_{GB}$",      "N/m²"),
+                ("s_gb",    "$S_{GB}$",         "W/m³"),
+                ("B_unit",  "$B_{unit}$",       "T"),
+                ("rho_s",   "$\\rho_s$",        "m"),
+            ]
+            # filter to only those keys present in norm
+            norm_quantities = [(k, lbl, u) for k, lbl, u in norm_quantities if k in norm]
+
+            n_qty = len(norm_quantities)
+            ncols_n = 4
+            nrows_n = int(np.ceil(n_qty / ncols_n))
+
+            fig8 = self.fn.add_figure(label=f"{extratitle}NEO normalizations", tab_color=fn_color)
+            grid8 = plt.GridSpec(nrows_n, ncols_n, hspace=0.55, wspace=0.4)
+
+            for idx, (key, lbl, unit) in enumerate(norm_quantities):
+                r = idx // ncols_n
+                c = idx % ncols_n
+                ax = fig8.add_subplot(grid8[r, c])
+                vals = np.asarray(norm[key])
+                if vals.ndim == 0 or vals.shape == ():
+                    ax.axhline(float(vals), color='k', lw=1.5)
+                elif vals.shape == roa_prof.shape:
+                    ax.plot(roa_m, vals[mask], color='k', lw=1.5)
+                else:
+                    # per-species array — plot each species
+                    for sp_idx in range(vals.shape[-1] if vals.ndim > 1 else 1):
+                        v = vals[:, sp_idx] if vals.ndim > 1 else vals
+                        ax.plot(roa_m, v[mask], lw=1.5, label=f"s{sp_idx+1}")
+                    ax.legend(loc="best", fontsize=6)
+                ax.set_xlabel("$r/a$"); ax.set_xlim(_xlim)
+                ax.set_title(f"{lbl}\n({unit})", fontsize=8)
 
 
     def read_scan(
@@ -166,7 +509,7 @@ class NEO(SIMtools.mitim_simulation):
         else:
             self.fn = fn
             
-        fig1 = self.fn.add_figure(label=f"{extratitle}Summary", tab_color=fn_color)
+        fig1 = self.fn.add_figure(label=f"{extratitle}Scan Summary", tab_color=fn_color)
         
         grid = plt.GridSpec(1, 3, hspace=0.7, wspace=0.2)
 
@@ -284,7 +627,7 @@ class NEOinput(SIMtools.GACODEinput):
 class NEOoutput(SIMtools.GACODEoutput):
     def __init__(self, FolderGACODE, suffix="", **kwargs):
         super().__init__()
-        
+
         self.FolderGACODE, self.suffix = FolderGACODE, suffix
 
         if suffix == "":
@@ -297,86 +640,335 @@ class NEOoutput(SIMtools.GACODEoutput):
         self.read()
 
     def read(self):
-                
-        with open(self.FolderGACODE / ("out.neo.transport_flux" + self.suffix), "r") as f:
-            lines = f.readlines()
-            
-        if len(lines) == 0:
-            raise ValueError(f"NEO output file {self.FolderGACODE / ('out.neo.transport_flux' + self.suffix)} is empty! NEO run may have failed for these inputs.")
-            
-        for i in range(len(lines)):
-            if '# Z       pflux_tgyro   eflux_tgyro   mflux_tgyro' in lines[i]:
-                # Found the header line, now process the data
-                break
-        
-        Z, G, Q, M = [], [], [], []
-        for i in range(i+2, len(lines)):
-            line = lines[i]
-            Z.append(float(line.split()[0]))
-            G.append(float(line.split()[1]))
-            Q.append(float(line.split()[2]))
-            M.append(float(line.split()[3]))
-        Z = np.array(Z)
-        G = np.array(G)
-        Q = np.array(Q)
-        M = np.array(M)
-        
-        
-        # Find electron line (Z= -1)
-        ie = int(np.where(Z == -1)[0][0])
-        
-        self.Ge = G[ie]
-        self.Qe = Q[ie]
-        self.Me = M[ie]
-        
-        self.GiAll = np.delete(G, ie)
-        self.QiAll = np.delete(Q, ie)
-        self.MiAll = np.delete(M, ie)
 
-        self.Qi = self.QiAll.sum()
-        self.Mt = self.Me + self.MiAll.sum()
-        
+        # ---- Grid (needed to determine n_species, n_theta for other parsers) ----
+        self._read_grid()
+
+        # ---- Main fluxes (required — raises on failure) ----
+        self._read_transport_flux()
+
+        # ---- Optional output files ----
+        self._read_equil()
+        self._read_theory()
+        self._read_transport()
+        self._read_transport_gv()
+        self._read_rotation()
+        self._read_diagnostic_geo()
+        self._read_prec()
+
+        # ---- Input file text ----
+        with open(self.FolderGACODE / ("input.neo" + self.suffix), "r") as fi:
+            self.inputFile = fi.read()
+
+    # ------------------------------------------------------------------
+    # Private readers
+    # ------------------------------------------------------------------
+
+    def _read_grid(self):
+        """Read out.neo.grid → n_species, n_energy, n_xi, n_theta, theta, n_radial."""
+        filepath = self.FolderGACODE / ("out.neo.grid" + self.suffix)
+        try:
+            data = np.loadtxt(filepath)
+            self.n_species = int(data[0])
+            self.n_energy  = int(data[1])
+            self.n_xi      = int(data[2])
+            self.n_theta   = int(data[3])
+            self.theta_grid = data[4 : 4 + self.n_theta]
+            self.n_radial  = int(data[4 + self.n_theta])
+        except Exception:
+            # Fall back to defaults; transport_flux parser will set n_species
+            self.n_species = None
+            self.n_energy  = None
+            self.n_xi      = None
+            self.n_theta   = None
+            self.theta_grid = None
+            self.n_radial  = 1
+
+    def _read_transport_flux(self):
+        """Read out.neo.transport_flux — DKE, GV and tgyro sections for all species."""
+        filepath = self.FolderGACODE / ("out.neo.transport_flux" + self.suffix)
+        with open(filepath, "r") as f:
+            lines = f.readlines()
+
+        if len(lines) == 0:
+            raise ValueError(
+                f"NEO output file {filepath} is empty! NEO run may have failed."
+            )
+
         self.roa = float(lines[0].split()[-1])
 
-        # ------------------------------------------------------------------------
-        # Input file
-        # ------------------------------------------------------------------------
+        # Parse the three sections: dke, gv, tgyro
+        section_keys = {
+            'pflux_dke':   'dke',
+            'pflux_gv':    'gv',
+            'pflux_tgyro': 'tgyro',
+        }
+        sections = {}
+        current = None
+        buf = []
+        for line in lines:
+            s = line.strip()
+            if s.startswith('#'):
+                for kw, name in section_keys.items():
+                    if kw in s:
+                        if current is not None:
+                            sections[current] = buf
+                        current = name
+                        buf = []
+                        break
+            elif current is not None and s and not s.startswith('('):
+                vals = s.split()
+                if len(vals) == 4:
+                    buf.append([float(v) for v in vals])
+        if current is not None:
+            sections[current] = buf
 
-        with open(self.FolderGACODE / ("input.neo" + self.suffix), "r") as fi:
-            lines = fi.readlines()
-        self.inputFile = "".join(lines)
+        for sec, rows in sections.items():
+            arr = np.array(rows)           # (n_species, 4): Z, pflux, eflux, mflux
+            Z = arr[:, 0]
+            G = arr[:, 1]
+            Q = arr[:, 2]
+            M = arr[:, 3]
+            ie = int(np.where(Z == -1)[0][0])
+
+            if sec == 'tgyro':
+                self.Ge     = G[ie];  self.Qe = Q[ie];  self.Me = M[ie]
+                self.GiAll  = np.delete(G, ie)
+                self.QiAll  = np.delete(Q, ie)
+                self.MiAll  = np.delete(M, ie)
+                self.Zi     = np.delete(Z, ie)
+                self.Qi     = self.QiAll.sum()
+                self.Mt     = self.Me + self.MiAll.sum()
+                if self.n_species is None:
+                    self.n_species = len(Z)
+            elif sec == 'dke':
+                self.Ge_dke    = G[ie];  self.Qe_dke = Q[ie];  self.Me_dke = M[ie]
+                self.GiAll_dke = np.delete(G, ie)
+                self.QiAll_dke = np.delete(Q, ie)
+                self.MiAll_dke = np.delete(M, ie)
+                self.Qi_dke    = self.QiAll_dke.sum()
+            elif sec == 'gv':
+                self.Ge_gv    = G[ie];  self.Qe_gv = Q[ie];  self.Me_gv = M[ie]
+                self.GiAll_gv = np.delete(G, ie)
+                self.QiAll_gv = np.delete(Q, ie)
+                self.MiAll_gv = np.delete(M, ie)
+                self.Qi_gv    = self.QiAll_gv.sum()
+
+    def _read_equil(self):
+        """Read out.neo.equil → q, omega0, domega0dr, n/T/a_Ln/a_Lt/nu per species."""
+        filepath = self.FolderGACODE / ("out.neo.equil" + self.suffix)
+        try:
+            eq = np.atleast_2d(np.loadtxt(filepath))[0]   # single-radius row
+            self.dphidr     = float(eq[1])
+            self.q          = float(eq[2])
+            self.rho_star   = float(eq[3])
+            self.R0_over_a  = float(eq[4])
+            self.omega0     = float(eq[5])
+            self.domega0dr  = float(eq[6])
+            # per-species arrays (all species, including electrons at index -1)
+            self.n_norm     = eq[7 + 0 :: 5]
+            self.T_norm     = eq[7 + 1 :: 5]
+            self.a_over_ln  = eq[7 + 2 :: 5]
+            self.a_over_lt  = eq[7 + 3 :: 5]
+            self.tauinv     = eq[7 + 4 :: 5]
+        except Exception:
+            pass
+
+    def _read_theory(self):
+        """Read out.neo.theory → Hinton-Hazeltine, Chang-Hinton, Taguchi-Gyro predictions."""
+        filepath = self.FolderGACODE / ("out.neo.theory" + self.suffix)
+        try:
+            d = np.atleast_2d(np.loadtxt(filepath))[0]
+            self.HHGamma  = float(d[1])
+            self.HHQi     = float(d[2])
+            self.HHQe     = float(d[3])
+            self.HHjparB  = float(d[4])
+            self.HHk      = float(d[5])
+            self.HHuparB  = float(d[6])
+            self.HHvtheta = float(d[7])
+            self.CHQi     = float(d[8])
+            self.TGQi     = float(d[9])
+            self.SjparB   = float(d[10])
+            self.Sk       = float(d[11])
+            self.SuparB   = float(d[12])
+            self.Svtheta  = float(d[13])
+            self.HRphisq  = float(d[14])
+            # per-species: HSGamma[is], HSQ[is], KjparB[is]
+            self.HSGamma  = d[15 + 0 :: 3]
+            self.HSQ      = d[15 + 1 :: 3]
+            self.KjparB   = d[15 + 2 :: 3]
+        except Exception:
+            pass
+
+    def _read_transport(self):
+        """Read out.neo.transport → jparB, vtheta0, uparB0, and per-species flows/fluxes."""
+        filepath = self.FolderGACODE / ("out.neo.transport" + self.suffix)
+        try:
+            d = np.atleast_2d(np.loadtxt(filepath))[0]
+            # d[0]=r/a, d[1]=phisq, d[2]=jparB, d[3]=vtheta0, d[4]=uparB0
+            # then per species (8 cols each): Gamma, Q, Pi, uparB, k, K, vtheta, vphi
+            self.phisq    = float(d[1])
+            self.jparB    = float(d[2])
+            self.vtheta0  = float(d[3])
+            self.uparB0   = float(d[4])
+            self.Gamma_sp = d[5  :: 8]
+            self.Q_sp     = d[6  :: 8]
+            self.Pi_sp    = d[7  :: 8]
+            self.uparB_sp = d[8  :: 8]
+            self.k_sp     = d[9  :: 8]
+            self.K_sp     = d[10 :: 8]
+            self.vtheta_sp= d[11 :: 8]
+            self.vphi_sp  = d[12 :: 8]
+        except Exception:
+            pass
+
+    def _read_transport_gv(self):
+        """Read out.neo.transport_gv → GV contribution per species (Gamma, Q, Pi)."""
+        filepath = self.FolderGACODE / ("out.neo.transport_gv" + self.suffix)
+        try:
+            d = np.atleast_2d(np.loadtxt(filepath))[0]
+            self.Gamma_gv_sp = d[1 + 0 :: 3]
+            self.Q_gv_sp     = d[1 + 1 :: 3]
+            self.Pi_gv_sp    = d[1 + 2 :: 3]
+        except Exception:
+            pass
+
+    def _read_rotation(self):
+        """Read out.neo.rotation → dphi_ave, n_ratio, V_conv, phi_theta(theta), n_ov_n0."""
+        filepath = self.FolderGACODE / ("out.neo.rotation" + self.suffix)
+        try:
+            d = np.loadtxt(filepath)
+            ns = self.n_species if self.n_species is not None else (len(d) - 1) // 2
+            nt = self.n_theta   if self.n_theta   is not None else 17
+            self.dphi_ave  = float(d[1])
+            # n_ratio and V_conv are interleaved: n_ratio[0], V_conv[0], n_ratio[1], ...
+            self.n_ratio   = d[2 : 2 + ns * 2 : 2]
+            self.V_conv    = d[3 : 3 + ns * 2 : 2]
+            N = ns * 2 + 2
+            self.phi_theta = d[N : N + nt]       # rotation potential vs theta
+            N += nt
+            # density ratio n(theta)/n0 reshaped to (n_species, n_theta)
+            n_ov_n0_flat = d[N:]
+            if len(n_ov_n0_flat) == ns * nt:
+                self.n_ov_n0 = n_ov_n0_flat.reshape(ns, nt)
+        except Exception:
+            pass
+
+    def _read_diagnostic_geo(self):
+        """Read out.neo.diagnostic_geo → f_trap, I/psi', Bmag(theta), and geo scalars."""
+        filepath = self.FolderGACODE / ("out.neo.diagnostic_geo" + self.suffix)
+        try:
+            with open(filepath, "r") as f:
+                lines = f.readlines()
+
+            for line in lines:
+                s = line.strip()
+                if "I/psi'" in s:
+                    self.I_over_psip = float(s.split('=')[-1])
+                elif "f_trap" in s:
+                    self.f_trap = float(s.split('=')[-1])
+                elif "n_theta" in s:
+                    nt = int(s.split('=')[-1])
+
+            # Collect all data values (non-comment lines)
+            vals = []
+            for line in lines:
+                if not line.strip().startswith('#') and line.strip():
+                    vals.append(float(line.strip()))
+            vals = np.array(vals)
+
+            # Layout: theta(nt), v_drift_x(nt), gradpar_Bmag(nt), Bmag(nt), w_theta(nt), R(nt), R0(1), dR0dr(1)
+            if self.theta_grid is None and len(vals) >= nt:
+                self.theta_grid = vals[:nt]
+            if len(vals) >= 4 * nt:
+                self.Bmag       = vals[3 * nt : 4 * nt]
+                self.w_theta    = vals[4 * nt : 5 * nt]
+                self.v_drift_x  = vals[nt     : 2 * nt]
+        except Exception:
+            pass
+
+        # Also read the compact scalar file (diagnostic_geo2)
+        filepath2 = self.FolderGACODE / ("out.neo.diagnostic_geo2" + self.suffix)
+        try:
+            geo2 = np.loadtxt(filepath2)
+            # geo2[0]=I/psi', geo2[1]=f_trap, geo2[2]=<B^2>, geo2[3]=Bpol(theta=0), geo2[4]=<1/B^2><B^2>-1
+            if not hasattr(self, 'I_over_psip'):
+                self.I_over_psip = float(geo2[0])
+            if not hasattr(self, 'f_trap'):
+                self.f_trap      = float(geo2[1])
+            self.Bmag2_avg   = float(geo2[2])
+            self.Bpol_th0    = float(geo2[3])
+        except Exception:
+            pass
+
+    def _read_prec(self):
+        """Read out.neo.prec → solver convergence metric."""
+        filepath = self.FolderGACODE / ("out.neo.prec" + self.suffix)
+        try:
+            self.prec = float(np.loadtxt(filepath))
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Unnormalization
+    # ------------------------------------------------------------------
 
     def unnormalize(self, normalization, rho=None):
-        
+
         if normalization is not None:
             print("\t- Unnormalizing NEO results using the provided normalization factors")
             rho_x = normalization["rho"]
             roa_x = normalization["roa"]
-            q_gb = normalization["q_gb"]
-            g_gb = normalization["g_gb"]
+            q_gb  = normalization["q_gb"]
+            g_gb  = normalization["g_gb"]
             pi_gb = normalization["pi_gb"]
-            s_gb = normalization["s_gb"]
+            s_gb  = normalization["s_gb"]
             rho_s = normalization["rho_s"]
-            a = normalization["rmin"][-1]
-
-            # ------------------------------------
-            # Usage of normalization quantities
-            # ------------------------------------
+            a     = normalization["rmin"][-1]   # LCFS minor radius [m]
+            ne_20 = normalization["ne_20"]       # electron density [1e20/m^3]
+            c_s   = normalization["c_s"]         # ion sound speed [m/s]
 
             if rho is None:
                 ir = np.argmin(np.abs(roa_x - self.roa))
-                rho_eval = rho_x[ir]
             else:
                 ir = np.argmin(np.abs(rho_x - rho))
-                rho_eval = rho
 
-            self.Qe_unn = self.Qe * q_gb[ir]
-            self.Qi_unn = self.Qi * q_gb[ir]
-            self.QiAll_unn = self.QiAll * q_gb[ir]
-            self.Ge_unn = self.Ge * g_gb[ir]
-            self.GiAll_unn = self.GiAll * g_gb[ir]
-            self.MiAll_unn = self.MiAll * g_gb[ir]
-            self.Mt_unn = self.Mt * s_gb[ir]
+            # ---- Fluxes (already existing) ----
+            self.Qe_unn     = self.Qe     * q_gb[ir]
+            self.Qi_unn     = self.Qi     * q_gb[ir]
+            self.QiAll_unn  = self.QiAll  * q_gb[ir]
+            self.Ge_unn     = self.Ge     * g_gb[ir]
+            self.GiAll_unn  = self.GiAll  * g_gb[ir]
+            self.MiAll_unn  = self.MiAll  * g_gb[ir]
+            self.Mt_unn     = self.Mt     * s_gb[ir]
+
+            # ---- Bootstrap current ----
+            # From NEO source: jpar_phys [kA/m^2] = jpar_GB * e * ne(r) * cs(r) * a * 1e-3
+            # (quantity is <j·B>/B_unit in kA/m^2)
+            _e   = 1.602e-19                        # elementary charge [C]
+            _ne  = ne_20[ir] * 1e20                 # electron density [m^-3]
+            _cs  = c_s[ir]                          # sound speed [m/s]
+            _j_factor = _e * _ne * _cs * a * 1e-3   # [kA/m^2] per GB unit
+
+            if hasattr(self, 'jparB'):
+                self.jparB_unn   = self.jparB   * _j_factor   # [kA/m^2]
+            if hasattr(self, 'HHjparB'):
+                self.HHjparB_unn = self.HHjparB * _j_factor
+            if hasattr(self, 'SjparB'):
+                self.SjparB_unn  = self.SjparB  * _j_factor
+
+            # ---- Velocities: v_phys [m/s] = v_GB * cs * a ----
+            _v_factor = _cs * a
+            if hasattr(self, 'uparB0'):
+                self.uparB0_unn   = self.uparB0   * _v_factor
+            if hasattr(self, 'vtheta0'):
+                self.vtheta0_unn  = self.vtheta0  * _v_factor
+            if hasattr(self, 'uparB_sp'):
+                self.uparB_sp_unn  = self.uparB_sp  * _v_factor
+            if hasattr(self, 'vtheta_sp'):
+                self.vtheta_sp_unn = self.vtheta_sp * _v_factor
+            if hasattr(self, 'vphi_sp'):
+                self.vphi_sp_unn   = self.vphi_sp   * _v_factor
 
             self.unnormalization_successful = True
 

--- a/src/mitim_tools/gacode_tools/TGLFtools.py
+++ b/src/mitim_tools/gacode_tools/TGLFtools.py
@@ -439,6 +439,21 @@ class TGLF(SIMtools.mitim_simulation):
                 if isinstance(v, np.ndarray):
                     arrays[spfx + k] = v.astype(np.float32)
 
+        # ---- 2-D scan data (aggregated arrays from read_scan2d) ----
+        scans2d = getattr(self, "scans2d", {})
+        scan2d_configs = getattr(self, "scan2d_configs", {})
+        meta["scan2d_labels"] = list(scans2d.keys())
+        meta["scan2d_configs"] = scan2d_configs
+        for scan_label in scans2d:
+            scan = scans2d[scan_label]
+            spfx = f"scan2d__{scan_label}__"
+            meta[f"{spfx}variable1"] = scan.get("variable1", "")
+            meta[f"{spfx}variable2"] = scan.get("variable2", "")
+            meta[f"{spfx}ky_target"] = float(scan.get("ky_target", 0.3))
+            for k, v in scan.items():
+                if isinstance(v, np.ndarray):
+                    arrays[spfx + k] = v.astype(np.float32)
+
         # ---- Metadata packed as JSON bytes ----
         meta_bytes = np.frombuffer(json.dumps(meta).encode("utf-8"), dtype=np.uint8)
         arrays["__meta__"] = meta_bytes
@@ -626,6 +641,25 @@ class TGLF(SIMtools.mitim_simulation):
             # float32 round-trip precision drift that breaks == comparisons in plot_scan
             scan["x"] = np.array(meta["rhos"])
             tglf.scans[scan_label] = scan
+
+        # ---- Restore 2-D scan data ----
+        tglf.scan2d_configs = meta.get("scan2d_configs", {})
+        # subfolder_scan: the last subfolder used; infer from configs if possible
+        _cfg_keys = list(tglf.scan2d_configs.keys())
+        tglf.subfolder_scan = _cfg_keys[-1] if _cfg_keys else getattr(tglf, "subfolder_scan", None)
+        tglf.scans2d = {}
+        for scan_label in meta.get("scan2d_labels", []):
+            spfx = f"scan2d__{scan_label}__"
+            scan = {}
+            scan["variable1"]  = meta.get(f"{spfx}variable1", "")
+            scan["variable2"]  = meta.get(f"{spfx}variable2", "")
+            scan["ky_target"]  = float(meta.get(f"{spfx}ky_target", 0.3))
+            scan["x"] = np.array(meta["rhos"])
+            for key in data.files:
+                if key.startswith(spfx):
+                    k = key[len(spfx):]
+                    scan[k] = data[key].astype(np.float64)
+            tglf.scans2d[scan_label] = scan
 
         print(f"> Loaded TGLF results from {IOtools.clipstr(file)} "
               f"({len(tglf.results)} label(s), {len(tglf.rhos)} rho(s))")
@@ -2380,6 +2414,341 @@ class TGLF(SIMtools.mitim_simulation):
                     if d.is_dir():
                         shutil.rmtree(d)
                         print(f"\t- Removed raw scan folder: {IOtools.clipstr(d)}", typeMsg="i")
+
+    # =========================================================================
+    # 2-D parameter scan
+    # =========================================================================
+
+    def run_scan2d(
+        self,
+        subfolder,
+        variable1,
+        varUpDown1,
+        variable2,
+        varUpDown2,
+        save_and_cleanup=None,
+        **kwargs_run,
+    ):
+        """
+        Run a 2-D grid scan varying two TGLF input parameters simultaneously.
+
+        All (mult1, mult2) combinations are prepared in a single code_executor
+        and submitted together for efficiency.  Folder names follow the pattern:
+          {subfolder}_{variable1}_{mult1}_{variable2}_{mult2}
+
+        kwargs_run is forwarded to _run_prepare / _run (code_settings, extraOptions,
+        cold_start, slurm_setup, …).
+        """
+        self.subfolder_scan = subfolder
+        if not hasattr(self, "scan2d_configs"):
+            self.scan2d_configs = {}
+        varUpDown1 = list(varUpDown1)
+        varUpDown2 = list(varUpDown2)
+        self.scan2d_configs[subfolder] = {
+            "variable1": variable1, "varUpDown1": varUpDown1,
+            "variable2": variable2, "varUpDown2": varUpDown2,
+        }
+
+        code_executor = {}
+        code_executor_full = {}
+        folders = {}
+        first = True
+
+        for mult1 in varUpDown1:
+            m1 = round(float(mult1), 6)
+            for mult2 in varUpDown2:
+                m2 = round(float(mult2), 6)
+                run_name = f"{subfolder}_{variable1}_{m1}_{variable2}_{m2}"
+                kw = dict(kwargs_run)
+                kw["forceIfcold_start"] = (not first) or kw.get("forceIfcold_start", False)
+                code_executor, code_executor_full = self._run_prepare(
+                    run_name,
+                    code_executor=code_executor,
+                    code_executor_full=code_executor_full,
+                    multipliers={variable1: m1, variable2: m2},
+                    **kw,
+                )
+                folders[(m1, m2)] = copy.deepcopy(self.FolderSimLast)
+                first = False
+
+        self._run(code_executor, code_executor_full=code_executor_full, **kwargs_run)
+
+        for mult1 in varUpDown1:
+            m1 = round(float(mult1), 6)
+            for mult2 in varUpDown2:
+                m2 = round(float(mult2), 6)
+                run_name = f"{subfolder}_{variable1}_{m1}_{variable2}_{m2}"
+                self.read(
+                    label=run_name,
+                    folder=folders[(m1, m2)],
+                    cold_startWF=False,
+                    require_all_files=not kwargs_run.get("only_minimal_files", False),
+                )
+
+        if save_and_cleanup is not None:
+            self.save_npz(save_and_cleanup)
+            import shutil
+            for d in sorted(self.FolderGACODE.glob(f"{subfolder}_*")):
+                if d.is_dir():
+                    shutil.rmtree(d)
+                    print(f"\t- Removed raw scan folder: {IOtools.clipstr(d)}", typeMsg="i")
+
+    def read_scan2d(
+        self,
+        label,
+        subfolder=None,
+        variable1=None,
+        varUpDown1=None,
+        variable2=None,
+        varUpDown2=None,
+        ion_OI_position_in_total_padded_list=3,
+        ky_target=0.3,
+    ):
+        """
+        Aggregate 2-D scan results into self.scans2d[label].
+
+        Arrays in scans2d[label] have shape (n_rhos, n1, n2).
+        """
+        if subfolder is None:
+            subfolder = getattr(self, "subfolder_scan", None)
+        if not hasattr(self, "scan2d_configs"):
+            self.scan2d_configs = {}
+        cfg = self.scan2d_configs.get(subfolder, {})
+        variable1   = variable1   or cfg.get("variable1")
+        varUpDown1  = list(varUpDown1  if varUpDown1  is not None else cfg.get("varUpDown1",  []))
+        variable2   = variable2   or cfg.get("variable2")
+        varUpDown2  = list(varUpDown2  if varUpDown2  is not None else cfg.get("varUpDown2",  []))
+
+        ion_idx = ion_OI_position_in_total_padded_list - 2
+
+        if not hasattr(self, "scans2d"):
+            self.scans2d = {}
+
+        n1, n2, nr = len(varUpDown1), len(varUpDown2), len(self.rhos)
+
+        arrs = {k: np.full((nr, n1, n2), np.nan)
+                for k in ("Qe_gb", "Qi_gb", "Ge_gb", "Gi_gb", "g_ky")}
+        v1_abs = np.full((nr, n1, n2), np.nan)
+        v2_abs = np.full((nr, n1, n2), np.nan)
+
+        # Find n_ky from the first available result so we can pre-allocate spectra arrays.
+        n_ky = None
+        for _m1 in varUpDown1:
+            for _m2 in varUpDown2:
+                _rk = f"{subfolder}_{variable1}_{round(float(_m1),6)}_{variable2}_{round(float(_m2),6)}"
+                if _rk in self.results and self.results[_rk]["output"]:
+                    _out0 = self.results[_rk]["output"][0]
+                    if hasattr(_out0, "ky") and _out0.ky is not None:
+                        n_ky = len(_out0.ky)
+                        break
+            if n_ky is not None:
+                break
+
+        if n_ky is not None:
+            ky_arr     = np.full((nr, n_ky), np.nan)
+            g_spectra  = np.full((nr, n1, n2, n_ky), np.nan)   # growth rate spectrum
+            f_spectra  = np.full((nr, n1, n2, n_ky), np.nan)   # real frequency spectrum
+        else:
+            ky_arr = g_spectra = f_spectra = None
+
+        for i1, mult1 in enumerate(varUpDown1):
+            m1 = round(float(mult1), 6)
+            for i2, mult2 in enumerate(varUpDown2):
+                m2    = round(float(mult2), 6)
+                rkey  = f"{subfolder}_{variable1}_{m1}_{variable2}_{m2}"
+                if rkey not in self.results:
+                    print(f"\t- Result not found: {rkey}", typeMsg="w")
+                    continue
+                for irho in range(nr):
+                    out    = self.results[rkey]["output"][irho]
+                    parsed = self.results[rkey]["parsed"][irho]
+                    arrs["Qe_gb"][irho, i1, i2] = out.Qe
+                    arrs["Qi_gb"][irho, i1, i2] = out.Qi
+                    arrs["Ge_gb"][irho, i1, i2] = out.Ge
+                    arrs["Gi_gb"][irho, i1, i2] = float(out.GiAll[ion_idx]) if hasattr(out, "GiAll") and len(out.GiAll) > ion_idx else np.nan
+                    ky_idx = int(np.argmin(np.abs(out.ky - ky_target)))
+                    arrs["g_ky"][irho, i1, i2]  = float(out.g[0, ky_idx])
+                    if parsed:
+                        v1_abs[irho, i1, i2] = float(parsed.get(variable1, np.nan))
+                        v2_abs[irho, i1, i2] = float(parsed.get(variable2, np.nan))
+
+                    # Full spectra (most-unstable mode, index 0)
+                    if n_ky is not None and hasattr(out, "g") and out.g is not None:
+                        if out.g.shape[1] == n_ky:
+                            g_spectra[irho, i1, i2, :] = out.g[0, :]
+                    if n_ky is not None and hasattr(out, "f") and out.f is not None:
+                        if out.f.shape[1] == n_ky:
+                            f_spectra[irho, i1, i2, :] = out.f[0, :]
+                    if n_ky is not None and hasattr(out, "ky") and out.ky is not None:
+                        if len(out.ky) == n_ky:
+                            ky_arr[irho, :] = out.ky
+
+        self.scans2d[label] = {
+            "variable1": variable1, "varUpDown1": np.array(varUpDown1),
+            "variable2": variable2, "varUpDown2": np.array(varUpDown2),
+            "x": np.array(self.rhos),
+            "v1_abs": v1_abs, "v2_abs": v2_abs,
+            "ky_target": ky_target,
+            **arrs,
+            "ky": ky_arr,
+            "g_spectra": g_spectra,
+            "f_spectra": f_spectra,
+        }
+
+    def plot_scan2d(self, label, fn=None):
+        """
+        Filled contour plots of 2-D scan results (one tab per quantity, one
+        column per rho).  Axes are the absolute parameter values from v1_abs /
+        v2_abs (falling back to the multiplier arrays when not available).
+        """
+        scan = self.scans2d[label]
+        rhos       = scan["x"]
+        nr         = len(rhos)
+        variable1  = scan["variable1"]
+        variable2  = scan["variable2"]
+        ky_target  = scan.get("ky_target", 0.3)
+
+        quantities = [
+            ("Qe_gb", "Qe (GB)",              r"$Q_e$ (GB)"),
+            ("Qi_gb", "Qi (GB)",              r"$Q_i$ (GB)"),
+            ("Ge_gb", "Ge (GB)",              r"$\Gamma_e$ (GB)"),
+            ("g_ky",  f"gamma at ky~{ky_target}", rf"$\gamma$ at $k_\theta\rho_s\approx{ky_target}$"),
+        ]
+
+        n1 = len(scan["varUpDown1"])
+        n2 = len(scan["varUpDown2"])
+
+        if fn is None:
+            self.fn = GUItools.FigureNotebook("TGLF 2D Scan", geometry="1500x900", vertical=True)
+            fn = self.fn
+
+        # ---- Scalar contourf tabs (Qe, Qi, Ge, g at ky_target) ----
+        for qkey, tab_label, qtitle in quantities:
+            fig = fn.add_figure(label=tab_label)
+            grid = plt.GridSpec(1, nr, hspace=0.4, wspace=0.4, figure=fig)
+
+            for irho in range(nr):
+                ax = fig.add_subplot(grid[0, irho])
+
+                Z = scan[qkey][irho]           # (n1, n2)
+                # Use absolute values where available, else multipliers
+                x1 = scan["v1_abs"][irho, :, 0]
+                x2 = scan["v2_abs"][irho, 0, :]
+                if np.any(np.isnan(x1)):
+                    x1 = scan["varUpDown1"]
+                if np.any(np.isnan(x2)):
+                    x2 = scan["varUpDown2"]
+
+                X1, X2 = np.meshgrid(x1, x2, indexing="ij")
+
+                finite = Z[np.isfinite(Z)]
+                if finite.size < 3:
+                    ax.set_title(f"{qtitle}\nr/a={rhos[irho]:.3f}")
+                    ax.text(0.5, 0.5, "no data", transform=ax.transAxes, ha="center")
+                    continue
+
+                vmin, vmax = finite.min(), finite.max()
+                levels = np.linspace(vmin, vmax, 21)
+
+                cf = ax.contourf(X1, X2, Z, levels=levels, cmap="inferno")
+                ax.contour(X1, X2, Z, levels=levels[::4], colors="white",
+                           linewidths=0.4, alpha=0.5)
+                plt.colorbar(cf, ax=ax, pad=0.02)
+
+                ax.set_xlabel(variable1, fontsize=8)
+                ax.set_ylabel(variable2, fontsize=8)
+                ax.set_title(f"r/a = {rhos[irho]:.3f}", fontsize=9)
+
+            fig.suptitle(qtitle, fontsize=10)
+
+        # ---- Spectral tabs: one tab per rho, rows = γ / ω, columns = variable2 values ----
+        #
+        # Each panel is a pcolormesh:
+        #   x-axis → variable1 values  (how the spectrum shifts with scan variable 1)
+        #   y-axis → k_θρ_s            (wavenumber axis)
+        #   colour → γ (inferno, clipped ≥0) or ω (RdBu_r diverging)
+        # Colourbar range is per-panel (not shared).
+
+        g_spectra = scan.get("g_spectra")   # (nr, n1, n2, n_ky) or None
+        f_spectra = scan.get("f_spectra")
+        ky_arr    = scan.get("ky")          # (nr, n_ky) or None
+        has_g = g_spectra is not None and not np.all(np.isnan(g_spectra))
+        has_f = f_spectra is not None and not np.all(np.isnan(f_spectra))
+        n_spec_rows = int(has_g) + int(has_f)
+
+        if n_spec_rows > 0:
+            spec_rows = []
+            if has_g:
+                spec_rows.append((g_spectra, r"$\gamma(k_\theta\rho_s)$", "inferno", False))
+            if has_f:
+                spec_rows.append((f_spectra, r"$\omega(k_\theta\rho_s)$", "RdBu_r",  True))
+
+            for irho in range(nr):
+                fig = fn.add_figure(label=f"spectra r/a={rhos[irho]:.2f}")
+                grid = plt.GridSpec(n_spec_rows, n2, hspace=0.55, wspace=0.15, figure=fig)
+
+                ky = ky_arr[irho] if ky_arr is not None else None
+                if ky is None or np.all(np.isnan(ky)):
+                    ky = np.arange(g_spectra.shape[-1] if has_g else f_spectra.shape[-1], dtype=float)
+
+                v1_vals = scan["v1_abs"][irho, :, 0]
+                if np.any(np.isnan(v1_vals)):
+                    v1_vals = scan["varUpDown1"].astype(float)
+
+                v2_vals = scan["v2_abs"][irho, 0, :]
+                if np.any(np.isnan(v2_vals)):
+                    v2_vals = scan["varUpDown2"].astype(float)
+
+                for irow, (spectra, row_title, cmap_name, diverging) in enumerate(spec_rows):
+                    for i2 in range(n2):
+                        ax = fig.add_subplot(grid[irow, i2])
+
+                        Z = spectra[irho, :, i2, :]    # (n1, n_ky)
+                        if not diverging:
+                            Z = np.clip(Z, 0.0, None)  # γ<0 → black (stable)
+
+                        # Per-panel colour range
+                        finite = Z[np.isfinite(Z)]
+                        if finite.size == 0:
+                            ax.set_visible(False)
+                            continue
+                        if diverging:
+                            clim = float(np.nanmax(np.abs(finite)))
+                            vmin_p, vmax_p = -clim, clim
+                        else:
+                            vmin_p, vmax_p = 0.0, float(np.nanmax(finite))
+
+                        mesh = ax.pcolormesh(
+                            v1_vals, ky, Z.T,
+                            cmap=cmap_name, vmin=vmin_p, vmax=vmax_p,
+                            shading="nearest",
+                        )
+
+                        # Dashed line at the scalar ky_target
+                        ax.axhline(ky_target, color="lime", lw=0.8, ls="--", alpha=0.7)
+
+                        cb = plt.colorbar(mesh, ax=ax, pad=0.04, fraction=0.06)
+                        cb.ax.tick_params(labelsize=6)
+
+                        # Axis labels on edges only
+                        if irow == n_spec_rows - 1:
+                            ax.set_xlabel(variable1, fontsize=7)
+                        else:
+                            ax.set_xticklabels([])
+                        if i2 == 0:
+                            ax.set_ylabel(r"$k_\theta\rho_s$", fontsize=8)
+                        else:
+                            ax.set_yticklabels([])
+
+                        ax.tick_params(labelsize=6)
+                        ax.set_title(f"{variable2}={v2_vals[i2]:.2f}", fontsize=7)
+
+                        # Row label on leftmost panel
+                        if i2 == 0:
+                            ax.text(-0.35, 0.5, row_title, transform=ax.transAxes,
+                                    fontsize=8, va="center", ha="center", rotation=90)
+
+                fig.suptitle(f"Instability spectra  r/a = {rhos[irho]:.3f}", fontsize=10)
 
     def plot_scan(
         self,

--- a/src/mitim_tools/gacode_tools/TGLFtools.py
+++ b/src/mitim_tools/gacode_tools/TGLFtools.py
@@ -20,6 +20,7 @@ from mitim_tools.gacode_tools.utils import (
     GACODEdefaults,
     GACODEplotting,
     GACODErun,
+    GACODEinprocess,
 )
 from mitim_tools.simulation_tools import SIMtools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
@@ -29,7 +30,19 @@ from mitim_tools.misc_tools.PLASMAtools import md_u
 
 MAX_TGLF_SPECIES = 6
 
-class TGLF(SIMtools.mitim_simulation):
+class TGLF(SIMtools.mitim_simulation, GACODEinprocess.TGLFInProcess):
+    """
+    TGLF wrapper.  Uses multiple inheritance to combine two engines:
+
+    * ``SIMtools.mitim_simulation`` — the standard subprocess / SLURM engine
+      (the file-based ``prep`` / ``_run_prepare`` / ``_run`` / ``read``).
+    * ``GACODEinprocess.TGLFInProcess`` — the pure in-process (ctypes)
+      mixin providing ``prep_inprocess`` / ``_run_prepare_inprocess`` /
+      ``_run_inprocess`` / ``read_inprocess``.
+
+    The four small dispatch methods below decide between the two engines
+    based on the ``self.in_process`` flag set at construction time.
+    """
     def __init__(
         self,
         rhos=[0.4, 0.6],  # rho locations of interest
@@ -40,8 +53,10 @@ class TGLF(SIMtools.mitim_simulation):
         alreadyRun=None,  # Option2: Do more stuff with a class that has already been created and store
     ):
 
-        super().__init__(rhos=rhos)
+        SIMtools.mitim_simulation.__init__(self, rhos=rhos)
         self.in_process = in_process
+        # In-process result cache (lazy-init via mixin); harmless when not used.
+        self._init_inprocess()
 
         def code_call(folder, p, n = 1, additional_command="", **kwargs):
             return f"tglf -e {folder} -n {n} -p {p} {additional_command}"
@@ -139,203 +154,36 @@ class TGLF(SIMtools.mitim_simulation):
                 "SELECTED": None,
             }
 
-            self._inprocess_cache: dict = {}   # {subfolder: raw {rho: outputs_dict}}
+    # ------------------------------------------------------------------
+    # In-process / subprocess dispatch.  Each method picks the engine
+    # based on self.in_process and forwards to either:
+    #   * GACODEinprocess.TGLFInProcess.<method>_inprocess  (in-process)
+    #   * SIMtools.mitim_simulation.<method> via super()    (subprocess)
+    # The actual physics/IO logic lives in those two parents — these
+    # dispatchers are intentionally tiny.
+    # ------------------------------------------------------------------
 
     def prep(self, mitim_state, FolderGACODE=None, **kwargs):
-        """
-        Prepare the TGLF run from a MITIM state (input.gacode path or object).
+        if self.in_process:
+            # In-process needs no folder — anything passed for FolderGACODE
+            # is silently ignored, and a synthetic in-memory path is used
+            # internally for cache keys.
+            return self.prep_inprocess(mitim_state)
+        return super().prep(mitim_state, FolderGACODE, **kwargs)
 
-        When ``self.in_process=True``, *FolderGACODE* is optional.  If omitted
-        a temporary directory is used as a logical base path — nothing is ever
-        written to it.  No ``input.tglf*`` or ``input.gacode_torun`` files are
-        created.
+    def _run_prepare(self, subfolder_simulation, **kwargs):
+        if self.in_process:
+            return self._run_prepare_inprocess(subfolder_simulation, **kwargs)
+        return super()._run_prepare(subfolder_simulation, **kwargs)
 
-        When ``self.in_process=False`` the behaviour is identical to the parent:
-        *FolderGACODE* is required and all files are written normally.
-        """
-        if not self.in_process:
-            return super().prep(mitim_state, FolderGACODE, **kwargs)
+    def _run(self, code_executor, **kwargs):
+        if self.in_process:
+            return self._run_inprocess(code_executor, **kwargs)
+        return super()._run(code_executor, **kwargs)
 
-        # ------------------------------------------------------------------
-        # Zero-file in-process prep
-        # ------------------------------------------------------------------
-        import tempfile
-        from mitim_tools.gacode_tools import PROFILEStools
-        from mitim_tools.gacode_tools.utils import NORMtools
-        from mitim_tools.misc_tools.PLASMAtools import md_u
-
-        # Use the provided folder as a logical base (no mkdir); fall back to temp.
-        if FolderGACODE is None:
-            self.FolderGACODE = Path(tempfile.mkdtemp(prefix="tglf_inprocess_"))
-        else:
-            self.FolderGACODE = Path(FolderGACODE).resolve()
-
-        # Load profiles
-        if isinstance(mitim_state, (str, Path)):
-            self.profiles = PROFILEStools.gacode_state(str(mitim_state))
-        else:
-            self.profiles = mitim_state
-
-        self.profiles.derive_quantities(mi_ref=md_u)
-
-        # Build TGLFinput objects in memory — no files written
-        raw = self.profiles.to_tglf(r=self.rhos, r_is_rho=True)
-        self.inputs_files = {}
-        for rho, d in raw.items():
-            inp = TGLFinput.initialize_in_memory(d)
-            # Set a logical (never-created) file path so later code that
-            # inspects inp.file doesn't hit AttributeError
-            inp.file = self.FolderGACODE / f"input.tglf_{float(rho):.4f}"
-            self.inputs_files[rho] = inp
-
-        # Normalizations (pure in-memory)
-        print("> Setting up normalizations")
-        self.NormalizationSets, cdf = NORMtools.normalizations(self.profiles)
-        return cdf
-
-    def _run_prepare(self, subfolder_simulation, code_executor=None, code_executor_full=None,
-                     code_settings=None, extraOptions={}, multipliers={}, minimum_delta_abs={},
-                     cold_start=False, forceIfcold_start=False, only_minimal_files=False,
-                     launchSlurm=True, slurm_setup=None, additional_files_to_send=None,
-                     **kwargs_control):
-        """
-        When ``self.in_process=True``: build TGLFinput objects in memory via
-        ``modifyInputs()`` — no folder creation, no file writes.
-        When ``self.in_process=False``: delegate to the parent implementation.
-        """
-        if not self.in_process:
-            return super()._run_prepare(
-                subfolder_simulation,
-                code_executor=code_executor,
-                code_executor_full=code_executor_full,
-                code_settings=code_settings,
-                extraOptions=extraOptions,
-                multipliers=multipliers,
-                minimum_delta_abs=minimum_delta_abs,
-                cold_start=cold_start,
-                forceIfcold_start=forceIfcold_start,
-                only_minimal_files=only_minimal_files,
-                launchSlurm=launchSlurm,
-                slurm_setup=slurm_setup,
-                additional_files_to_send=additional_files_to_send,
-                **kwargs_control,
-            )
-
-        # ------------------------------------------------------------------
-        # Zero-file in-process path
-        # ------------------------------------------------------------------
-        from mitim_tools.simulation_tools.SIMtools import modifyInputs
-
-        if code_executor is None:
-            code_executor = {}
-        if code_executor_full is None:
-            code_executor_full = {}
-
-        # Compute the logical folder path (never created on disk)
-        Folder_sim = (self.FolderGACODE / subfolder_simulation).resolve()
-
-        inputs = copy.deepcopy(self.inputs_files)
-
-        mod_input_file = {}
-        for i, rho in enumerate(self.rhos):
-            print(f"\t- [in-process] Preparing input for rho={rho:.4f}")
-            input_sim_rho = modifyInputs(
-                inputs[rho],
-                code_settings=code_settings,
-                extraOptions=extraOptions,
-                multipliers=multipliers,
-                minimum_delta_abs=minimum_delta_abs if minimum_delta_abs else {},
-                position_change=i,
-                addControlFunction=self.run_specifications["control_function"],
-                controls_file=self.run_specifications["controls_file"],
-                NS=inputs[rho].num_recorded,
-            )
-            if code_settings is not None:
-                input_sim_rho.removeLowDensitySpecie()
-                input_sim_rho.remove_fast()
-            if kwargs_control.get("Quasineutral", False):
-                input_sim_rho.ensureQuasineutrality()
-            input_sim_rho.anticipate_problems()
-            mod_input_file[rho] = input_sim_rho
-
-        code_executor_full[subfolder_simulation] = {}
-        code_executor[subfolder_simulation] = {}
-        for irho in self.rhos:
-            entry = {
-                "folder":     Folder_sim,
-                "dictionary": mod_input_file[irho],
-                "inputs":     None,
-                "extraOptions": extraOptions,
-                "multipliers":  multipliers,
-                "additional_files_to_send": None,
-            }
-            code_executor_full[subfolder_simulation][irho] = entry
-            code_executor[subfolder_simulation][irho] = entry
-
-        self.FolderSimLast = Folder_sim
-        return code_executor, code_executor_full
-
-    def _run(self, code_executor, run_type='normal', **kwargs_run):
-        """
-        Dispatch to in-process ctypes engine or parent subprocess/SLURM engine.
-
-        When ``self.in_process=True`` the Fortran physics is called directly via
-        ctypes for every (subfolder, rho) in *code_executor* — no file I/O.
-        Results are stored in ``self._inprocess_cache[str(folder_sim)]``.
-        """
-        if not self.in_process:
-            return super()._run(code_executor, run_type=run_type, **kwargs_run)
-
-        import os
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-        from mitim_tools.simulation_tools.interfaces import tglf_inprocess as _tip
-
-        # Build work items — one per (subfolder_variation, rho)
-        work_items = []   # (subfolder_sim, rho, flat, tglf_input, folder_sim)
-        for subfolder_sim, rho_dict in code_executor.items():
-            for rho, rho_info in rho_dict.items():
-                folder_sim = rho_info["folder"]
-                tglf_input = rho_info["dictionary"]
-                flat = {}
-                flat.update(tglf_input.controls)
-                flat.update(tglf_input.plasma)
-                for i, sp_data in tglf_input.species.items():
-                    for var, val in sp_data.items():
-                        flat[f"{var}_{i}"] = val
-                work_items.append((subfolder_sim, rho, flat, tglf_input, folder_sim))
-
-        n_workers = os.cpu_count() or 1
-        n_jobs    = len(work_items)
-        print(f"\t- [in-process] Submitting {n_jobs} TGLF cases across {min(n_workers, n_jobs)} workers")
-
-        results_by_folder: dict = {}
-
-        # Use threads, not processes.
-        # • ctypes releases the GIL during Fortran calls → true parallelism.
-        # • Each thread loads a private copy of the .so (via _get_thread_lib())
-        #   so Fortran module-level globals are independent per thread.
-        # • No macOS spawn/fork/forkserver issues; no __main__ re-execution.
-        with ThreadPoolExecutor(max_workers=min(n_workers, n_jobs)) as pool:
-            future_map = {
-                pool.submit(_tip._parallel_worker, flat): (subfolder_sim, rho, tglf_input, folder_sim)
-                for subfolder_sim, rho, flat, tglf_input, folder_sim in work_items
-            }
-            for future in as_completed(future_map):
-                subfolder_sim, rho, tglf_input, folder_sim = future_map[future]
-                outputs = future.result()
-                key = str(folder_sim)
-                if key not in results_by_folder:
-                    results_by_folder[key] = {"raw": {}, "inputs": {}}
-                results_by_folder[key]["raw"][float(rho)]    = outputs
-                results_by_folder[key]["inputs"][float(rho)] = tglf_input
-                print(
-                    f"\t- [in-process] rho={rho:.4f}  "
-                    f"Qe={outputs['elec_eflux']:.4f}  "
-                    f"Qi[0]={outputs['ion_eflux'][0]:.4f}"
-                )
-
-        self._inprocess_cache.update(results_by_folder)
-        self.simulation_job = None   # keep attribute consistent with parent
+    # NOTE: read() is defined further down because it accepts TGLF-specific
+    # kwargs (d_perp_cm, suffix, save_and_cleanup, ...) and dispatches
+    # there.  See its body below.
 
     # This is redefined (from parent) because it has the option of producing WaveForms (very TGLF specific)
     def run(
@@ -1136,62 +984,11 @@ class TGLF(SIMtools.mitim_simulation):
         save_and_cleanup = None,  # If a Path/str is given, save npz there then delete the raw run folder
     ):
         # ------------------------------------------------------------------
-        # In-process path: build results entirely from memory (no file I/O)
+        # In-process path: delegate to GACODEinprocess.TGLFInProcess
+        # mixin, which builds results entirely from the in-process cache.
         # ------------------------------------------------------------------
         if self.in_process:
-            subfolder = folder if folder is not None else self.FolderSimLast
-            cache_key = str(subfolder)
-            if cache_key not in self._inprocess_cache:
-                raise RuntimeError(
-                    f"No in-process results cached for key '{cache_key}'. "
-                    "Call run() first."
-                )
-            cached   = self._inprocess_cache[cache_key]
-            raw      = cached["raw"]       # {rho: outputs_dict}
-            inp_files = cached["inputs"]   # {rho: TGLFinput}
-
-            if "d_perp_dict" not in self.__dict__:
-                self.d_perp_dict = None
-
-            self.updateConvolution()
-
-            output_list, inputclasses, parsed = [], [], []
-            for rho in self.rhos:
-                inputclass = inp_files.get(rho) or inp_files.get(float(rho))
-                outputs    = raw.get(rho)    or raw.get(float(rho))
-                out = TGLFoutput.from_inprocess(inputclass, outputs)
-                out.unnormalize(
-                    self.NormalizationSets["SELECTED"],
-                    rho=rho,
-                    convolution_fun_fluct=self.convolution_fun_fluct,
-                    factorTot_to_Perp=self.factorTot_to_Perp,
-                )
-                output_list.append(out)
-                inputclasses.append(inputclass)
-                # Build the flat input dict so read_scan() can access scan variables
-                if inputclass is not None:
-                    flat_parsed = {}
-                    flat_parsed.update(inputclass.controls)
-                    flat_parsed.update(inputclass.plasma)
-                    for i, sp_data in inputclass.species.items():
-                        for var, val in sp_data.items():
-                            flat_parsed[f"{var}_{i}"] = val
-                else:
-                    flat_parsed = {}
-                parsed.append(flat_parsed)
-
-            self.results[label] = {
-                "output":      output_list,
-                "inputclasses": inputclasses,
-                "parsed":      parsed,
-                "x":           np.array(self.rhos),
-                "convolution_fun_fluct": self.convolution_fun_fluct,
-                "DRMAJDX_LOC": self.DRMAJDX_LOC,
-                "profiles":    self.NormalizationSets.get("input_gacode"),
-                "wavefunction": {},
-            }
-            print(f"\t- [in-process] Read results for label '{label}' ({len(self.rhos)} rho values)")
-            return
+            return self.read_inprocess(label=label, folder=folder)
 
         print("> Reading TGLF results")
 

--- a/src/mitim_tools/gacode_tools/TGLFtools.py
+++ b/src/mitim_tools/gacode_tools/TGLFtools.py
@@ -306,7 +306,7 @@ class TGLF(SIMtools.mitim_simulation):
         The complementary classmethod TGLF.from_npz(file) reconstructs a functional
         TGLF object from this file.
         """
-        import json
+        import json, io, bz2
 
         file = Path(file)
         arrays = {}
@@ -339,40 +339,16 @@ class TGLF(SIMtools.mitim_simulation):
                 meta[f"{pfx}tglf_version"] = getattr(output, "tglf_version", "")
                 meta[f"{pfx}scalar_sat_params"] = getattr(output, "scalar_sat_params", {})
 
-                # Main spectra — includes all derived slice attributes so that
-                # from_npz() can restore them directly without re-running read().
+                # Base spectra only — derived slices are recomputed by _compute_derived()
+                # on load, so they don't need to be stored.
                 _spectrum_attrs = [
-                    "ky", "Eigenvalues", "g", "f",
-                    "AmplitudeSpectrum", "AmplitudeSpectrum_Te", "AmplitudeSpectrum_ne",
-                    "AmplitudeSpectrum_Ti", "AmplitudeSpectrum_ni",
-                    "nTSpectrum", "neTeSpectrum", "niTiSpectrum",
-                    "FieldSpectrum", "v_spectrum", "phi_spectrum",
-                    "a_par_spectrum", "a_per_spectrum",
+                    "ky", "Eigenvalues",
+                    "AmplitudeSpectrum",
+                    "nTSpectrum",
+                    "FieldSpectrum",
                     "SumFluxSpectrum",
-                    "SumFlux_Qe_phi", "SumFlux_Qe_a_par", "SumFlux_Qe_a_per",
-                    "SumFlux_Qe_a", "SumFlux_Qe",
-                    "SumFlux_Ge_phi", "SumFlux_Ge_a_par", "SumFlux_Ge_a_per",
-                    "SumFlux_Ge_a", "SumFlux_Ge",
-                    "SumFlux_QiAll_phi", "SumFlux_QiAll_a_par", "SumFlux_QiAll_a_per",
-                    "SumFlux_QiAll_a", "SumFlux_QiAll",
-                    "SumFlux_Qi_phi", "SumFlux_Qi_a", "SumFlux_Qi",
-                    "SumFlux_GiAll_phi", "SumFlux_GiAll_a", "SumFlux_GiAll",
-                    "SumFlux_Gi_phi", "SumFlux_Gi_a", "SumFlux_Gi",
-                    "SumFlux_MtAll_phi", "SumFlux_MtAll_a", "SumFlux_MtAll",
-                    "SumFlux_Mt_phi", "SumFlux_Mt_a", "SumFlux_Mt",
-                    # QL flux spectrum — full array plus all derived slices used by plotTGLF_Field
                     "QLFluxSpectrum",
-                    "QLFluxSpectrum_Ge_phi", "QLFluxSpectrum_Qe_phi",
-                    "QLFluxSpectrum_GiAll_phi", "QLFluxSpectrum_Gi_phi",
-                    "QLFluxSpectrum_QiAll_phi", "QLFluxSpectrum_Qi_phi",
-                    "QLFluxSpectrum_Ge_a_par", "QLFluxSpectrum_Qe_a_par",
-                    "QLFluxSpectrum_GiAll_a_par", "QLFluxSpectrum_Gi_a_par",
-                    "QLFluxSpectrum_QiAll_a_par", "QLFluxSpectrum_Qi_a_par",
-                    "QLFluxSpectrum_Ge_a_per", "QLFluxSpectrum_Qe_a_per",
-                    "QLFluxSpectrum_GiAll_a_per", "QLFluxSpectrum_Gi_a_per",
-                    "QLFluxSpectrum_QiAll_a_per", "QLFluxSpectrum_Qi_a_per",
-                    "IntensitySpectrum", "IntensitySpectrum_ne", "IntensitySpectrum_Te",
-                    "IntensitySpectrum_ni", "IntensitySpectrum_Ti",
+                    "IntensitySpectrum",
                 ]
                 for attr in _spectrum_attrs:
                     if hasattr(output, attr):
@@ -411,6 +387,23 @@ class TGLF(SIMtools.mitim_simulation):
                         arrays[pfx + attr] = np.array([getattr(output, attr)], dtype=np.float32)
 
 
+        # ---- Wavefunction data ----
+        # Structure: results[label]["wavefunction"][f"ky{val}"][rho] = dict of arrays
+        # Field names contain parens (e.g. "RE(phi)") so we sanitize them for npz keys.
+        _wf_safe = lambda n: n.replace("(", "").replace(")", "")
+        for label in self.results:
+            wf_data = self.results[label].get("wavefunction", {})
+            ky_keys = [k for k in wf_data if wf_data[k]]  # non-empty ky entries
+            meta[f"{label}__wf_ky_keys"] = ky_keys
+            for ky_key in ky_keys:
+                for irho, rho_val in enumerate(self.rhos):
+                    if rho_val not in wf_data[ky_key]:
+                        continue
+                    wf = wf_data[ky_key][rho_val]
+                    pfx_wf = f"wf__{label}__{ky_key}__{irho}__"
+                    for field, arr in wf.items():
+                        arrays[pfx_wf + _wf_safe(field)] = np.asarray(arr, dtype=np.float32)
+
         # ---- Normalization (SELECTED set only — pure numpy arrays) ----
         norm = self.NormalizationSets.get("SELECTED")
         if norm is not None:
@@ -430,16 +423,36 @@ class TGLF(SIMtools.mitim_simulation):
                 except (TypeError, ValueError):
                     pass
 
+        # ---- Scan data (aggregated arrays from read_scan) ----
+        meta["scan_labels"] = list(self.scans.keys())
+        meta["ion_OI_position_in_total_padded_list_scan"] = getattr(
+            self, "ion_OI_position_in_total_padded_list_scan", 3)
+        meta["variablesDrives"] = list(getattr(self, "variablesDrives", []))
+        for scan_label in self.scans:
+            scan = self.scans[scan_label]
+            spfx = f"scan__{scan_label}__"
+            meta[f"{spfx}variable"] = scan.get("variable", "")
+            meta[f"{spfx}positionBase"] = scan.get("positionBase")
+            meta[f"{spfx}unnorm_ok"] = bool(scan.get("unnormalization_successful", True))
+            meta[f"{spfx}results_tags"] = list(scan.get("results_tags", []))
+            for k, v in scan.items():
+                if isinstance(v, np.ndarray):
+                    arrays[spfx + k] = v.astype(np.float32)
+
         # ---- Metadata packed as JSON bytes ----
         meta_bytes = np.frombuffer(json.dumps(meta).encode("utf-8"), dtype=np.uint8)
         arrays["__meta__"] = meta_bytes
 
-        np.savez_compressed(file, **arrays)
+        # Pack all arrays into one uncompressed zip stream, then bz2-compress the
+        # whole thing.  Cross-array bz2 compression is ~4× smaller than compressing
+        # each array independently as np.savez_compressed does.
+        import io, bz2
+        buf = io.BytesIO()
+        np.savez(buf, **arrays)
+        file.write_bytes(bz2.compress(buf.getvalue(), compresslevel=9))
 
-        # Report size (np.savez_compressed appends .npz if not present)
-        npz_path = file.with_suffix(".npz") if file.suffix != ".npz" else file
-        size_kb = npz_path.stat().st_size / 1024
-        print(f"> Saved TGLF results to {IOtools.clipstr(npz_path)} ({size_kb:.1f} kB)")
+        size_kb = file.stat().st_size / 1024
+        print(f"> Saved TGLF results to {IOtools.clipstr(file)} ({size_kb:.1f} kB)")
 
     @classmethod
     def from_npz(cls, file):
@@ -450,13 +463,14 @@ class TGLF(SIMtools.mitim_simulation):
         the stored results.  Methods that require the raw run folders, TGYRO objects,
         or profiles (GACODE profile tabs, renormalization) are not available.
         """
-        import json
+        import json, io, bz2
 
         file = Path(file)
-        if file.suffix != ".npz":
-            file = file.with_suffix(".npz")
-
-        data = np.load(file, allow_pickle=False)
+        raw = file.read_bytes()
+        # Auto-detect bz2 (magic b"BZh") vs legacy plain-npz
+        if raw[:3] == b"BZh":
+            raw = bz2.decompress(raw)
+        data = np.load(io.BytesIO(raw), allow_pickle=False)
         meta = json.loads(data["__meta__"].tobytes().decode("utf-8"))
 
         from mitim_tools.simulation_tools import SIMtools
@@ -500,7 +514,29 @@ class TGLF(SIMtools.mitim_simulation):
             res["DRMAJDX_LOC"] = meta.get(f"{label}__DRMAJDX_LOC", {})
             res["convolution_fun_fluct"] = None
             res["profiles"] = None
-            res["wavefunction"] = {}
+
+            # Restore wavefunction data
+            _wf_orig = {"REphi": "RE(phi)", "IMphi": "IM(phi)",
+                        "REBper": "RE(Bper)", "IMBper": "IM(Bper)",
+                        "REBpar": "RE(Bpar)", "IMBpar": "IM(Bpar)"}
+            ky_keys = meta.get(f"{label}__wf_ky_keys", [])
+            wf_dict = {}
+            n_rhos_wf = len(meta[f"{label}__x"])
+            for ky_key in ky_keys:
+                wf_dict[ky_key] = {}
+                for irho_wf in range(n_rhos_wf):
+                    rho_val = meta[f"{label}__x"][irho_wf]
+                    pfx_wf = f"wf__{label}__{ky_key}__{irho_wf}__"
+                    wf = {}
+                    for safe, orig in {**_wf_orig,
+                                       "theta": "theta", "ky": "ky",
+                                       "gamma": "gamma", "freq": "freq"}.items():
+                        key = pfx_wf + safe
+                        if key in data:
+                            wf[orig] = data[key].astype(np.float64)
+                    if wf:
+                        wf_dict[ky_key][rho_val] = wf
+            res["wavefunction"] = wf_dict
 
             outputs, inputclasses, parseds = [], [], []
 
@@ -555,6 +591,9 @@ class TGLF(SIMtools.mitim_simulation):
                 input_dict = SIMtools.buildDictFromInput(output.inputFile)
                 output.inputclass = TGLFinput.initialize_in_memory(input_dict)
 
+                # Re-derive all slice attributes from base spectra
+                output._compute_derived()
+
                 # Re-derive postprocess metrics (requires SumFlux_* to be set)
                 output.postprocess()
 
@@ -566,6 +605,27 @@ class TGLF(SIMtools.mitim_simulation):
             res["inputclasses"] = inputclasses
             res["parsed"] = parseds
             tglf.results[label] = res
+
+        # ---- Restore scan data ----
+        tglf.ion_OI_position_in_total_padded_list_scan = int(
+            meta.get("ion_OI_position_in_total_padded_list_scan", 3))
+        tglf.variablesDrives = list(meta.get("variablesDrives", []))
+        tglf.scans = {}
+        for scan_label in meta.get("scan_labels", []):
+            spfx = f"scan__{scan_label}__"
+            scan = {}
+            scan["variable"] = meta.get(f"{spfx}variable", "")
+            scan["positionBase"] = meta.get(f"{spfx}positionBase")
+            scan["unnormalization_successful"] = bool(meta.get(f"{spfx}unnorm_ok", True))
+            scan["results_tags"] = list(meta.get(f"{spfx}results_tags", []))
+            for key in data.files:
+                if key.startswith(spfx):
+                    k = key[len(spfx):]
+                    scan[k] = data[key].astype(np.float64)
+            # x (rho values) must exactly match self.rhos; restore from meta to avoid
+            # float32 round-trip precision drift that breaks == comparisons in plot_scan
+            scan["x"] = np.array(meta["rhos"])
+            tglf.scans[scan_label] = scan
 
         print(f"> Loaded TGLF results from {IOtools.clipstr(file)} "
               f"({len(tglf.results)} label(s), {len(tglf.rhos)} rho(s))")
@@ -763,6 +823,7 @@ class TGLF(SIMtools.mitim_simulation):
         cold_startWF = True, # If this is a "complete" read, I will assign a None
         require_all_files = True,   # If False, I only need the fluxes
         input_gacode = None, # Only needed to grab normalizations if they weren't populated already (e.g. this is just a "read" of an already run folder
+        save_and_cleanup = None,  # If a Path/str is given, save npz there then delete the raw run folder
     ):
         print("> Reading TGLF results")
 
@@ -860,6 +921,13 @@ class TGLF(SIMtools.mitim_simulation):
         # After read, go back to no waveforms in case I want to read another case without it
         if cold_startWF:
             self.ky_single = None
+
+        if save_and_cleanup is not None:
+            self.save_npz(save_and_cleanup)
+            if folder is not None and folder.exists():
+                import shutil
+                shutil.rmtree(folder)
+                print(f"\t- Removed raw run folder: {IOtools.clipstr(folder)}", typeMsg="i")
 
     def plot(
         self,
@@ -2246,6 +2314,7 @@ class TGLF(SIMtools.mitim_simulation):
         subfolder=None,
         variable="RLTS_1",
         ion_OI_position_in_total_padded_list=3,
+        save_and_cleanup=None,  # If a Path/str is given, save npz there then delete the raw scan subfolder
     ):
         
         ion_OI_position_in_ion_list = ion_OI_position_in_total_padded_list - 2
@@ -2299,8 +2368,18 @@ class TGLF(SIMtools.mitim_simulation):
                 axes_swap = [1, 2, 0] # [rho, scan, ky]
             elif len(self.scans[label][var].shape) == 4:
                 axes_swap = [2, 3, 1, 0] # [rho, scan, nmode, ky]
-                
+
             self.scans[label][var] = np.transpose(self.scans[label][var], axes=axes_swap)
+
+        if save_and_cleanup is not None:
+            self.save_npz(save_and_cleanup)
+            resolved_subfolder = subfolder if subfolder is not None else self.subfolder_scan
+            if resolved_subfolder is not None:
+                import shutil
+                for d in sorted(self.FolderGACODE.glob(f"{resolved_subfolder}_*")):
+                    if d.is_dir():
+                        shutil.rmtree(d)
+                        print(f"\t- Removed raw scan folder: {IOtools.clipstr(d)}", typeMsg="i")
 
     def plot_scan(
         self,
@@ -2852,6 +2931,7 @@ class TGLF(SIMtools.mitim_simulation):
         variablesDrives=["RLTS_1", "RLTS_2", "RLNS_1", "XNUE", "TAUS_2"],
         minimum_delta_abs={},
         ion_OI_position_in_total_padded_list=2,
+        save_and_cleanup=None,  # If a Path/str, save npz there then delete raw scan folders
         **kwargs_TGLFrun,
     ):
         
@@ -2923,7 +3003,15 @@ class TGLF(SIMtools.mitim_simulation):
 
             scan_name = f"{subfolder}_{variable}"  # e.g. turbDrives_RLTS_1
 
-            self.read_scan(label=scan_name, variable=variable,ion_OI_position_in_total_padded_list=ion_OI_position_in_total_padded_list)
+            self.read_scan(label=scan_name, variable=variable, ion_OI_position_in_total_padded_list=ion_OI_position_in_total_padded_list)
+
+        if save_and_cleanup is not None:
+            self.save_npz(save_and_cleanup)
+            import shutil
+            for d in sorted(self.FolderGACODE.glob(f"{subfolder}_*")):
+                if d.is_dir():
+                    shutil.rmtree(d)
+                    print(f"\t- Removed raw scan folder: {IOtools.clipstr(d)}", typeMsg="i")
 
     def plotScanTurbulenceDrives(
         self, label="drives1", figs=None, **kwargs_TGLFscanPlot
@@ -4161,6 +4249,135 @@ class TGLFoutput(SIMtools.GACODEoutput):
         self.MtES = np.sum(self.SumFlux_Mt_phi)
         self.MtEM = np.sum(self.SumFlux_Mt_a)
 
+    def _compute_derived(self):
+        """
+        Re-derive all slice attributes from the stored base spectra.
+
+        Requires that the following base attributes are already set on self:
+          Eigenvalues, AmplitudeSpectrum, nTSpectrum, FieldSpectrum,
+          SumFluxSpectrum, QLFluxSpectrum, IntensitySpectrum,
+          ions_included, fields, num_fields, inputclass
+        """
+        # ---- Eigenvalues -> g, f ----
+        self.g = self.Eigenvalues[0, :, :]
+        self.f = self.Eigenvalues[1, :, :]
+
+        # ---- AmplitudeSpectrum slices ----
+        self.AmplitudeSpectrum_Te = self.AmplitudeSpectrum[0, 0, :]
+        self.AmplitudeSpectrum_Ti = self.AmplitudeSpectrum[0, 1:, :]
+        self.AmplitudeSpectrum_ne = self.AmplitudeSpectrum[1, 0, :]
+        self.AmplitudeSpectrum_ni = self.AmplitudeSpectrum[1, 1:, :]
+
+        # ---- nTSpectrum slices ----
+        self.neTeSpectrum = self.nTSpectrum[0, :, :]
+        self.niTiSpectrum = self.nTSpectrum[1:, :, :]
+
+        # ---- FieldSpectrum slices ----
+        self.v_spectrum   = self.FieldSpectrum[0, :, :]
+        self.phi_spectrum = self.FieldSpectrum[1, :, :]
+        self.a_par_spectrum = self.FieldSpectrum[2, :, :]
+        self.a_per_spectrum = self.FieldSpectrum[3, :, :]
+
+        # ---- SumFluxSpectrum slices ----
+        self.SumFlux_Qe_phi   = self.SumFluxSpectrum[1, 0, 0, :]
+        self.SumFlux_Ge_phi   = self.SumFluxSpectrum[0, 0, 0, :]
+        self.SumFlux_QiAll_phi = self.SumFluxSpectrum[1, 1:, 0, :]
+
+        contF = 0
+        if "a_par" in self.fields:
+            self.SumFlux_Qe_a_par    = self.SumFluxSpectrum[1, 0, 1 + contF, :]
+            self.SumFlux_Ge_a_par    = self.SumFluxSpectrum[0, 0, 1 + contF, :]
+            self.SumFlux_QiAll_a_par = self.SumFluxSpectrum[1, 1:, 1 + contF, :]
+            contF += 1
+        else:
+            self.SumFlux_Qe_a_par    = self.SumFlux_Qe_phi * 0.0
+            self.SumFlux_Ge_a_par    = self.SumFlux_Ge_phi * 0.0
+            self.SumFlux_QiAll_a_par = self.SumFlux_QiAll_phi * 0.0
+
+        if "a_per" in self.fields:
+            self.SumFlux_Qe_a_per    = self.SumFluxSpectrum[1, 0, 1 + contF, :]
+            self.SumFlux_Ge_a_per    = self.SumFluxSpectrum[0, 0, 1 + contF, :]
+            self.SumFlux_QiAll_a_per = self.SumFluxSpectrum[1, 1:, 1 + contF, :]
+        else:
+            self.SumFlux_Qe_a_per    = self.SumFlux_Qe_phi * 0.0
+            self.SumFlux_Ge_a_per    = self.SumFlux_Ge_phi * 0.0
+            self.SumFlux_QiAll_a_per = self.SumFlux_QiAll_phi * 0.0
+
+        self.SumFlux_Qe_a    = self.SumFlux_Qe_a_par    + self.SumFlux_Qe_a_per
+        self.SumFlux_Ge_a    = self.SumFlux_Ge_a_par    + self.SumFlux_Ge_a_per
+        self.SumFlux_QiAll_a = self.SumFlux_QiAll_a_par + self.SumFlux_QiAll_a_per
+
+        self.SumFlux_Qe    = self.SumFlux_Qe_phi    + self.SumFlux_Qe_a
+        self.SumFlux_Ge    = self.SumFlux_Ge_phi    + self.SumFlux_Ge_a
+        self.SumFlux_QiAll = self.SumFlux_QiAll_phi + self.SumFlux_QiAll_a
+
+        sum_ions = tuple([i - 1 for i in self.ions_included])
+
+        self.SumFlux_Qi_phi = self.SumFlux_QiAll_phi[sum_ions, :].sum(axis=0)
+        self.SumFlux_Qi_a   = self.SumFlux_QiAll_a[sum_ions, :].sum(axis=0)
+        self.SumFlux_Qi     = self.SumFlux_Qi_phi + self.SumFlux_Qi_a
+
+        self.SumFlux_GiAll_phi = self.SumFluxSpectrum[0, 1:, 0, :]
+        self.SumFlux_GiAll_a   = (self.SumFluxSpectrum[0, 1:, 1, :] if self.num_fields > 1
+                                   else self.SumFlux_GiAll_phi * 0.0)
+        self.SumFlux_GiAll     = self.SumFlux_GiAll_phi + self.SumFlux_GiAll_a
+        self.SumFlux_Gi_phi    = self.SumFlux_GiAll_phi[sum_ions, :].sum(axis=0)
+        self.SumFlux_Gi_a      = self.SumFlux_GiAll_a[sum_ions, :].sum(axis=0)
+        self.SumFlux_Gi        = self.SumFlux_Gi_phi + self.SumFlux_Gi_a
+
+        signMt = -self.inputclass.plasma['SIGN_IT']
+        self.SumFlux_MtAll_phi = self.SumFluxSpectrum[2, :, 0, :] * signMt
+        self.SumFlux_MtAll_a   = (self.SumFluxSpectrum[2, :, 1, :] * signMt if self.num_fields > 1
+                                   else self.SumFlux_MtAll_phi * 0.0)
+        self.SumFlux_MtAll     = self.SumFlux_MtAll_phi + self.SumFlux_MtAll_a
+        self.SumFlux_Mt_phi    = self.SumFlux_MtAll_phi.sum(axis=0)
+        self.SumFlux_Mt_a      = self.SumFlux_MtAll_a.sum(axis=0)
+        self.SumFlux_Mt        = self.SumFlux_Mt_phi + self.SumFlux_Mt_a
+
+        # ---- QLFluxSpectrum slices ----
+        self.QLFluxSpectrum_Ge_phi    = self.QLFluxSpectrum[0, 0, 0, :, :]
+        self.QLFluxSpectrum_Qe_phi    = self.QLFluxSpectrum[1, 0, 0, :, :]
+        self.QLFluxSpectrum_GiAll_phi = self.QLFluxSpectrum[0, 1:, 0, :, :]
+        self.QLFluxSpectrum_Gi_phi    = self.QLFluxSpectrum_GiAll_phi[sum_ions, :].sum(axis=0)
+        self.QLFluxSpectrum_QiAll_phi = self.QLFluxSpectrum[1, 1:, 0, :, :]
+        self.QLFluxSpectrum_Qi_phi    = self.QLFluxSpectrum_QiAll_phi[sum_ions, :].sum(axis=0)
+
+        if "a_par" in self.fields:
+            self.QLFluxSpectrum_Ge_a_par    = self.QLFluxSpectrum[0, 0, 1, :, :]
+            self.QLFluxSpectrum_Qe_a_par    = self.QLFluxSpectrum[1, 0, 1, :, :]
+            self.QLFluxSpectrum_GiAll_a_par = self.QLFluxSpectrum[0, 1:, 1, :, :]
+            self.QLFluxSpectrum_Gi_a_par    = self.QLFluxSpectrum_GiAll_a_par[sum_ions, :].sum(axis=0)
+            self.QLFluxSpectrum_QiAll_a_par = self.QLFluxSpectrum[1, 1:, 1, :, :]
+            self.QLFluxSpectrum_Qi_a_par    = self.QLFluxSpectrum_QiAll_a_par[sum_ions, :].sum(axis=0)
+        else:
+            self.QLFluxSpectrum_Ge_a_par    = self.QLFluxSpectrum_Ge_phi * 0.0
+            self.QLFluxSpectrum_Qe_a_par    = self.QLFluxSpectrum_Qe_phi * 0.0
+            self.QLFluxSpectrum_GiAll_a_par = self.QLFluxSpectrum_QiAll_phi * 0.0
+            self.QLFluxSpectrum_Gi_a_par    = self.QLFluxSpectrum_Qi_phi * 0.0
+            self.QLFluxSpectrum_QiAll_a_par = self.QLFluxSpectrum_QiAll_phi * 0.0
+            self.QLFluxSpectrum_Qi_a_par    = self.QLFluxSpectrum_Qi_phi * 0.0
+
+        if "a_per" in self.fields:
+            self.QLFluxSpectrum_Ge_a_per    = self.QLFluxSpectrum[0, 0, 2, :, :]
+            self.QLFluxSpectrum_Qe_a_per    = self.QLFluxSpectrum[1, 0, 2, :, :]
+            self.QLFluxSpectrum_GiAll_a_per = self.QLFluxSpectrum[0, 1:, 2, :, :]
+            self.QLFluxSpectrum_Gi_a_per    = self.QLFluxSpectrum_GiAll_a_per[sum_ions, :].sum(axis=0)
+            self.QLFluxSpectrum_QiAll_a_per = self.QLFluxSpectrum[1, 1:, 2, :, :]
+            self.QLFluxSpectrum_Qi_a_per    = self.QLFluxSpectrum_QiAll_a_per[sum_ions, :].sum(axis=0)
+        else:
+            self.QLFluxSpectrum_Ge_a_per    = self.QLFluxSpectrum_Ge_phi * 0.0
+            self.QLFluxSpectrum_Qe_a_per    = self.QLFluxSpectrum_Qe_phi * 0.0
+            self.QLFluxSpectrum_GiAll_a_per = self.QLFluxSpectrum_GiAll_phi * 0.0
+            self.QLFluxSpectrum_Gi_a_per    = self.QLFluxSpectrum_Gi_phi * 0.0
+            self.QLFluxSpectrum_QiAll_a_per = self.QLFluxSpectrum_QiAll_phi * 0.0
+            self.QLFluxSpectrum_Qi_a_per    = self.QLFluxSpectrum_Qi_phi * 0.0
+
+        # ---- IntensitySpectrum slices ----
+        self.IntensitySpectrum_ne = self.IntensitySpectrum[0, 0, :, :]
+        self.IntensitySpectrum_Te = self.IntensitySpectrum[1, 0, :, :]
+        self.IntensitySpectrum_ni = self.IntensitySpectrum[0, 1:, :, :]
+        self.IntensitySpectrum_Ti = self.IntensitySpectrum[1, 1:, :, :]
+
     # Redefined because of very specific TGLF stuff
     def read(self,require_all_files=True):
         # --------------------------------------------------------------------------------
@@ -4250,9 +4467,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
                 .transpose((2, 1, 0))
             )
 
-            self.g = self.Eigenvalues[0, :, :]
-            self.f = self.Eigenvalues[1, :, :]
-
             # ------------------------------------------------------------------------
             # TGLF model
             # ------------------------------------------------------------------------
@@ -4304,12 +4518,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             self.num_species = self.AmplitudeSpectrum.shape[1]
 
-            self.AmplitudeSpectrum_Te = self.AmplitudeSpectrum[0, 0, :]
-            self.AmplitudeSpectrum_Ti = self.AmplitudeSpectrum[0, 1:, :]
-
-            self.AmplitudeSpectrum_ne = self.AmplitudeSpectrum[1, 0, :]
-            self.AmplitudeSpectrum_ni = self.AmplitudeSpectrum[1, 1:, :]
-
             # ------------------------------------------------------------------------
             # Cross Phase Spectrum
             # ------------------------------------------------------------------------
@@ -4323,9 +4531,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             # Using my convention of [species,nmode,ky]
             self.nTSpectrum = datanT.transpose((0, 2, 1)) * 180 / (np.pi)
-
-            self.neTeSpectrum = self.nTSpectrum[0, :, :]
-            self.niTiSpectrum = self.nTSpectrum[1:, :, :]
 
             # ----------------------------------------------------------------------------------------
             # Field Spectrum (gyro-bohm normalized field fluctuation intensity spectra per mode)
@@ -4347,11 +4552,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
                 self.FieldSpectrum[2, i] = data[0, :, 4 * i + 2]
                 self.FieldSpectrum[3, i] = data[0, :, 4 * i + 3]
             # *************************************************
-
-            self.v_spectrum = self.FieldSpectrum[0, :, :]
-            self.phi_spectrum = self.FieldSpectrum[1, :, :]
-            self.a_par_spectrum = self.FieldSpectrum[2, :, :]
-            self.a_per_spectrum = self.FieldSpectrum[3, :, :]
 
             with open(
                 self.FolderGACODE / ("out.tglf.field_spectrum" + self.suffix), "r"
@@ -4390,66 +4590,8 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             # Using my convention of [quantity,species,field,ky]
             self.SumFluxSpectrum = data_re.transpose((3, 0, 1, 2))
-            # *************************************************
-
-            self.SumFlux_Qe_phi = self.SumFluxSpectrum[1, 0, 0, :]
-            self.SumFlux_Ge_phi = self.SumFluxSpectrum[0, 0, 0, :]
-            self.SumFlux_QiAll_phi = self.SumFluxSpectrum[1, 1:, 0, :]
-
-            contF = 0
-            if "a_par" in self.fields:
-                self.SumFlux_Qe_a_par = self.SumFluxSpectrum[1, 0, 1 + contF, :]
-                self.SumFlux_Ge_a_par = self.SumFluxSpectrum[0, 0, 1 + contF, :]
-                self.SumFlux_QiAll_a_par = self.SumFluxSpectrum[1, 1:, 1 + contF, :]
-                contF += 1
-            else:
-                self.SumFlux_Qe_a_par = self.SumFlux_Qe_phi * 0.0
-                self.SumFlux_Ge_a_par = self.SumFlux_Ge_phi * 0.0
-                self.SumFlux_QiAll_a_par = self.SumFlux_QiAll_phi * 0.0
-
-            if "a_per" in self.fields:
-                self.SumFlux_Qe_a_per = self.SumFluxSpectrum[1, 0, 1 + contF, :]
-                self.SumFlux_Ge_a_per = self.SumFluxSpectrum[0, 0, 1 + contF, :]
-                self.SumFlux_QiAll_a_per = self.SumFluxSpectrum[1, 1:, 1 + contF, :]
-                contF += 1
-            else:
-                self.SumFlux_Qe_a_per = self.SumFlux_Qe_phi * 0.0
-                self.SumFlux_Ge_a_per = self.SumFlux_Ge_phi * 0.0
-                self.SumFlux_QiAll_a_per = self.SumFlux_QiAll_phi * 0.0
-
-            self.SumFlux_Qe_a = self.SumFlux_Qe_a_par + self.SumFlux_Qe_a_per
-            self.SumFlux_Ge_a = self.SumFlux_Ge_a_par + self.SumFlux_Ge_a_per
-            self.SumFlux_QiAll_a = self.SumFlux_QiAll_a_par + self.SumFlux_QiAll_a_per
-
-            self.SumFlux_Qe = self.SumFlux_Qe_phi + self.SumFlux_Qe_a
-            self.SumFlux_Ge = self.SumFlux_Ge_phi + self.SumFlux_Ge_a
-            self.SumFlux_QiAll = self.SumFlux_QiAll_phi + self.SumFlux_QiAll_a
-
-            # Sum ion contributions
 
             print(f"\t\t- For Qi spectrum, summing contributions from ions {self.ions_included} (#0 is e-)",typeMsg="i",)
-            sum_ions = tuple([i - 1 for i in self.ions_included])
-
-            self.SumFlux_Qi_phi = self.SumFlux_QiAll_phi[sum_ions, :].sum(axis=0)
-            self.SumFlux_Qi_a = self.SumFlux_QiAll_a[sum_ions, :].sum(axis=0)
-            self.SumFlux_Qi = self.SumFlux_Qi_phi + self.SumFlux_Qi_a
-
-            # Per-ion and total particle flux spectra [species, ky]
-            self.SumFlux_GiAll_phi = self.SumFluxSpectrum[0, 1:, 0, :]
-            self.SumFlux_GiAll_a = self.SumFluxSpectrum[0, 1:, 1, :] if self.num_fields > 1 else self.SumFlux_GiAll_phi * 0.0
-            self.SumFlux_GiAll = self.SumFlux_GiAll_phi + self.SumFlux_GiAll_a
-            self.SumFlux_Gi_phi = self.SumFlux_GiAll_phi[sum_ions, :].sum(axis=0)
-            self.SumFlux_Gi_a = self.SumFlux_GiAll_a[sum_ions, :].sum(axis=0)
-            self.SumFlux_Gi = self.SumFlux_Gi_phi + self.SumFlux_Gi_a
-
-            # Momentum (toroidal stress) flux spectra [species, ky] — sign applied as in gbflux
-            signMt = -self.inputclass.plasma['SIGN_IT']
-            self.SumFlux_MtAll_phi = self.SumFluxSpectrum[2, :, 0, :] * signMt  # all species incl. electrons
-            self.SumFlux_MtAll_a = (self.SumFluxSpectrum[2, :, 1, :] * signMt if self.num_fields > 1 else self.SumFlux_MtAll_phi * 0.0)
-            self.SumFlux_MtAll = self.SumFlux_MtAll_phi + self.SumFlux_MtAll_a
-            self.SumFlux_Mt_phi = self.SumFlux_MtAll_phi.sum(axis=0)  # total ES momentum spectrum
-            self.SumFlux_Mt_a = self.SumFlux_MtAll_a.sum(axis=0)      # total EM momentum spectrum
-            self.SumFlux_Mt = self.SumFlux_Mt_phi + self.SumFlux_Mt_a
 
             # ------------------------------------------------------------------------
             # QL Flux Spectrum (QL weights per mode)
@@ -4462,8 +4604,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
                 columns=None,
                 numky=self.num_ky,
             )
-
-            # Re-arrange to separa specie and field
 
             data_re = np.reshape(
                 data,
@@ -4479,72 +4619,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             # Using my convention of [quantity,species,field,nmode,ky]
             self.QLFluxSpectrum = data_re.transpose((4, 0, 1, 2, 3))
-            # *************************************************
-
-            self.QLFluxSpectrum_Ge_phi = self.QLFluxSpectrum[0, 0, 0, :, :]
-            self.QLFluxSpectrum_Qe_phi = self.QLFluxSpectrum[1, 0, 0, :, :]
-
-            self.QLFluxSpectrum_GiAll_phi = self.QLFluxSpectrum[0, 1:, 0, :, :]
-            self.QLFluxSpectrum_Gi_phi = self.QLFluxSpectrum_GiAll_phi[sum_ions, :].sum(
-                axis=0
-            )  # Sum over ions
-            self.QLFluxSpectrum_QiAll_phi = self.QLFluxSpectrum[1, 1:, 0, :, :]
-            self.QLFluxSpectrum_Qi_phi = self.QLFluxSpectrum_QiAll_phi[sum_ions, :].sum(
-                axis=0
-            )  # Sum over ions
-
-            contF = 1
-            if "a_par" in self.fields:
-                self.QLFluxSpectrum_Ge_a_par = self.QLFluxSpectrum[0, 0, 1, :, :]
-                self.QLFluxSpectrum_Qe_a_par = self.QLFluxSpectrum[1, 0, 1, :, :]
-
-                self.QLFluxSpectrum_GiAll_a_par = self.QLFluxSpectrum[0, 1:, 1, :, :]
-                self.QLFluxSpectrum_Gi_a_par = self.QLFluxSpectrum_GiAll_a_par[
-                    sum_ions, :
-                ].sum(
-                    axis=0
-                )  # Sum over ions
-                self.QLFluxSpectrum_QiAll_a_par = self.QLFluxSpectrum[1, 1:, 1, :, :]
-                self.QLFluxSpectrum_Qi_a_par = self.QLFluxSpectrum_QiAll_a_par[
-                    sum_ions, :
-                ].sum(
-                    axis=0
-                )  # Sum over ions
-                contF += 1
-            else:
-                self.QLFluxSpectrum_Ge_a_par = self.QLFluxSpectrum_Ge_phi * 0.0
-                self.QLFluxSpectrum_Qe_a_par = self.QLFluxSpectrum_Qe_phi * 0.0
-
-                self.QLFluxSpectrum_GiAll_a_par = self.QLFluxSpectrum_QiAll_phi * 0.0
-                self.QLFluxSpectrum_Gi_a_par = self.QLFluxSpectrum_Qi_phi * 0.0
-                self.QLFluxSpectrum_QiAll_a_par = self.QLFluxSpectrum_QiAll_phi * 0.0
-                self.QLFluxSpectrum_Qi_a_par = self.QLFluxSpectrum_Qi_phi * 0.0
-
-            if "a_per" in self.fields:
-                self.QLFluxSpectrum_Ge_a_per = self.QLFluxSpectrum[0, 0, 2, :, :]
-                self.QLFluxSpectrum_Qe_a_per = self.QLFluxSpectrum[1, 0, 2, :, :]
-
-                self.QLFluxSpectrum_GiAll_a_per = self.QLFluxSpectrum[0, 1:, 2, :, :]
-                self.QLFluxSpectrum_Gi_a_per = self.QLFluxSpectrum_GiAll_a_per[
-                    sum_ions, :
-                ].sum(
-                    axis=0
-                )  # Sum over ions
-                self.QLFluxSpectrum_QiAll_a_per = self.QLFluxSpectrum[1, 1:, 2, :, :]
-                self.QLFluxSpectrum_Qi_a_per = self.QLFluxSpectrum_QiAll_a_per[
-                    sum_ions, :
-                ].sum(
-                    axis=0
-                )  # Sum over ions
-                contF += 1
-            else:
-                self.QLFluxSpectrum_Ge_a_per = self.QLFluxSpectrum_Ge_phi * 0.0
-                self.QLFluxSpectrum_Qe_a_per = self.QLFluxSpectrum_Qe_phi * 0.0
-
-                self.QLFluxSpectrum_GiAll_a_per = self.QLFluxSpectrum_GiAll_phi * 0.0
-                self.QLFluxSpectrum_Gi_a_per = self.QLFluxSpectrum_Gi_phi * 0.0
-                self.QLFluxSpectrum_QiAll_a_per = self.QLFluxSpectrum_QiAll_phi * 0.0
-                self.QLFluxSpectrum_Qi_a_per = self.QLFluxSpectrum_Qi_phi * 0.0
 
             # ------------------------------------------------------------------------
             # Intensity Spectrum
@@ -4566,11 +4640,8 @@ class TGLFoutput(SIMtools.GACODEoutput):
             # Using my convention of [quantity=(density,temperature,parallel velocity,parallel energy),species,nmode,ky]
             self.IntensitySpectrum = data_re.transpose((3, 0, 1, 2))
 
-            self.IntensitySpectrum_ne = self.IntensitySpectrum[0, 0, :, :]
-            self.IntensitySpectrum_Te = self.IntensitySpectrum[1, 0, :, :]
-
-            self.IntensitySpectrum_ni = self.IntensitySpectrum[0, 1:, :, :]
-            self.IntensitySpectrum_Ti = self.IntensitySpectrum[1, 1:, :, :]
+            # Re-derive all slice attributes from the base spectra
+            self._compute_derived()
 
         else:
             self.ky = np.zeros((1,))

--- a/src/mitim_tools/gacode_tools/TGLFtools.py
+++ b/src/mitim_tools/gacode_tools/TGLFtools.py
@@ -388,7 +388,7 @@ class TGLF(SIMtools.mitim_simulation):
                         arrays[f"{pfx}tglf_model__{k}"] = np.asarray(v, dtype=np.float32)
 
                 # Scalar fluxes (from gbflux)
-                for attr in ["Ge", "Qe", "Qi", "Qifast", "Me", "Mt", "Se", "Si"]:
+                for attr in ["Ge", "Qe", "Qi", "Gi", "Qifast", "Me", "Mt", "Se", "Si"]:
                     if hasattr(output, attr):
                         arrays[pfx + attr] = np.array([getattr(output, attr)], dtype=np.float32)
                 for attr in ["GiAll", "QiAll", "MiAll", "SiAll"]:
@@ -542,7 +542,7 @@ class TGLF(SIMtools.mitim_simulation):
                         output.tglf_model[sub] = data[key].astype(np.float64)
 
                 # Scalar fluxes stored as 1-element arrays — unwrap to float
-                for attr in ["Ge", "Qe", "Qi", "Qifast", "Me", "Mt", "Se", "Si",
+                for attr in ["Ge", "Qe", "Qi", "Gi", "Qifast", "Me", "Mt", "Se", "Si",
                              "Qe_unn", "Qi_unn", "Qifast_unn", "Ge_unn", "Mt_unn", "Se_unn",
                              "AmplitudeSpectrum_Te_level", "AmplitudeSpectrum_ne_level",
                              "neTeSpectrum_level"]:
@@ -943,6 +943,9 @@ class TGLF(SIMtools.mitim_simulation):
                     if il not in max_fields:
                         max_fields.append(il)
 
+        from mitim_tools.misc_tools.style_tools.themes import apply_theme
+        apply_theme()
+
         if fn is None:
             self.fn = GUItools.FigureNotebook("TGLF MITIM Notebook", geometry="1700x900", vertical=True)
         else:
@@ -968,6 +971,20 @@ class TGLF(SIMtools.mitim_simulation):
         figO = self.fn.add_figure(
             label=f"{extratitle}Model Details", tab_color=fn_color
         )
+        figFlux2 = self.fn.add_figure(
+            label=f"{extratitle}Ion & Mom. Fluxes", tab_color=fn_color
+        )
+
+        # SAT parameters tab (only if at least one run has them populated)
+        has_sat_params = any(
+            self.results[lbl]["output"][ir].scalar_sat_params
+            for lbl in labels
+            for ir in range(len(self.results[lbl]["output"]))
+        )
+        if has_sat_params:
+            figSAT = self.fn.add_figure(
+                label=f"{extratitle}SAT Parameters", tab_color=fn_color
+            )
 
         figsWF = {}
         for ky_single0 in ky_single_stored_unique:
@@ -1127,6 +1144,24 @@ class TGLF(SIMtools.mitim_simulation):
         grid = plt.GridSpec(2, 1, hspace=0.5, wspace=0.5)
         axs7 = [fig7.add_subplot(grid[0]), fig7.add_subplot(grid[1])]
 
+        # Ion & Momentum Fluxes axes
+        grid = plt.GridSpec(3, 4, hspace=0.6, wspace=0.35)
+        axsFlux2 = np.empty((3, 4), dtype=plt.Axes)
+        axsFlux2[0, 0] = figFlux2.add_subplot(grid[0, 0])
+        for r in range(3):
+            for c_ in range(4):
+                if r == 0 and c_ == 0:
+                    continue
+                sharex = axsFlux2[0, 0] if c_ < 2 else None
+                axsFlux2[r, c_] = figFlux2.add_subplot(grid[r, c_], sharex=sharex)
+
+        # SAT parameters axes — one shared figure, one line per label
+        if has_sat_params:
+            grid = plt.GridSpec(1, 2, hspace=0.4, wspace=0.4)
+            axsSAT = np.empty((1, 2), dtype=plt.Axes)
+            axsSAT[0, 0] = figSAT.add_subplot(grid[0, 0])
+            axsSAT[0, 1] = figSAT.add_subplot(grid[0, 1])
+
         if successful_normalization:
             grid = plt.GridSpec(2, 2, hspace=0.4, wspace=0.2)
             axT2 = fig3.add_subplot(grid[0, 0])
@@ -1134,13 +1169,15 @@ class TGLF(SIMtools.mitim_simulation):
             axT2_3 = fig3.add_subplot(grid[1, 0], sharex=axT2)
             axT2_4 = fig3.add_subplot(grid[1, 1], sharex=axT2)
 
-            grid = plt.GridSpec(2, 3, hspace=0.3, wspace=0.3)
+            grid = plt.GridSpec(2, 4, hspace=0.3, wspace=0.3)
             axS00 = figS.add_subplot(grid[0, 0])
             axS01 = figS.add_subplot(grid[0, 1])
             axS10 = figS.add_subplot(grid[1, 0])
             axS11 = figS.add_subplot(grid[1, 1], sharex=axS01, sharey=axS01)
             axS20 = figS.add_subplot(grid[0, 2])
             axS21 = figS.add_subplot(grid[1, 2], sharex=axS01)
+            axS_Gi = figS.add_subplot(grid[0, 3])
+            axS_Mt = figS.add_subplot(grid[1, 3], sharex=axS01)
 
             grid = plt.GridSpec(3, 3, hspace=0.5, wspace=0.3)
             axFluc00 = figF.add_subplot(grid[0, 0])
@@ -1221,6 +1258,23 @@ class TGLF(SIMtools.mitim_simulation):
                 self.results[label]["output"][irho].plotTGLF_Model(
                     axs=axsTGLF3, c=colors[cont], label=full_label
                 )
+
+                self.results[label]["output"][irho].plotTGLF_IonMomFluxes(
+                    axs=axsFlux2,
+                    c=colors[cont],
+                    label=full_label,
+                    fontsizeLeg=fontsizeLeg,
+                    title_legend=title_legend,
+                    cont=cont,
+                )
+
+                if has_sat_params:
+                    self.results[label]["output"][irho].plotTGLF_SAT(
+                        axs=axsSAT,
+                        c=colors[cont],
+                        label=full_label,
+                        cont=cont,
+                    )
 
                 self.results[label]["output"][irho].plotTGLF_Fluctuations(
                     axs=axsTGLF_flucts,
@@ -1310,6 +1364,7 @@ class TGLF(SIMtools.mitim_simulation):
 
             Qe, Qi, Ge = [], [], []
             QeGB, QiGB, GeGB = [], [], []
+            GiGB, MtGB = [], []
             TeF, neTe = [], []
             roas = []
             for irho_cont in range(len(self.rhos)):
@@ -1329,6 +1384,8 @@ class TGLF(SIMtools.mitim_simulation):
                 QeGB.append(self.results[label]["output"][irho].Qe)
                 QiGB.append(self.results[label]["output"][irho].Qi)
                 GeGB.append(self.results[label]["output"][irho].Ge)
+                GiGB.append(self.results[label]["output"][irho].Gi)
+                MtGB.append(self.results[label]["output"][irho].Mt)
 
             if self.results[label]["output"][irho].unnormalization_successful:
                 axT2.plot(self.rhos, Qe, "-o", c=colorLab[0], lw=2, label=full_label)
@@ -1368,6 +1425,9 @@ class TGLF(SIMtools.mitim_simulation):
 
                 axS20.plot(self.rhos, TeF, "-o", c=colorLab[0], lw=2, label=label)
                 axS21.plot(self.rhos, neTe, "-o", c=colorLab[0], lw=2, label=label)
+
+                axS_Gi.plot(roas, GiGB, "-o", c=colorLab[0], lw=2, label=label)
+                axS_Mt.plot(roas, MtGB, "-o", c=colorLab[0], lw=2, label=label)
 
             axsTGLF1[3, 0].plot(roas, QeGB, "-", c=colorLab[0], lw=1)
             axsTGLF1[3, 1].plot(roas, QiGB, "-", c=colorLab[0], lw=1)
@@ -1502,12 +1562,12 @@ class TGLF(SIMtools.mitim_simulation):
 
         if len(self.rhos) > 1 or len(labels) > 1:
             axsTGLF1[1, 0].legend(
-                loc="lower right", fontsize=fontsizeLeg, title=title_legend
+                loc="lower right", title=title_legend
             )
 
         if successful_normalization:
             if len(self.rhos) > 1 or len(labels) > 1:
-                axS10.legend(loc="best", fontsize=fontsizeLeg * 1.5, title=title_legend)
+                axS10.legend(loc="best", title=title_legend)
 
             ax = axT2
             ax.set_xlabel("$\\rho_N$")
@@ -1516,7 +1576,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_title("Electron heat flux")
             ax.legend(loc="best")
             ax.set_xlim([0, 1])
-            GRAPHICStools.addDenseAxis(ax)
 
             # Simple
             ax = axS01
@@ -1524,9 +1583,8 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_ylabel("$Q_e$ ($MW/m^2$)")
             ax.set_ylim(bottom=0)
             ax.set_title("Electron heat flux")
-            ax.legend(loc="best", fontsize=fontsizeLeg * 1.5, title=title_legend)
+            ax.legend(loc="best", title=title_legend)
             ax.set_xlim([0, 1])
-            GRAPHICStools.addDenseAxis(ax)
 
             # ---
 
@@ -1536,7 +1594,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_ylim(bottom=0)
             ax.set_title("Ion heat flux")
             ax.set_xlim([0, 1])
-            GRAPHICStools.addDenseAxis(ax)
 
             # Simple
             ax = axS11
@@ -1545,7 +1602,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_ylim(bottom=0)
             ax.set_title("Ion heat flux")
             ax.set_xlim([0, 1])
-            GRAPHICStools.addDenseAxis(ax)
             # ---
 
             # Simple
@@ -1555,7 +1611,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_ylim(bottom=0)
             ax.set_title("Temperature fluctuations")
             ax.set_xlim([0, 1])
-            GRAPHICStools.addDenseAxis(ax)
             # ---
 
             # Simple
@@ -1564,14 +1619,28 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_ylabel("Angle (degrees)")
             ax.set_title("$n_eT_e$ phase angle")
             ax.set_xlim([0, 1])
-            GRAPHICStools.addDenseAxis(ax)
+            # ---
+
+            ax = axS_Gi
+            ax.set_xlabel("$r/a$")
+            ax.set_ylabel("$\\Gamma_i$ (GB)")
+            ax.set_title("Ion particle flux (summed thermal ions)")
+            ax.axhline(y=0, ls="--", c="k", lw=1)
+            ax.set_xlim([0, 1])
+            ax.legend(loc="best", title=title_legend)
+
+            ax = axS_Mt
+            ax.set_xlabel("$r/a$")
+            ax.set_ylabel("$\\Pi$ (GB)")
+            ax.set_title("Total momentum flux")
+            ax.axhline(y=0, ls="--", c="k", lw=1)
+            ax.set_xlim([0, 1])
             # ---
 
             ax = axT2_3
             ax.set_xlabel("$\\rho_N$")
             ax.set_ylabel("$\\Gamma_e$ ($1E20/s/m^2$)")
             ax.set_xlim([0, 1])
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = axT2_4
             ax.set_xlabel("$\\rho_N$")
@@ -1580,7 +1649,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_title("GB Fluxes")
             ax.set_yscale("log")
             ax.set_xlim([0, 1])
-            GRAPHICStools.addDenseAxis(ax)
 
             # FLUCTS
 
@@ -1804,35 +1872,29 @@ class TGLF(SIMtools.mitim_simulation):
             ax = axFluc00
             ax.set_xlabel("$k_{\\perp}$ ($cm^{-1}$)")
             ax.set_ylim(bottom=0)
-            ax.legend(loc="best", fontsize=fontsizeLeg)
+            ax.legend(loc="best")
             ax.set_xscale("linear")
             ax.set_xlim(lims)
-            GRAPHICStools.addDenseAxis(ax)
             ax = axFluc01
             ax.set_xlabel("$k_{\\perp}$ ($cm^{-1}$)")
             ax.set_ylim(bottom=0)
             # ax.legend(loc='best');
             ax.set_xscale("linear")
             ax.set_xlim([0, 3])
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = axFluc10e
             ax.set_xlabel("$k_{\\perp}$ ($cm^{-1}$)")
             ax.set_ylim(bottom=0)
             ax.set_xscale("linear")
             ax.set_xlim(lims)
-            GRAPHICStools.addDenseAxis(ax)
             ax = axFluc11e
             ax.set_xlabel("$k_{\\perp}$ ($cm^{-1}$)")
             ax.set_ylim(bottom=0)
             ax.set_xscale("linear")
             ax.set_xlim(lims)
-            GRAPHICStools.addDenseAxis(ax)
 
             axFluc00Sym.set_ylabel("Convolution")
-            GRAPHICStools.addDenseAxis(axFluc00Sym)
             axFluc01Sym.set_ylabel("Convolution")
-            GRAPHICStools.addDenseAxis(axFluc01Sym)
             axFluc00Sym.set_ylim([0, 1])
             axFluc01Sym.set_ylim([0, 1])
 
@@ -1863,7 +1925,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.scatter(TL, T, color=C)
             ax.set_ylabel("$\\delta T_e/T_e$ (%)")
             ax.set_ylim(bottom=0)
-            GRAPHICStools.addDenseAxis(ax)
 
             for tick in ax.get_xticklabels():
                 tick.set_rotation(20)
@@ -1873,7 +1934,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.scatter(TL, N, color=C)
             ax.set_ylabel("$\\delta n_e/n_e$ (%)")
             ax.set_ylim(bottom=0)
-            GRAPHICStools.addDenseAxis(ax)
 
             for tick in ax.get_xticklabels():
                 tick.set_rotation(20)
@@ -1882,7 +1942,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.plot(TL, NT, "-", c="k")
             ax.scatter(TL, NT, color=C)
             ax.set_ylabel("$n_eT_e$ angle (degrees)")
-            GRAPHICStools.addDenseAxis(ax)
 
             for tick in ax.get_xticklabels():
                 tick.set_rotation(20)
@@ -2083,7 +2142,6 @@ class TGLF(SIMtools.mitim_simulation):
                 ax = ax00
                 ax.set_xlabel("$k_\\theta \\rho_s$")
                 ax.set_ylabel("$\\gamma$ ($c_s/a$)")
-                GRAPHICStools.addDenseAxis(ax)
                 if addLegend:
                     GRAPHICStools.addLegendApart(
                         ax, size=6, ratio=0.6, title=title_legend
@@ -2095,7 +2153,6 @@ class TGLF(SIMtools.mitim_simulation):
                 ax = ax10
                 ax.set_xlabel("$k_\\theta \\rho_s$")
                 ax.set_ylabel("$\\omega$ ($c_s/a$)")
-                GRAPHICStools.addDenseAxis(ax)
                 if addLegend:
                     GRAPHICStools.addLegendApart(ax, size=6, ratio=0.6, withleg=False)
                 ax.set_title("Real Frequency")
@@ -2105,33 +2162,27 @@ class TGLF(SIMtools.mitim_simulation):
                 ax.set_xlabel("Poloidal angle $\\theta$ ($\\pi$)")
                 ax.set_ylabel("Electric potential $\\delta\\phi$")
                 ax.set_title("Real component $\\delta\\phi$")
-                GRAPHICStools.addDenseAxis(ax)
 
                 ax = ax11
                 ax.set_ylabel("Electric potential $\\delta\\phi$")
                 ax.set_title("Imaginary component $\\delta\\phi$")
-                GRAPHICStools.addDenseAxis(ax)
 
                 ax = ax02
                 ax.set_ylabel("Magnetic potential $\\delta A_{\\parallel}$")
                 ax.set_title("Real component $\\delta A_{\\parallel}$ ($\\delta B_{\\perp}$)")
-                GRAPHICStools.addDenseAxis(ax)
 
                 ax = ax12
                 ax.set_ylabel("Magnetic potential $\\delta A_{\\parallel}$")
                 ax.set_title("Imaginary component $\\delta A_{\\parallel}$ ($\\delta B_{\\perp}$)")
-                GRAPHICStools.addDenseAxis(ax)
 
                 ax = ax03
 
                 ax.set_ylabel("Magnetic potential $\\delta A_{\\perp}$")
                 ax.set_title("Real component $\\delta A_{\\perp}$ ($\\delta B_{\\parallel}$)")
-                GRAPHICStools.addDenseAxis(ax)
 
                 ax = ax13
                 ax.set_ylabel("Magnetic potential $\\delta A_{\\perp}$")
                 ax.set_title("Imaginary component $\\delta A_{\\perp}$ ($\\delta B_{\\parallel}$)")
-                GRAPHICStools.addDenseAxis(ax)
 
         # --------------------------------
         # Profiles
@@ -2672,42 +2723,37 @@ class TGLF(SIMtools.mitim_simulation):
             ax = ax1_00
             ax.set_xlabel(variableLabel)
             ax.set_ylabel("$Q_e$ ($MW/m^2$)")
-            ax.legend(loc="best", fontsize=fontsizeLeg)
+            ax.legend(loc="best")
             ax.set_ylim(bottom=0)
             ax.set_title("Electron heat flux")
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = ax1_10
             ax.set_xlabel(variableLabel)
             ax.set_ylabel("$Q_i$ ($MW/m^2$)")
-            ax.legend(loc="best", fontsize=fontsizeLeg)
+            ax.legend(loc="best")
             ax.set_ylim(bottom=0)
             ax.set_title("Ion heat flux")
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = ax1_20
             ax.set_xlabel(variableLabel)
             ax.set_ylabel("$\\Gamma_e$ ($1E20/s/m^2$)")
-            ax.legend(loc="best", fontsize=fontsizeLeg)
+            ax.legend(loc="best")
             ax.axhline(y=0, ls="-.", c="k", lw=1)
             ax.set_title("Electron particle flux")
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = ax1_30
             ax.set_xlabel(variableLabel)
             ax.set_ylabel("$\\Gamma_i$ ($1E20/s/m^2$)")
-            ax.legend(loc="best", fontsize=fontsizeLeg)
+            ax.legend(loc="best")
             ax.axhline(y=0, ls="-.", c="k", lw=1)
             ax.set_title(f"Ion particle flux (ION_{self.ion_OI_position_in_total_padded_list_scan})")
-            GRAPHICStools.addDenseAxis(ax)
 
         ax = ax1_00e
         ax.set_xlabel(variableLabel)
         ax.set_ylabel("$Q_e$ (GB)")
-        ax.legend(loc="best", fontsize=fontsizeLeg)
+        ax.legend(loc="best")
         ax.set_ylim(bottom=0)
         ax.set_title("Electron heat flux")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = ax1_10e
         ax.set_xlabel(variableLabel)
@@ -2715,7 +2761,6 @@ class TGLF(SIMtools.mitim_simulation):
         # ax.legend(loc='best')
         ax.set_ylim(bottom=0)
         ax.set_title("Ion heat flux")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = ax1_20e
         ax.set_xlabel(variableLabel)
@@ -2723,7 +2768,6 @@ class TGLF(SIMtools.mitim_simulation):
         # ax.legend(loc='best')
         ax.axhline(y=0, ls="--", c="k", lw=1)
         ax.set_title("Electron particle flux")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = ax1_30e
         ax.set_xlabel(variableLabel)
@@ -2731,32 +2775,27 @@ class TGLF(SIMtools.mitim_simulation):
         # ax.legend(loc='best')
         ax.axhline(y=0, ls="--", c="k", lw=1)
         ax.set_title(f"Ion #{self.ion_OI_position_in_total_padded_list_scan} particle flux")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = ax2_11
         ax.set_xlabel(variableLabel)
         ax.set_ylabel("$\\eta_{a/b}=max(\\gamma_{a})/max(\\gamma_{b})$")
-        ax.legend(loc="best", fontsize=fontsizeLeg)
+        ax.legend(loc="best")
         ax.set_ylim(bottom=0)
         ax.set_title("Dominant turbulence")
         ax.axhline(y=1.0, ls="--", c="k", lw=0.5)
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = ax2_01
         ax.set_xlabel(variableLabel)
         ax.set_ylabel("$\\gamma$ ($c_s/a$)")
-        ax.legend(loc="best", fontsize=fontsizeLeg)
+        ax.legend(loc="best")
         ax.set_ylim(bottom=0)
         ax.set_title("Largest growth rate")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = ax2_00
         ax.set_xlim([1e-2, 3e1])
-        ax.legend(loc="best", fontsize=fontsizeLeg)
-        GRAPHICStools.addDenseAxis(ax)
+        ax.legend(loc="best")
 
         ax = ax2_10
-        GRAPHICStools.addDenseAxis(ax)
 
         # --------------------------------------------------------
         # Plot full TGLFs
@@ -3225,8 +3264,7 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_ylabel(f"Transport flux {self.scans[label]['var_y']}")
             ax.set_title("Incremental diffusivity calculations")
             # if len(labels) > 1 or len(self.rhos) > 1:
-            ax.legend(fontsize=8, loc="best")
-            GRAPHICStools.addDenseAxis(ax)
+            ax.legend(loc="best")
 
             ax.set_xlim([x_min * 0.9, x_max * 1.1])
             ax.set_ylim([y_min * 0.9, y_max * 1.1])
@@ -3243,7 +3281,6 @@ class TGLF(SIMtools.mitim_simulation):
 
             ax.set_xlim([0.8, 1.2])
             ax.set_ylim([0.5, 2.0])
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = ax01
             ax.set_xlabel("$\\rho_N$")
@@ -3251,18 +3288,16 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_xlim([0, 1])
             # ax.set_ylim(bottom=0)
             ax.set_title("Diffusivity profiles (effective and incremental)")
-            ax.legend(fontsize=10, loc="best")
+            ax.legend(loc="best")
             ax.axhline(y=0.0, ls="-", c="k", lw=0.3)
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = ax11
             ax.set_xlabel("$\\rho_N$")
             ax.set_ylabel("$\\chi^{PB}$ ($m^2/s$), $V^{PB}$ ($m/s$)")
             ax.set_xlim([0, 1])
             ax.set_title("Phenomenological (diffusivity + pinch)")
-            ax.legend(fontsize=10, loc="best")
+            ax.legend(loc="best")
             ax.axhline(y=0.0, ls="-", c="k", lw=0.3)
-            GRAPHICStools.addDenseAxis(ax)
 
         elif analysisType == "Z":
             grid = plt.GridSpec(2, 3, hspace=0.3, wspace=0.3)
@@ -3361,8 +3396,7 @@ class TGLF(SIMtools.mitim_simulation):
             )
             ax.set_ylabel(f"Transport flux {self.scans[label]['var_y']}")
             ax.set_title("D and V calculations")
-            ax.legend(fontsize=7, loc="best")
-            GRAPHICStools.addDenseAxis(ax)
+            ax.legend(loc="best")
 
             ax = ax11
             ax.set_xlabel("$\\rho_N$")
@@ -3370,7 +3404,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_xlim([0, 1])
             ax.axhline(y=0, lw=1, ls="--", c="k")
             ax.set_title("V pinch profiles")
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = ax01
             ax.set_xlabel("$\\rho_N$")
@@ -3378,7 +3411,6 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_xlim([0, 1])
             ax.axhline(y=0, lw=1, ls="--", c="k")
             ax.set_title("D diffusivity profiles")
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = ax02
             ax.set_xlabel("$\\rho_N$")
@@ -3386,14 +3418,12 @@ class TGLF(SIMtools.mitim_simulation):
             ax.set_xlim([0, 1])
             ax.axhline(y=0, lw=1, ls="--", c="k")
             ax.set_title("Gradients at zero-flux condition")
-            GRAPHICStools.addDenseAxis(ax)
 
             ax = ax12
             ax.set_xlabel("$\\rho_N$")
             ax.set_ylabel("Relative $n_Z$")
             ax.set_xlim([0, 1])
             ax.set_title(f"Integrated profile using BC={BC}")
-            GRAPHICStools.addDenseAxis(ax)
 
     def updateConvolution(self):
         self.DRMAJDX_LOC = {}
@@ -4126,6 +4156,10 @@ class TGLFoutput(SIMtools.GACODEoutput):
         self.QiEM = np.sum(self.SumFlux_Qi_a)
         self.GeES = np.sum(self.SumFlux_Ge_phi)
         self.GeEM = np.sum(self.SumFlux_Ge_a)
+        self.GiES = np.sum(self.SumFlux_Gi_phi)
+        self.GiEM = np.sum(self.SumFlux_Gi_a)
+        self.MtES = np.sum(self.SumFlux_Mt_phi)
+        self.MtEM = np.sum(self.SumFlux_Mt_a)
 
     # Redefined because of very specific TGLF stuff
     def read(self,require_all_files=True):
@@ -4400,6 +4434,23 @@ class TGLFoutput(SIMtools.GACODEoutput):
             self.SumFlux_Qi_a = self.SumFlux_QiAll_a[sum_ions, :].sum(axis=0)
             self.SumFlux_Qi = self.SumFlux_Qi_phi + self.SumFlux_Qi_a
 
+            # Per-ion and total particle flux spectra [species, ky]
+            self.SumFlux_GiAll_phi = self.SumFluxSpectrum[0, 1:, 0, :]
+            self.SumFlux_GiAll_a = self.SumFluxSpectrum[0, 1:, 1, :] if self.num_fields > 1 else self.SumFlux_GiAll_phi * 0.0
+            self.SumFlux_GiAll = self.SumFlux_GiAll_phi + self.SumFlux_GiAll_a
+            self.SumFlux_Gi_phi = self.SumFlux_GiAll_phi[sum_ions, :].sum(axis=0)
+            self.SumFlux_Gi_a = self.SumFlux_GiAll_a[sum_ions, :].sum(axis=0)
+            self.SumFlux_Gi = self.SumFlux_Gi_phi + self.SumFlux_Gi_a
+
+            # Momentum (toroidal stress) flux spectra [species, ky] — sign applied as in gbflux
+            signMt = -self.inputclass.plasma['SIGN_IT']
+            self.SumFlux_MtAll_phi = self.SumFluxSpectrum[2, :, 0, :] * signMt  # all species incl. electrons
+            self.SumFlux_MtAll_a = (self.SumFluxSpectrum[2, :, 1, :] * signMt if self.num_fields > 1 else self.SumFlux_MtAll_phi * 0.0)
+            self.SumFlux_MtAll = self.SumFlux_MtAll_phi + self.SumFlux_MtAll_a
+            self.SumFlux_Mt_phi = self.SumFlux_MtAll_phi.sum(axis=0)  # total ES momentum spectrum
+            self.SumFlux_Mt_a = self.SumFlux_MtAll_a.sum(axis=0)      # total EM momentum spectrum
+            self.SumFlux_Mt = self.SumFlux_Mt_phi + self.SumFlux_Mt_a
+
             # ------------------------------------------------------------------------
             # QL Flux Spectrum (QL weights per mode)
             # ------------------------------------------------------------------------
@@ -4586,6 +4637,20 @@ class TGLFoutput(SIMtools.GACODEoutput):
             self.SumFlux_Qi_phi = np.zeros((1,))
             self.SumFlux_Qi_a = np.zeros((1,))
             self.SumFlux_Qi = np.zeros((1,))
+
+            self.SumFlux_GiAll_phi = np.zeros((1, 1))
+            self.SumFlux_GiAll_a = np.zeros((1, 1))
+            self.SumFlux_GiAll = np.zeros((1, 1))
+            self.SumFlux_Gi_phi = np.zeros((1,))
+            self.SumFlux_Gi_a = np.zeros((1,))
+            self.SumFlux_Gi = np.zeros((1,))
+
+            self.SumFlux_MtAll_phi = np.zeros((1, 1))
+            self.SumFlux_MtAll_a = np.zeros((1, 1))
+            self.SumFlux_MtAll = np.zeros((1, 1))
+            self.SumFlux_Mt_phi = np.zeros((1,))
+            self.SumFlux_Mt_a = np.zeros((1,))
+            self.SumFlux_Mt = np.zeros((1,))
 
             # QL Flux Spectrum
             self.QLFluxSpectrum = np.zeros((5, 1, 1, 1, 1))
@@ -4937,7 +5002,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_title("Spectrum: $\\delta T_e$ Amplitude")
         ax.set_ylabel("$A_{T_e}(k_y)$")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[1, 1]
 
@@ -4957,7 +5021,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_title("Spectrum: $\\delta n_e$ Amplitude")
         ax.set_ylabel("$A_{n_e}(k_y)$")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[2, 1]
 
@@ -4977,7 +5040,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_title("Spectrum: $n_e-T_e$ cross-phase angle")
         ax.set_ylabel("$\\alpha_{n_e,T_e}$ (degrees)")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax.axhline(y=0, ls="--", lw=1, c="k")
         ax.set_ylim([-180, 180])
@@ -4993,7 +5055,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$Q_{e,ky}$")
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[1, 2]
 
@@ -5004,7 +5065,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$Q_{i,ky}$")
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[2, 2]
 
@@ -5015,7 +5075,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$\\Gamma_{e,ky}$")
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
 
         # ***** Flux Values
 
@@ -5026,7 +5085,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_xlabel("$r/a$ (RMIN_LOC)")
         ax.set_ylabel("$Q_e/Q_{GB}$")
         ax.set_xlim([0, 1])
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Profile: $Q_e$ (GB)")
 
         ax = axs[3, 1]
@@ -5036,7 +5094,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_xlabel("$r/a$ (RMIN_LOC)")
         ax.set_ylabel("$Q_i/Q_{GB}$")
         ax.set_xlim([0, 1])
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Profile: $Q_i$ (GB)")
 
         ax = axs[3, 2]
@@ -5047,7 +5104,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$\\Gamma/\\Gamma_{GB}$")
         ax.set_xlim([0, 1])
         ax.axhline(y=0, ls="--", lw=1, c="k")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Profile: $\\Gamma_e$ (GB)")
 
     def plotTGLF_Contributors(
@@ -5100,9 +5156,8 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$Q_{e,ky}$")
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Spectrum (ES+EM): $Q_e$")
-        ax.legend(loc="best", fontsize=fontsizeLeg * 1.5, title=title_legend)
+        ax.legend(loc="best", title=title_legend)
 
         ax = axs[1, 0]
         ax.plot(
@@ -5129,7 +5184,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$Q_{i,ky}$")
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[2, 0]
         ax.plot(
@@ -5156,7 +5210,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$\\Gamma_{e,ky}$")
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
 
         # ***** EM+ES Flux radial
 
@@ -5198,9 +5251,8 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_xlabel("$r/a$ (RMIN_LOC)")
         ax.set_ylabel("$Q_e$ (GB)")
         ax.set_title("Profile (ES+EM): $Q_e$ (GB)")
-        ax.legend(loc="best", fontsize=fontsizeLeg * 1.5, title=title_legend)
+        ax.legend(loc="best", title=title_legend)
         ax.axhline(y=0, ls="--", c="k", lw=1)
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[1, 2]
         ax.plot(
@@ -5241,7 +5293,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$Q_i$ (GB)")
         ax.set_title("Profile (ES+EM): $Q_i$ (GB)")
         ax.axhline(y=0, ls="--", c="k", lw=1)
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[2, 2]
 
@@ -5283,7 +5334,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$\\Gamma_e$ (GB)")
         ax.set_title("Profile (ES+EM): $\\Gamma_e$ (GB)")
         ax.axhline(y=0, ls="--", c="k", lw=1)
-        GRAPHICStools.addDenseAxis(ax)
 
         # ***** Cumulative Spectra
 
@@ -5294,7 +5344,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.axhline(y=self.Qe, ls="--", lw=0.5, c=c)
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Spectrum (Cumulative): $Q_e$")
 
         ax = axs[1, 1]
@@ -5304,7 +5353,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.axhline(y=self.Qi, ls="--", lw=0.5, c=c)
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Spectrum (Cumulative): $Q_i$")
 
         ax = axs[2, 1]
@@ -5314,7 +5362,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.axhline(y=self.Ge, ls="--", lw=0.5, c=c)
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Spectrum (Cumulative): $\\Gamma_e$")
         ax.axhline(y=0, ls="--", lw=0.5, c="k")
 
@@ -5385,9 +5432,8 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$Q_{i,ky}$")
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Spectrum (each ion): $Q_i$")
-        ax.legend(loc="best", fontsize=fontsizeLeg * 1.5, title=title_legend)
+        ax.legend(loc="best", title=title_legend)
 
     def plotTGLF_Fluctuations(
         self, c="b", label="", axs=None, fontsizeLeg=4, title_legend="", cont=0
@@ -5412,7 +5458,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Amplitude Spectrum: $n_e$")
 
         ax = axs[1, 0]
@@ -5420,7 +5465,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Amplitude Spectrum: $T_e$")
 
         ax = axs[2, 0]
@@ -5437,9 +5481,8 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("$n_e-T_e$ Spectrum")
-        ax.legend(loc="best", fontsize=fontsizeLeg, title=title_legend)
+        GRAPHICStools.addLegendApart(ax, size=fontsizeLeg, ratio=0.9, title=title_legend)
 
         ax = axs[3, 0]
         for i in range(self.num_nmodes):
@@ -5455,7 +5498,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Intensity Spectrum: $n_e$")
 
         ax = axs[4, 0]
@@ -5472,7 +5514,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Intensity Spectrum: $T_e$")
 
         for ion in range(self.num_species - 1):
@@ -5488,7 +5529,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             ax.set_xscale("log")
             ax.set_xlabel("$k_{\\theta}\\rho_s$")
-            GRAPHICStools.addDenseAxis(ax)
             ax.set_title(f"Amplitude Spectrum: $n_{{i}}$ (ion {ion+1})")
 
             ax = axs[1, ion + 1]
@@ -5503,7 +5543,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             ax.set_xscale("log")
             ax.set_xlabel("$k_{\\theta}\\rho_s$")
-            GRAPHICStools.addDenseAxis(ax)
             ax.set_title(f"Amplitude Spectrum: $T_{{i}}$ (ion {ion+1})")
 
             ax = axs[2, ion + 1]
@@ -5520,7 +5559,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             ax.set_xscale("log")
             ax.set_xlabel("$k_{\\theta}\\rho_s$")
-            GRAPHICStools.addDenseAxis(ax)
             ax.set_title(f"$n_i-T_i$ Spectrum (ion {ion+1})")
 
             ax = axs[3, ion + 1]
@@ -5537,7 +5575,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             ax.set_xscale("log")
             ax.set_xlabel("$k_{\\theta}\\rho_s$")
-            GRAPHICStools.addDenseAxis(ax)
             ax.set_title(f"Intensity Spectrum: $n_{{i}}$ (ion {ion+1})")
 
             ax = axs[4, ion + 1]
@@ -5554,7 +5591,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             ax.set_xscale("log")
             ax.set_xlabel("$k_{\\theta}\\rho_s$")
-            GRAPHICStools.addDenseAxis(ax)
             ax.set_title(f"Intensity Spectrum: $T_{{i}}$ (ion {ion+1})")
 
     def plotTGLF_Field(
@@ -5635,9 +5671,7 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title(f"Growth Rate Spectrum")
-        ax.legend(loc="best", fontsize=fontsizeLeg, title=title_legend)
 
         ax = axs[1, 0]
         for i in range(self.num_nmodes):
@@ -5653,7 +5687,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title(f"Field Spectrum: {v[1]}")
 
         # ****************************************************************
@@ -5673,7 +5706,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("QL Spectrum: $Q_e$")
 
         ax = axs[0, 2]
@@ -5690,7 +5722,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("QL Spectrum: $\\Gamma_e$")
 
         for ion in range(self.num_species - 1):
@@ -5707,7 +5738,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             ax.set_xscale("log")
             ax.set_xlabel("$k_{\\theta}\\rho_s$")
-            GRAPHICStools.addDenseAxis(ax)
             ax.set_title(f"QL Spectrum: $Q_i$ (ion {ion+1})")
 
         # ****************************************************************
@@ -5719,7 +5749,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Sum Flux Spectrum: $Q_e$")
 
         ax = axs[1, 2]
@@ -5727,7 +5756,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
         ax.set_xscale("log")
         ax.set_xlabel("$k_{\\theta}\\rho_s$")
-        GRAPHICStools.addDenseAxis(ax)
         ax.set_title("Sum Flux Spectrum: $\\Gamma_e$")
 
         for ion in range(self.num_species - 1):
@@ -5736,8 +5764,233 @@ class TGLFoutput(SIMtools.GACODEoutput):
 
             ax.set_xscale("log")
             ax.set_xlabel("$k_{\\theta}\\rho_s$")
-            GRAPHICStools.addDenseAxis(ax)
             ax.set_title(f"Sum Flux Spectrum: $Q_i$ (ion {ion+1})")
+
+        # Place legend outside the last column so it never overlaps inner plots
+        ax_last = axs[0, axs.shape[1] - 1]
+        handles, labels_h = axs[0, 0].get_legend_handles_labels()
+        box = ax_last.get_position()
+        ax_last.set_position([box.x0, box.y0, box.width * 0.9, box.height])
+        prop = {"size": fontsizeLeg} if fontsizeLeg is not None else {}
+        ax_last.legend(handles, labels_h, loc="upper left",
+                       bbox_to_anchor=(1, 1.0), prop=prop, title=title_legend)
+
+    def plotTGLF_IonMomFluxes(
+        self, c="b", label="", axs=None, fontsizeLeg=4, title_legend=None, cont=0
+    ):
+        """
+        Plot per-ion particle fluxes (Gi), per-ion heat flux (QiAll), total momentum
+        flux (Mt) spectra and radial totals.  axs must be shape (3, 4).
+        """
+
+        if axs is None:
+            plt.ion()
+            fig = plt.figure(figsize=(14, 7))
+            grid = plt.GridSpec(3, 4, hspace=0.6, wspace=0.3)
+            axs = np.empty((3, 4), dtype=plt.Axes)
+            axs[0, 0] = fig.add_subplot(grid[0, 0])
+            for r in range(3):
+                for c_ in range(4):
+                    if r == 0 and c_ == 0:
+                        continue
+                    sharex = axs[0, 0] if c_ < 2 else None
+                    axs[r, c_] = fig.add_subplot(grid[r, c_], sharex=sharex)
+
+        typeline = GRAPHICStools.listmarkersLS()
+        n_ions = self.SumFlux_GiAll_phi.shape[0]
+
+        # --- Column 0: per-ion particle flux spectra (ES + EM) ---
+        ax = axs[0, 0]
+        for ion in range(n_ions):
+            ax.plot(self.ky, self.SumFlux_GiAll_phi[ion, :], typeline[ion],
+                    color=c, lw=0.7, markersize=2,
+                    label=f"ion {ion+1} ES" if cont == 0 else "")
+            ax.plot(self.ky, self.SumFlux_GiAll_a[ion, :], typeline[ion],
+                    color=c, lw=0.3, markersize=1, alpha=0.5,
+                    label=f"ion {ion+1} EM" if cont == 0 else "")
+        ax.axhline(y=0, ls="--", lw=1, c="k")
+        ax.set_ylabel("$\\Gamma_{i,ky}$")
+        ax.set_xscale("log")
+        ax.set_xlabel("$k_{\\theta}\\rho_s$")
+        ax.set_title("Spectrum: $\\Gamma_i$ per ion")
+        ax.legend(loc="best", title=title_legend)
+
+        # --- Column 0 row 1: per-ion heat flux spectra ---
+        ax = axs[1, 0]
+        for ion in range(n_ions):
+            ax.plot(self.ky, self.SumFlux_QiAll_phi[ion, :], typeline[ion],
+                    color=c, lw=0.7, markersize=2,
+                    label=f"ion {ion+1} ES" if cont == 0 else "")
+            ax.plot(self.ky, self.SumFlux_QiAll_a[ion, :], typeline[ion],
+                    color=c, lw=0.3, markersize=1, alpha=0.5)
+        ax.axhline(y=0, ls="--", lw=1, c="k")
+        ax.set_ylabel("$Q_{i,ky}$")
+        ax.set_xscale("log")
+        ax.set_xlabel("$k_{\\theta}\\rho_s$")
+        ax.set_title("Spectrum: $Q_i$ per ion")
+        ax.legend(loc="best", title=title_legend)
+
+        # --- Column 0 row 2: total momentum flux spectrum ---
+        ax = axs[2, 0]
+        ax.plot(self.ky, self.SumFlux_Mt_phi, "-o", color=c, lw=0.7, markersize=2,
+                label="ES" if cont == 0 else "")
+        ax.plot(self.ky, self.SumFlux_Mt_a, "-s", color=c, lw=0.3, markersize=2,
+                label="EM" if cont == 0 else "")
+        ax.axhline(y=0, ls="--", lw=1, c="k")
+        ax.set_ylabel("$\\Pi_{ky}$ (GB)")
+        ax.set_xscale("log")
+        ax.set_xlabel("$k_{\\theta}\\rho_s$")
+        ax.set_title("Spectrum: Total momentum $\\Pi$")
+        ax.legend(loc="best", title=title_legend)
+
+        # --- Column 1: cumulative spectra ---
+        ax = axs[0, 1]
+        ax.plot(self.ky, np.cumsum(self.SumFlux_Gi), "-o", color=c, lw=1.0, markersize=2)
+        ax.axhline(y=self.Gi if hasattr(self, 'Gi') else 0, ls="--", lw=0.5, c=c)
+        ax.set_xscale("log")
+        ax.set_xlabel("$k_{\\theta}\\rho_s$")
+        ax.set_title("Cumulative: $\\Gamma_i$ (summed ions)")
+
+        ax = axs[1, 1]
+        ax.plot(self.ky, np.cumsum(self.SumFlux_Qi), "-o", color=c, lw=1.0, markersize=2)
+        ax.axhline(y=self.Qi, ls="--", lw=0.5, c=c)
+        ax.set_xscale("log")
+        ax.set_xlabel("$k_{\\theta}\\rho_s$")
+        ax.set_title("Cumulative: $Q_i$ (summed ions)")
+
+        ax = axs[2, 1]
+        ax.plot(self.ky, np.cumsum(self.SumFlux_Mt), "-o", color=c, lw=1.0, markersize=2)
+        ax.axhline(y=self.Mt, ls="--", lw=0.5, c=c)
+        ax.set_xscale("log")
+        ax.set_xlabel("$k_{\\theta}\\rho_s$")
+        ax.set_title("Cumulative: $\\Pi$ (total momentum)")
+
+        # --- Column 2: per-ion radial scalars ---
+        ax = axs[0, 2]
+        for ion in range(n_ions):
+            Gi_ion = self.GiAll[ion] if hasattr(self, 'GiAll') and len(self.GiAll) > ion else 0.0
+            ax.plot([self.roa], [Gi_ion], typeline[ion], c=c, markersize=5,
+                    label=f"ion {ion+1}" if cont == 0 else "")
+        ax.set_xlim([0, 1])
+        ax.set_xlabel("$r/a$")
+        ax.set_ylabel("$\\Gamma_i$ (GB)")
+        ax.set_title("Profile: $\\Gamma_i$ per ion")
+        ax.axhline(y=0, ls="--", c="k", lw=1)
+        ax.legend(loc="best", title=title_legend)
+
+        ax = axs[1, 2]
+        for ion in range(n_ions):
+            Qi_ion = self.QiAll[ion] if hasattr(self, 'QiAll') and len(self.QiAll) > ion else 0.0
+            ax.plot([self.roa], [Qi_ion], typeline[ion], c=c, markersize=5,
+                    label=f"ion {ion+1}" if cont == 0 else "")
+        ax.set_xlim([0, 1])
+        ax.set_xlabel("$r/a$")
+        ax.set_ylabel("$Q_i$ (GB)")
+        ax.set_title("Profile: $Q_i$ per ion")
+        ax.axhline(y=0, ls="--", c="k", lw=1)
+
+        ax = axs[2, 2]
+        ax.plot([self.roa], [self.MtES], "-o", c=c, markersize=5,
+                label="ES" if cont == 0 else "")
+        ax.plot([self.roa], [self.MtEM], "-s", c=c, markersize=5,
+                label="EM" if cont == 0 else "")
+        ax.plot([self.roa], [self.Mt], "-*", c=c, markersize=5,
+                label="ES+EM" if cont == 0 else "")
+        ax.set_xlim([0, 1])
+        ax.set_xlabel("$r/a$")
+        ax.set_ylabel("$\\Pi$ (GB)")
+        ax.set_title("Profile: Total momentum $\\Pi$")
+        ax.axhline(y=0, ls="--", c="k", lw=1)
+        ax.legend(loc="best", title=title_legend)
+
+        # --- Column 3: per-species momentum spectrum ---
+        ax = axs[0, 3]
+        for sp in range(self.SumFlux_MtAll_phi.shape[0]):
+            lbl = "electrons" if sp == 0 else f"ion {sp}"
+            ax.plot(self.ky, self.SumFlux_MtAll_phi[sp, :], typeline[sp],
+                    color=c, lw=0.7, markersize=2,
+                    label=lbl if cont == 0 else "")
+        ax.axhline(y=0, ls="--", lw=1, c="k")
+        ax.set_ylabel("$\\Pi_{ky}$ (GB)")
+        ax.set_xscale("log")
+        ax.set_xlabel("$k_{\\theta}\\rho_s$")
+        ax.set_title("Momentum (ES) per species")
+        ax.legend(loc="best", title=title_legend)
+
+        ax = axs[1, 3]
+        for ion in range(n_ions):
+            Gi_ion = float(np.sum(self.SumFlux_GiAll_phi[ion, :]))
+            ax.plot([self.roa], [Gi_ion], typeline[ion], c=c, markersize=5,
+                    label=f"ion {ion+1}" if cont == 0 else "")
+        ax.set_xlim([0, 1])
+        ax.set_xlabel("$r/a$")
+        ax.set_ylabel("$\\Gamma_i$ ES (GB)")
+        ax.set_title("Profile: $\\Gamma_i$ ES per ion")
+        ax.axhline(y=0, ls="--", c="k", lw=1)
+
+        ax = axs[2, 3]
+        for sp in range(self.SumFlux_MtAll_phi.shape[0]):
+            Mt_sp = float(np.sum(self.SumFlux_MtAll_phi[sp, :]))
+            lbl = "electrons" if sp == 0 else f"ion {sp}"
+            ax.plot([self.roa], [Mt_sp], typeline[sp], c=c, markersize=5,
+                    label=lbl if cont == 0 else "")
+        ax.set_xlim([0, 1])
+        ax.set_xlabel("$r/a$")
+        ax.set_ylabel("$\\Pi$ ES (GB)")
+        ax.set_title("Momentum ES per species")
+        ax.axhline(y=0, ls="--", c="k", lw=1)
+        ax.legend(loc="best", title=title_legend)
+
+    def plotTGLF_SAT(self, axs=None, c="b", label="", cont=0):
+        """
+        Plot scalar saturation parameters (requires scalar_sat_params to be populated).
+        axs must be shape (1, 2). All labels are overlaid on the same axes as colored lines.
+        """
+
+        if not self.scalar_sat_params:
+            return
+
+        if axs is None:
+            plt.ion()
+            fig = plt.figure(figsize=(10, 4))
+            grid = plt.GridSpec(1, 2)
+            axs = np.empty((1, 2), dtype=plt.Axes)
+            axs[0, 0] = fig.add_subplot(grid[0, 0])
+            axs[0, 1] = fig.add_subplot(grid[0, 1])
+
+        # ---- left: key scalar SAT parameters, one colored line per label ----
+        scalar_keys = ["ALPHA_ZF", "kymax_out", "vzf_out", "rho_ion", "rho_e",
+                       "ETG_FACTOR", "SAT_geo0_out", "SAT_geo1_out", "SAT_geo2_out"]
+        ax = axs[0, 0]
+        vals_present = {k: self.scalar_sat_params[k] for k in scalar_keys if k in self.scalar_sat_params}
+        if vals_present:
+            ks = list(vals_present.keys())
+            vs = [vals_present[k] for k in ks]
+            xs = np.arange(len(ks))
+            ax.plot(xs, vs, "-o", color=c, lw=1.5, markersize=5, label=label)
+            ax.set_xticks(xs)
+            ax.set_xticklabels(ks, rotation=40, ha="right", fontsize=7)
+            ax.axhline(y=0, ls="--", lw=0.5, c="k")
+            ax.set_title(f"SAT scalars (r/a={self.roa:.3f})")
+            ax.legend(loc="best")
+
+        # ---- right: geometry / normalization parameters as a line plot ----
+        geo_keys = ["Bt0_out", "B_geo0_out", "grad_r0_out", "B_unit", "R_unit", "q_unit"]
+        ax = axs[0, 1]
+        vals_geo = {k: self.scalar_sat_params[k] for k in geo_keys if k in self.scalar_sat_params}
+        if vals_geo:
+            ks = list(vals_geo.keys())
+            vs = [vals_geo[k] for k in ks]
+            xs = np.arange(len(ks))
+            sat_rule = self.scalar_sat_params.get("SAT_RULE", "?")
+            xnu     = self.scalar_sat_params.get("XNU_MODEL", "?")
+            lbl = f"{label}  [SAT{sat_rule}, XNU{xnu}]"
+            ax.plot(xs, vs, "-o", color=c, lw=1.5, markersize=5, label=lbl)
+            ax.set_xticks(xs)
+            ax.set_xticklabels(ks, rotation=40, ha="right", fontsize=7)
+            ax.axhline(y=0, ls="--", lw=0.5, c="k")
+            ax.set_title(f"SAT geometry (r/a={self.roa:.3f})")
+            ax.legend(loc="best")
 
     def plotTGLF_Model(self, c="b", label="", axs=None):
         if axs is None:
@@ -5768,7 +6021,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         for i in [0.3, 1.65]:
             ax.axhline(y=i, lw=0.5, ls="--", c="k")
         ax.set_title("Gaussian Width Spectrum")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[1, 0]
         ax.plot(
@@ -5785,7 +6037,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$kx_e$")
         ax.set_xscale("log")
         ax.set_title("Spectral Shift Spectrum, $<phi|kx/ky|phi>/<phi|phi>$")
-        GRAPHICStools.addDenseAxis(ax)
 
         ax = axs[0, 1]
         ax.plot(
@@ -5802,7 +6053,6 @@ class TGLFoutput(SIMtools.GACODEoutput):
         ax.set_ylabel("$<p_0>$")
         ax.set_xscale("log")
         ax.set_title("SAT0 normalization")
-        GRAPHICStools.addDenseAxis(ax)
 
 
 def processGrowthRates(k, g, f, gs, fs, klow=0.8, coeff=0):

--- a/src/mitim_tools/gacode_tools/TGLFtools.py
+++ b/src/mitim_tools/gacode_tools/TGLFtools.py
@@ -33,6 +33,7 @@ class TGLF(SIMtools.mitim_simulation):
     def __init__(
         self,
         rhos=[0.4, 0.6],  # rho locations of interest
+        in_process=False,  # If True, run TGLF in-process via ctypes (no subprocess); requires libtglf_serial.so
         cdf=None,  # Option1: Start from CDF file (TRANSP) - Path to file
         time=100.0,  # 		   Time to extract CDF file
         avTime=0.0,  # 		   Averaging window to extract CDF file
@@ -40,6 +41,7 @@ class TGLF(SIMtools.mitim_simulation):
     ):
 
         super().__init__(rhos=rhos)
+        self.in_process = in_process
 
         def code_call(folder, p, n = 1, additional_command="", **kwargs):
             return f"tglf -e {folder} -n {n} -p {p} {additional_command}"
@@ -137,6 +139,204 @@ class TGLF(SIMtools.mitim_simulation):
                 "SELECTED": None,
             }
 
+            self._inprocess_cache: dict = {}   # {subfolder: raw {rho: outputs_dict}}
+
+    def prep(self, mitim_state, FolderGACODE=None, **kwargs):
+        """
+        Prepare the TGLF run from a MITIM state (input.gacode path or object).
+
+        When ``self.in_process=True``, *FolderGACODE* is optional.  If omitted
+        a temporary directory is used as a logical base path — nothing is ever
+        written to it.  No ``input.tglf*`` or ``input.gacode_torun`` files are
+        created.
+
+        When ``self.in_process=False`` the behaviour is identical to the parent:
+        *FolderGACODE* is required and all files are written normally.
+        """
+        if not self.in_process:
+            return super().prep(mitim_state, FolderGACODE, **kwargs)
+
+        # ------------------------------------------------------------------
+        # Zero-file in-process prep
+        # ------------------------------------------------------------------
+        import tempfile
+        from mitim_tools.gacode_tools import PROFILEStools
+        from mitim_tools.gacode_tools.utils import NORMtools
+        from mitim_tools.misc_tools.PLASMAtools import md_u
+
+        # Use the provided folder as a logical base (no mkdir); fall back to temp.
+        if FolderGACODE is None:
+            self.FolderGACODE = Path(tempfile.mkdtemp(prefix="tglf_inprocess_"))
+        else:
+            self.FolderGACODE = Path(FolderGACODE).resolve()
+
+        # Load profiles
+        if isinstance(mitim_state, (str, Path)):
+            self.profiles = PROFILEStools.gacode_state(str(mitim_state))
+        else:
+            self.profiles = mitim_state
+
+        self.profiles.derive_quantities(mi_ref=md_u)
+
+        # Build TGLFinput objects in memory — no files written
+        raw = self.profiles.to_tglf(r=self.rhos, r_is_rho=True)
+        self.inputs_files = {}
+        for rho, d in raw.items():
+            inp = TGLFinput.initialize_in_memory(d)
+            # Set a logical (never-created) file path so later code that
+            # inspects inp.file doesn't hit AttributeError
+            inp.file = self.FolderGACODE / f"input.tglf_{float(rho):.4f}"
+            self.inputs_files[rho] = inp
+
+        # Normalizations (pure in-memory)
+        print("> Setting up normalizations")
+        self.NormalizationSets, cdf = NORMtools.normalizations(self.profiles)
+        return cdf
+
+    def _run_prepare(self, subfolder_simulation, code_executor=None, code_executor_full=None,
+                     code_settings=None, extraOptions={}, multipliers={}, minimum_delta_abs={},
+                     cold_start=False, forceIfcold_start=False, only_minimal_files=False,
+                     launchSlurm=True, slurm_setup=None, additional_files_to_send=None,
+                     **kwargs_control):
+        """
+        When ``self.in_process=True``: build TGLFinput objects in memory via
+        ``modifyInputs()`` — no folder creation, no file writes.
+        When ``self.in_process=False``: delegate to the parent implementation.
+        """
+        if not self.in_process:
+            return super()._run_prepare(
+                subfolder_simulation,
+                code_executor=code_executor,
+                code_executor_full=code_executor_full,
+                code_settings=code_settings,
+                extraOptions=extraOptions,
+                multipliers=multipliers,
+                minimum_delta_abs=minimum_delta_abs,
+                cold_start=cold_start,
+                forceIfcold_start=forceIfcold_start,
+                only_minimal_files=only_minimal_files,
+                launchSlurm=launchSlurm,
+                slurm_setup=slurm_setup,
+                additional_files_to_send=additional_files_to_send,
+                **kwargs_control,
+            )
+
+        # ------------------------------------------------------------------
+        # Zero-file in-process path
+        # ------------------------------------------------------------------
+        from mitim_tools.simulation_tools.SIMtools import modifyInputs
+
+        if code_executor is None:
+            code_executor = {}
+        if code_executor_full is None:
+            code_executor_full = {}
+
+        # Compute the logical folder path (never created on disk)
+        Folder_sim = (self.FolderGACODE / subfolder_simulation).resolve()
+
+        inputs = copy.deepcopy(self.inputs_files)
+
+        mod_input_file = {}
+        for i, rho in enumerate(self.rhos):
+            print(f"\t- [in-process] Preparing input for rho={rho:.4f}")
+            input_sim_rho = modifyInputs(
+                inputs[rho],
+                code_settings=code_settings,
+                extraOptions=extraOptions,
+                multipliers=multipliers,
+                minimum_delta_abs=minimum_delta_abs if minimum_delta_abs else {},
+                position_change=i,
+                addControlFunction=self.run_specifications["control_function"],
+                controls_file=self.run_specifications["controls_file"],
+                NS=inputs[rho].num_recorded,
+            )
+            if code_settings is not None:
+                input_sim_rho.removeLowDensitySpecie()
+                input_sim_rho.remove_fast()
+            if kwargs_control.get("Quasineutral", False):
+                input_sim_rho.ensureQuasineutrality()
+            input_sim_rho.anticipate_problems()
+            mod_input_file[rho] = input_sim_rho
+
+        code_executor_full[subfolder_simulation] = {}
+        code_executor[subfolder_simulation] = {}
+        for irho in self.rhos:
+            entry = {
+                "folder":     Folder_sim,
+                "dictionary": mod_input_file[irho],
+                "inputs":     None,
+                "extraOptions": extraOptions,
+                "multipliers":  multipliers,
+                "additional_files_to_send": None,
+            }
+            code_executor_full[subfolder_simulation][irho] = entry
+            code_executor[subfolder_simulation][irho] = entry
+
+        self.FolderSimLast = Folder_sim
+        return code_executor, code_executor_full
+
+    def _run(self, code_executor, run_type='normal', **kwargs_run):
+        """
+        Dispatch to in-process ctypes engine or parent subprocess/SLURM engine.
+
+        When ``self.in_process=True`` the Fortran physics is called directly via
+        ctypes for every (subfolder, rho) in *code_executor* — no file I/O.
+        Results are stored in ``self._inprocess_cache[str(folder_sim)]``.
+        """
+        if not self.in_process:
+            return super()._run(code_executor, run_type=run_type, **kwargs_run)
+
+        import os
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        from mitim_tools.simulation_tools.interfaces import tglf_inprocess as _tip
+
+        # Build work items — one per (subfolder_variation, rho)
+        work_items = []   # (subfolder_sim, rho, flat, tglf_input, folder_sim)
+        for subfolder_sim, rho_dict in code_executor.items():
+            for rho, rho_info in rho_dict.items():
+                folder_sim = rho_info["folder"]
+                tglf_input = rho_info["dictionary"]
+                flat = {}
+                flat.update(tglf_input.controls)
+                flat.update(tglf_input.plasma)
+                for i, sp_data in tglf_input.species.items():
+                    for var, val in sp_data.items():
+                        flat[f"{var}_{i}"] = val
+                work_items.append((subfolder_sim, rho, flat, tglf_input, folder_sim))
+
+        n_workers = os.cpu_count() or 1
+        n_jobs    = len(work_items)
+        print(f"\t- [in-process] Submitting {n_jobs} TGLF cases across {min(n_workers, n_jobs)} workers")
+
+        results_by_folder: dict = {}
+
+        # Use threads, not processes.
+        # • ctypes releases the GIL during Fortran calls → true parallelism.
+        # • Each thread loads a private copy of the .so (via _get_thread_lib())
+        #   so Fortran module-level globals are independent per thread.
+        # • No macOS spawn/fork/forkserver issues; no __main__ re-execution.
+        with ThreadPoolExecutor(max_workers=min(n_workers, n_jobs)) as pool:
+            future_map = {
+                pool.submit(_tip._parallel_worker, flat): (subfolder_sim, rho, tglf_input, folder_sim)
+                for subfolder_sim, rho, flat, tglf_input, folder_sim in work_items
+            }
+            for future in as_completed(future_map):
+                subfolder_sim, rho, tglf_input, folder_sim = future_map[future]
+                outputs = future.result()
+                key = str(folder_sim)
+                if key not in results_by_folder:
+                    results_by_folder[key] = {"raw": {}, "inputs": {}}
+                results_by_folder[key]["raw"][float(rho)]    = outputs
+                results_by_folder[key]["inputs"][float(rho)] = tglf_input
+                print(
+                    f"\t- [in-process] rho={rho:.4f}  "
+                    f"Qe={outputs['elec_eflux']:.4f}  "
+                    f"Qi[0]={outputs['ion_eflux'][0]:.4f}"
+                )
+
+        self._inprocess_cache.update(results_by_folder)
+        self.simulation_job = None   # keep attribute consistent with parent
+
     # This is redefined (from parent) because it has the option of producing WaveForms (very TGLF specific)
     def run(
         self,
@@ -145,12 +345,88 @@ class TGLF(SIMtools.mitim_simulation):
         forceClosestUnstableWF=True,    # Look at the growth rate spectrum and run exactly the ky of the closest unstable
         **kwargs_generic_run
     ):
-        
-        code_executor_full = super().run(subfolder, **kwargs_generic_run)
+        if runWaveForms and self.in_process:
+            print("\t- runWaveForms not supported in in-process mode — skipping", typeMsg="w")
+            runWaveForms = None
 
-        kwargs_generic_run['runWaveForms'] = runWaveForms
-        kwargs_generic_run['forceClosestUnstableWF'] = forceClosestUnstableWF
-        self._helper_wf(code_executor_full, **kwargs_generic_run)
+        if not self.in_process:
+            # Standard subprocess / SLURM path
+            code_executor_full = super().run(subfolder, **kwargs_generic_run)
+            kwargs_generic_run['runWaveForms'] = runWaveForms
+            kwargs_generic_run['forceClosestUnstableWF'] = forceClosestUnstableWF
+            self._helper_wf(code_executor_full, **kwargs_generic_run)
+            return
+
+        # ------------------------------------------------------------------
+        # In-process path: route through overridden _run_prepare + _run
+        # (zero file I/O — folder never created, no input.tglf written)
+        # ------------------------------------------------------------------
+        super().run(subfolder, **kwargs_generic_run)
+        # FolderSimLast is now the resolved Path set by _run_prepare()
+
+    def run_inprocess(
+        self,
+        subfolder,
+        code_settings=None,
+        extraOptions={},
+        multipliers={},
+    ):
+        """
+        Run TGLF fully in-memory — zero file I/O for both input preparation
+        and physics execution.
+
+        Inputs are built directly from ``self.profiles`` via
+        ``PROFILES_GACODE.to_tglf()``, with ``code_settings``,
+        ``extraOptions``, and ``multipliers`` applied in memory.
+        The Fortran physics subroutine is called directly via ctypes —
+        no subprocess fork, no ``input.tglf*`` files written.
+
+        Only ``out.tglf.gbflux_{rho:.4f}`` is written per rho (the minimal
+        file needed by ``read()``).
+
+        Prerequisites
+        -------------
+            Build the shared library once before first use::
+
+                cd <MITIM-fusion>/src/mitim_tools/simulation_tools/interfaces
+                bash build_tglf_lib.sh
+
+        Usage
+        -----
+            tglf.prep(...)
+            tglf.run_inprocess("run1/", code_settings="SAT1")
+            tglf.read(label="run1", require_all_files=False)
+        """
+        from mitim_tools.simulation_tools.interfaces import tglf_inprocess as _tip
+        from mitim_tools.misc_tools import IOtools
+
+        # ------------------------------------------------------------------
+        # 1. Build inputs in memory via to_tglf() and run physics
+        # ------------------------------------------------------------------
+        runner = _tip.TGLFInProcess()
+        runner.prepare(
+            self.profiles,
+            rhos=self.rhos,
+            code_settings=code_settings,
+            extraOptions=extraOptions,
+            multipliers=multipliers,
+        )
+        results = runner.run_all()   # {rho: output_dict} — zero file I/O
+
+        # ------------------------------------------------------------------
+        # 2. Create output folder and write the minimal file read() needs
+        # ------------------------------------------------------------------
+        Folder_sim = IOtools.expandPath(self.FolderGACODE / subfolder)
+        Folder_sim.mkdir(parents=True, exist_ok=True)
+
+        for rho, outputs in results.items():
+            _tip.write_gbflux(outputs, Folder_sim / f"out.tglf.gbflux_{rho:.4f}")
+            print(
+                f"\t- [in-process] rho={rho:.4f}  Qe={outputs['elec_eflux']:.4f}"
+                f"  Qi[0]={outputs['ion_eflux'][0]:.4f}"
+            )
+
+        return results
 
     # This is redefined (from parent) because it has the option of producing WaveForms (very TGLF specific)
     def run_scan(
@@ -859,6 +1135,64 @@ class TGLF(SIMtools.mitim_simulation):
         input_gacode = None, # Only needed to grab normalizations if they weren't populated already (e.g. this is just a "read" of an already run folder
         save_and_cleanup = None,  # If a Path/str is given, save npz there then delete the raw run folder
     ):
+        # ------------------------------------------------------------------
+        # In-process path: build results entirely from memory (no file I/O)
+        # ------------------------------------------------------------------
+        if self.in_process:
+            subfolder = folder if folder is not None else self.FolderSimLast
+            cache_key = str(subfolder)
+            if cache_key not in self._inprocess_cache:
+                raise RuntimeError(
+                    f"No in-process results cached for key '{cache_key}'. "
+                    "Call run() first."
+                )
+            cached   = self._inprocess_cache[cache_key]
+            raw      = cached["raw"]       # {rho: outputs_dict}
+            inp_files = cached["inputs"]   # {rho: TGLFinput}
+
+            if "d_perp_dict" not in self.__dict__:
+                self.d_perp_dict = None
+
+            self.updateConvolution()
+
+            output_list, inputclasses, parsed = [], [], []
+            for rho in self.rhos:
+                inputclass = inp_files.get(rho) or inp_files.get(float(rho))
+                outputs    = raw.get(rho)    or raw.get(float(rho))
+                out = TGLFoutput.from_inprocess(inputclass, outputs)
+                out.unnormalize(
+                    self.NormalizationSets["SELECTED"],
+                    rho=rho,
+                    convolution_fun_fluct=self.convolution_fun_fluct,
+                    factorTot_to_Perp=self.factorTot_to_Perp,
+                )
+                output_list.append(out)
+                inputclasses.append(inputclass)
+                # Build the flat input dict so read_scan() can access scan variables
+                if inputclass is not None:
+                    flat_parsed = {}
+                    flat_parsed.update(inputclass.controls)
+                    flat_parsed.update(inputclass.plasma)
+                    for i, sp_data in inputclass.species.items():
+                        for var, val in sp_data.items():
+                            flat_parsed[f"{var}_{i}"] = val
+                else:
+                    flat_parsed = {}
+                parsed.append(flat_parsed)
+
+            self.results[label] = {
+                "output":      output_list,
+                "inputclasses": inputclasses,
+                "parsed":      parsed,
+                "x":           np.array(self.rhos),
+                "convolution_fun_fluct": self.convolution_fun_fluct,
+                "DRMAJDX_LOC": self.DRMAJDX_LOC,
+                "profiles":    self.NormalizationSets.get("input_gacode"),
+                "wavefunction": {},
+            }
+            print(f"\t- [in-process] Read results for label '{label}' ({len(self.rhos)} rho values)")
+            return
+
         print("> Reading TGLF results")
 
         if d_perp_cm is not None:
@@ -4569,7 +4903,7 @@ def readTGLFresults(
 class TGLFoutput(SIMtools.GACODEoutput):
     def __init__(self, FolderGACODE, suffix="", require_all_files=True):
         super().__init__()
-        
+
         self.FolderGACODE, self.suffix = FolderGACODE, suffix
 
         if self.suffix == "":
@@ -4584,6 +4918,139 @@ class TGLFoutput(SIMtools.GACODEoutput):
         self.postprocess()
 
         print(f"\t- TGLF was run with {self.num_species} species, {self.num_nmodes} modes, {self.num_fields} field(s) ({', '.join(self.fields)}), {self.num_ky} wavenumbers",)
+
+    @classmethod
+    def from_inprocess(cls, inputclass, outputs):
+        """
+        Create a TGLFoutput from in-process ctypes results — no file I/O.
+
+        Replicates the ``require_all_files=False`` path of ``TGLFoutput.read()``:
+        all flux quantities are populated from *outputs*; spectral arrays are
+        set to dummy zeros so that ``postprocess()`` and ``unnormalize()`` can
+        run without error.  Spectral/growth-rate metrics will be zero/NaN.
+
+        Parameters
+        ----------
+        inputclass : TGLFinput
+            Processed input object for this rho (provides species ordering,
+            SIGN_IT correction).  May be None (conservative fallback used).
+        outputs : dict
+            Output dict from ``TGLFInProcess.run_from_dict()`` — keys:
+            ``ns``, ``elec_pflux``, ``elec_eflux``, ``elec_mflux``,
+            ``elec_expwd``, ``ion_pflux``, ``ion_eflux``, ``ion_mflux``,
+            ``ion_expwd``.
+        """
+        obj = cls.__new__(cls)
+        SIMtools.GACODEoutput.__init__(obj)   # sets obj.inputFile = None
+
+        obj.FolderGACODE  = None
+        obj.suffix        = ""
+        obj.inputclass    = inputclass
+        obj.roa           = inputclass.plasma["RMIN_LOC"] if inputclass is not None else 0.0
+        obj.inputFile     = ""
+        obj.inputFile_gen = ""
+
+        # --- Species accounting (same logic as TGLFoutput.read()) ---
+        if inputclass is not None:
+            extras = [i - 1 for i in inputclass.ions_info["thermal_list_extras"]]
+            obj.ions_included = (1,) + tuple(extras)
+            obj.fast_included = tuple(i - 1 for i in inputclass.ions_info["fast_list"])
+        else:
+            obj.ions_included = (1,)
+            obj.fast_included = ()
+
+        # --- Flux values ---
+        ns = outputs["ns"]
+        ni = ns - 1
+
+        obj.Ge    = outputs["elec_pflux"]
+        obj.Qe    = outputs["elec_eflux"]
+        obj.Me    = outputs["elec_mflux"]
+        obj.Se    = outputs["elec_expwd"]
+        obj.GiAll = np.array(outputs["ion_pflux"][:ni])
+        obj.QiAll = np.array(outputs["ion_eflux"][:ni])
+        obj.MiAll = np.array(outputs["ion_mflux"][:ni])
+        obj.SiAll = np.array(outputs["ion_expwd"][:ni])
+
+        # Build [e, ion1, ion2, ...] arrays for ions_included indexing
+        Gfull = np.concatenate([[obj.Ge], obj.GiAll])
+        Qfull = np.concatenate([[obj.Qe], obj.QiAll])
+        obj.Gi    = float(Gfull[list(obj.ions_included)].sum())
+        obj.Qi    = float(Qfull[list(obj.ions_included)].sum())
+        obj.Qifast = float(Qfull[list(obj.fast_included)].sum()) if obj.fast_included else 0.0
+
+        # SIGN_IT correction for momentum (same as read())
+        sign_it = inputclass.plasma["SIGN_IT"] if inputclass is not None else 1.0
+        signMt   = -sign_it
+        obj.Me   = obj.Me  * signMt
+        obj.MiAll = obj.MiAll * signMt
+        obj.Mt   = obj.Me + float(obj.MiAll.sum())
+        obj.Si   = float(obj.SiAll.sum())
+
+        # --- Spectral placeholders (mirrors require_all_files=False block) ---
+        obj.ky         = np.zeros((1,))
+        obj.num_ky     = 1
+        obj.num_nmodes = 1
+        obj.num_species = ns
+        obj.num_fields = 1
+        obj.fields     = []
+        obj.Eigenvalues = np.zeros((2, 1, 1))
+        obj.g           = np.zeros((1, 1))
+        obj.f           = np.zeros((1, 1))
+        obj.tglf_model  = {"width": np.zeros((1,)), "spectral_shift": np.zeros((1,)), "ave_p0": np.zeros((1,))}
+        obj.AmplitudeSpectrum    = np.zeros((1, 1, 1))
+        obj.AmplitudeSpectrum_Te = np.zeros((1,))
+        obj.AmplitudeSpectrum_Ti = np.zeros((1, 1))
+        obj.AmplitudeSpectrum_ne = np.zeros((1,))
+        obj.AmplitudeSpectrum_ni = np.zeros((1, 1))
+        obj.nTSpectrum   = np.zeros((1, 1, 1))
+        obj.neTeSpectrum = np.zeros((1, 1))
+        obj.niTiSpectrum = np.zeros((1, 1, 1))
+        obj.FieldSpectrum    = np.zeros((4, 1, 1))
+        obj.v_spectrum       = np.zeros((1, 1))
+        obj.phi_spectrum     = np.zeros((1, 1))
+        obj.a_par_spectrum   = np.zeros((1, 1))
+        obj.a_per_spectrum   = np.zeros((1, 1))
+        obj.SumFluxSpectrum  = np.zeros((5, 1, 1, 1))
+        obj.SumFlux_Qe_phi   = np.zeros((1,)); obj.SumFlux_Ge_phi   = np.zeros((1,))
+        obj.SumFlux_QiAll_phi = np.zeros((1, 1))
+        obj.SumFlux_Qe_a_par = np.zeros((1,)); obj.SumFlux_Ge_a_par = np.zeros((1,))
+        obj.SumFlux_QiAll_a_par = np.zeros((1, 1))
+        obj.SumFlux_Qe_a_per = np.zeros((1,)); obj.SumFlux_Ge_a_per = np.zeros((1,))
+        obj.SumFlux_QiAll_a_per = np.zeros((1, 1))
+        obj.SumFlux_Qe_a  = np.zeros((1,)); obj.SumFlux_Ge_a  = np.zeros((1,))
+        obj.SumFlux_QiAll_a = np.zeros((1, 1))
+        obj.SumFlux_Qe    = np.zeros((1,)); obj.SumFlux_Ge    = np.zeros((1,))
+        obj.SumFlux_QiAll = np.zeros((1, 1))
+        obj.SumFlux_Qi_phi = np.zeros((1,)); obj.SumFlux_Qi_a = np.zeros((1,))
+        obj.SumFlux_Qi     = np.zeros((1,))
+        obj.SumFlux_GiAll_phi = np.zeros((1, 1)); obj.SumFlux_GiAll_a = np.zeros((1, 1))
+        obj.SumFlux_GiAll = np.zeros((1, 1))
+        obj.SumFlux_Gi_phi = np.zeros((1,)); obj.SumFlux_Gi_a = np.zeros((1,))
+        obj.SumFlux_Gi     = np.zeros((1,))
+        obj.SumFlux_MtAll_phi = np.zeros((1, 1)); obj.SumFlux_MtAll_a = np.zeros((1, 1))
+        obj.SumFlux_MtAll  = np.zeros((1, 1))
+        obj.SumFlux_Mt_phi = np.zeros((1,)); obj.SumFlux_Mt_a = np.zeros((1,))
+        obj.SumFlux_Mt     = np.zeros((1,))
+        obj.QLFluxSpectrum  = np.zeros((5, 1, 1, 1, 1))
+        obj.QLFluxSpectrum_Ge_phi    = np.zeros((1, 1)); obj.QLFluxSpectrum_Qe_phi    = np.zeros((1, 1))
+        obj.QLFluxSpectrum_GiAll_phi = np.zeros((1, 1, 1)); obj.QLFluxSpectrum_Gi_phi = np.zeros((1, 1))
+        obj.QLFluxSpectrum_QiAll_phi = np.zeros((1, 1, 1)); obj.QLFluxSpectrum_Qi_phi = np.zeros((1, 1))
+        obj.QLFluxSpectrum_Ge_a_par    = np.zeros((1, 1)); obj.QLFluxSpectrum_Qe_a_par    = np.zeros((1, 1))
+        obj.QLFluxSpectrum_GiAll_a_par = np.zeros((1, 1, 1)); obj.QLFluxSpectrum_Gi_a_par = np.zeros((1, 1))
+        obj.QLFluxSpectrum_QiAll_a_par = np.zeros((1, 1, 1)); obj.QLFluxSpectrum_Qi_a_par = np.zeros((1, 1))
+        obj.QLFluxSpectrum_Ge_a_per    = np.zeros((1, 1)); obj.QLFluxSpectrum_Qe_a_per    = np.zeros((1, 1))
+        obj.QLFluxSpectrum_GiAll_a_per = np.zeros((1, 1, 1)); obj.QLFluxSpectrum_Gi_a_per = np.zeros((1, 1))
+        obj.QLFluxSpectrum_QiAll_a_per = np.zeros((1, 1, 1)); obj.QLFluxSpectrum_Qi_a_per = np.zeros((1, 1))
+        obj.IntensitySpectrum    = np.zeros((4, 1, 1, 1))
+        obj.IntensitySpectrum_ne = np.zeros((1, 1)); obj.IntensitySpectrum_Te = np.zeros((1, 1))
+        obj.IntensitySpectrum_ni = np.zeros((1, 1, 1)); obj.IntensitySpectrum_Ti = np.zeros((1, 1, 1))
+
+        obj.postprocess()
+
+        print(f"\t- [in-process] rho={obj.roa:.4f}  "
+              f"Qe={obj.Qe:.4f}  Qi={obj.Qi:.4f}  Ge={obj.Ge:.4f}")
+        return obj
 
     def postprocess(self):
         coeff, klow = 0.0, 0.8

--- a/src/mitim_tools/gacode_tools/TGLFtools.py
+++ b/src/mitim_tools/gacode_tools/TGLFtools.py
@@ -294,6 +294,283 @@ class TGLF(SIMtools.mitim_simulation):
         with open(file, "wb") as handle:
             pickle.dump(tglf_copy, handle, protocol=4)
 
+    def save_npz(self, file):
+        """
+        Save all TGLF results as a lightweight compressed numpy archive (.npz).
+
+        Only numerical arrays and the minimal metadata required for plotting/analysis
+        are stored.  Heavy Python objects (profiles, TGYRO, matplotlib functions) are
+        intentionally omitted to keep the file small.  Arrays are stored as float32
+        (half the size of float64, sufficient for post-processing).
+
+        The complementary classmethod TGLF.from_npz(file) reconstructs a functional
+        TGLF object from this file.
+        """
+        import json
+
+        file = Path(file)
+        arrays = {}
+        meta = {
+            "rhos": [float(r) for r in self.rhos],
+            "labels": list(self.results.keys()),
+            "mitim_version": mitim_version,
+        }
+
+        # ---- Per-label / per-rho output arrays ----
+        for label in self.results:
+            res = self.results[label]
+            meta[f"{label}__x"] = [float(v) for v in res["x"]]
+            meta[f"{label}__DRMAJDX_LOC"] = res.get("DRMAJDX_LOC", {})
+
+            for irho, output in enumerate(res["output"]):
+                pfx = f"{label}__{irho}__"
+
+                # Scalar metadata
+                meta[f"{pfx}roa"] = float(output.roa)
+                meta[f"{pfx}num_species"] = int(output.num_species)
+                meta[f"{pfx}num_nmodes"] = int(output.num_nmodes)
+                meta[f"{pfx}num_ky"] = int(output.num_ky)
+                meta[f"{pfx}num_fields"] = int(output.num_fields)
+                meta[f"{pfx}fields"] = list(output.fields)
+                meta[f"{pfx}ions_included"] = list(output.ions_included)
+                meta[f"{pfx}fast_included"] = list(output.fast_included)
+                meta[f"{pfx}unnorm_ok"] = bool(output.unnormalization_successful)
+                meta[f"{pfx}inputFile"] = output.inputFile
+                meta[f"{pfx}tglf_version"] = getattr(output, "tglf_version", "")
+                meta[f"{pfx}scalar_sat_params"] = getattr(output, "scalar_sat_params", {})
+
+                # Main spectra — includes all derived slice attributes so that
+                # from_npz() can restore them directly without re-running read().
+                _spectrum_attrs = [
+                    "ky", "Eigenvalues", "g", "f",
+                    "AmplitudeSpectrum", "AmplitudeSpectrum_Te", "AmplitudeSpectrum_ne",
+                    "AmplitudeSpectrum_Ti", "AmplitudeSpectrum_ni",
+                    "nTSpectrum", "neTeSpectrum", "niTiSpectrum",
+                    "FieldSpectrum", "v_spectrum", "phi_spectrum",
+                    "a_par_spectrum", "a_per_spectrum",
+                    "SumFluxSpectrum",
+                    "SumFlux_Qe_phi", "SumFlux_Qe_a_par", "SumFlux_Qe_a_per",
+                    "SumFlux_Qe_a", "SumFlux_Qe",
+                    "SumFlux_Ge_phi", "SumFlux_Ge_a_par", "SumFlux_Ge_a_per",
+                    "SumFlux_Ge_a", "SumFlux_Ge",
+                    "SumFlux_QiAll_phi", "SumFlux_QiAll_a_par", "SumFlux_QiAll_a_per",
+                    "SumFlux_QiAll_a", "SumFlux_QiAll",
+                    "SumFlux_Qi_phi", "SumFlux_Qi_a", "SumFlux_Qi",
+                    "SumFlux_GiAll_phi", "SumFlux_GiAll_a", "SumFlux_GiAll",
+                    "SumFlux_Gi_phi", "SumFlux_Gi_a", "SumFlux_Gi",
+                    "SumFlux_MtAll_phi", "SumFlux_MtAll_a", "SumFlux_MtAll",
+                    "SumFlux_Mt_phi", "SumFlux_Mt_a", "SumFlux_Mt",
+                    # QL flux spectrum — full array plus all derived slices used by plotTGLF_Field
+                    "QLFluxSpectrum",
+                    "QLFluxSpectrum_Ge_phi", "QLFluxSpectrum_Qe_phi",
+                    "QLFluxSpectrum_GiAll_phi", "QLFluxSpectrum_Gi_phi",
+                    "QLFluxSpectrum_QiAll_phi", "QLFluxSpectrum_Qi_phi",
+                    "QLFluxSpectrum_Ge_a_par", "QLFluxSpectrum_Qe_a_par",
+                    "QLFluxSpectrum_GiAll_a_par", "QLFluxSpectrum_Gi_a_par",
+                    "QLFluxSpectrum_QiAll_a_par", "QLFluxSpectrum_Qi_a_par",
+                    "QLFluxSpectrum_Ge_a_per", "QLFluxSpectrum_Qe_a_per",
+                    "QLFluxSpectrum_GiAll_a_per", "QLFluxSpectrum_Gi_a_per",
+                    "QLFluxSpectrum_QiAll_a_per", "QLFluxSpectrum_Qi_a_per",
+                    "IntensitySpectrum", "IntensitySpectrum_ne", "IntensitySpectrum_Te",
+                    "IntensitySpectrum_ni", "IntensitySpectrum_Ti",
+                ]
+                for attr in _spectrum_attrs:
+                    if hasattr(output, attr):
+                        v = getattr(output, attr)
+                        if isinstance(v, np.ndarray):
+                            arrays[pfx + attr] = v.astype(np.float32)
+                        elif isinstance(v, (int, float)):
+                            arrays[pfx + attr] = np.array([v], dtype=np.float32)
+
+                # tglf_model sub-arrays
+                if hasattr(output, "tglf_model"):
+                    for k, v in output.tglf_model.items():
+                        arrays[f"{pfx}tglf_model__{k}"] = np.asarray(v, dtype=np.float32)
+
+                # Scalar fluxes (from gbflux)
+                for attr in ["Ge", "Qe", "Qi", "Qifast", "Me", "Mt", "Se", "Si"]:
+                    if hasattr(output, attr):
+                        arrays[pfx + attr] = np.array([getattr(output, attr)], dtype=np.float32)
+                for attr in ["GiAll", "QiAll", "MiAll", "SiAll"]:
+                    if hasattr(output, attr):
+                        v = getattr(output, attr)
+                        arrays[pfx + attr] = np.asarray(v, dtype=np.float32)
+
+                # Unnormalized fluxes (if available)
+                for attr in ["Qe_unn", "Qi_unn", "Qifast_unn", "Ge_unn", "Mt_unn", "Se_unn"]:
+                    if hasattr(output, attr):
+                        arrays[pfx + attr] = np.array([getattr(output, attr)], dtype=np.float32)
+                for attr in ["QiAll_unn", "GiAll_unn"]:
+                    if hasattr(output, attr):
+                        arrays[pfx + attr] = np.asarray(getattr(output, attr), dtype=np.float32)
+
+                # Fluctuation levels
+                for attr in ["AmplitudeSpectrum_Te_level", "AmplitudeSpectrum_ne_level",
+                             "neTeSpectrum_level"]:
+                    if hasattr(output, attr):
+                        arrays[pfx + attr] = np.array([getattr(output, attr)], dtype=np.float32)
+
+
+        # ---- Normalization (SELECTED set only — pure numpy arrays) ----
+        norm = self.NormalizationSets.get("SELECTED")
+        if norm is not None:
+            for k, v in norm.items():
+                try:
+                    arrays[f"norm__{k}"] = np.asarray(v, dtype=np.float32)
+                except (TypeError, ValueError):
+                    pass  # skip non-array entries (e.g. mi_ref scalar handled below)
+                    meta[f"norm_scalar__{k}"] = float(v) if isinstance(v, (int, float, np.floating)) else str(v)
+
+        # EXP normalization (experimental fluxes for comparison plots)
+        exp = self.NormalizationSets.get("EXP")
+        if exp is not None:
+            for k, v in exp.items():
+                try:
+                    arrays[f"exp__{k}"] = np.asarray(v, dtype=np.float32)
+                except (TypeError, ValueError):
+                    pass
+
+        # ---- Metadata packed as JSON bytes ----
+        meta_bytes = np.frombuffer(json.dumps(meta).encode("utf-8"), dtype=np.uint8)
+        arrays["__meta__"] = meta_bytes
+
+        np.savez_compressed(file, **arrays)
+
+        # Report size (np.savez_compressed appends .npz if not present)
+        npz_path = file.with_suffix(".npz") if file.suffix != ".npz" else file
+        size_kb = npz_path.stat().st_size / 1024
+        print(f"> Saved TGLF results to {IOtools.clipstr(npz_path)} ({size_kb:.1f} kB)")
+
+    @classmethod
+    def from_npz(cls, file):
+        """
+        Reconstruct a TGLF object from a file written by save_npz().
+
+        The returned object supports plot() and all analysis methods that operate on
+        the stored results.  Methods that require the raw run folders, TGYRO objects,
+        or profiles (GACODE profile tabs, renormalization) are not available.
+        """
+        import json
+
+        file = Path(file)
+        if file.suffix != ".npz":
+            file = file.with_suffix(".npz")
+
+        data = np.load(file, allow_pickle=False)
+        meta = json.loads(data["__meta__"].tobytes().decode("utf-8"))
+
+        from mitim_tools.simulation_tools import SIMtools
+
+        # ---- Bare TGLF shell ----
+        tglf = object.__new__(cls)
+        tglf.rhos = meta["rhos"]
+        tglf.results = {}
+        tglf.NormalizationSets = {
+            k: None for k in ["TRANSP", "PROFILES", "TGYRO", "EXP", "input_gacode", "SELECTED"]
+        }
+        tglf.ky_single = None
+        tglf.tgyro = None
+        tglf.d_perp_dict = None
+        tglf.convolution_fun_fluct = None
+        tglf.factorTot_to_Perp = 1.0
+        tglf.DRMAJDX_LOC = {}
+        tglf.FoldersTGLF_WF = {}
+
+        # ---- Rebuild NormalizationSets["SELECTED"] ----
+        norm_keys = [k[len("norm__"):] for k in data.files if k.startswith("norm__")]
+        if norm_keys:
+            norm = {k: data[f"norm__{k}"].astype(np.float64) for k in norm_keys}
+            # restore scalar entries stored in meta
+            for mk, mv in meta.items():
+                if mk.startswith("norm_scalar__"):
+                    norm[mk[len("norm_scalar__"):]] = mv
+            tglf.NormalizationSets["SELECTED"] = norm
+
+        # ---- Rebuild NormalizationSets["EXP"] ----
+        exp_keys = [k[len("exp__"):] for k in data.files if k.startswith("exp__")]
+        if exp_keys:
+            tglf.NormalizationSets["EXP"] = {
+                k: data[f"exp__{k}"].astype(np.float64) for k in exp_keys
+            }
+
+        # ---- Rebuild results per label ----
+        for label in meta["labels"]:
+            res = {}
+            res["x"] = np.array(meta[f"{label}__x"])
+            res["DRMAJDX_LOC"] = meta.get(f"{label}__DRMAJDX_LOC", {})
+            res["convolution_fun_fluct"] = None
+            res["profiles"] = None
+            res["wavefunction"] = {}
+
+            outputs, inputclasses, parseds = [], [], []
+
+            n_rhos = len(meta[f"{label}__x"])
+            for irho in range(n_rhos):
+                pfx = f"{label}__{irho}__"
+
+                # Bare TGLFoutput shell
+                output = object.__new__(TGLFoutput)
+                output.FolderGACODE = None
+                output.suffix = ""
+
+                # Metadata
+                output.roa = float(meta[f"{pfx}roa"])
+                output.num_species = int(meta[f"{pfx}num_species"])
+                output.num_nmodes = int(meta[f"{pfx}num_nmodes"])
+                output.num_ky = int(meta[f"{pfx}num_ky"])
+                output.num_fields = int(meta[f"{pfx}num_fields"])
+                output.fields = list(meta[f"{pfx}fields"])
+                output.ions_included = tuple(int(x) for x in meta[f"{pfx}ions_included"])
+                output.fast_included = tuple(int(x) for x in meta[f"{pfx}fast_included"])
+                output.unnormalization_successful = bool(meta[f"{pfx}unnorm_ok"])
+                output.inputFile = meta[f"{pfx}inputFile"]
+                output.tglf_version = meta.get(f"{pfx}tglf_version", "")
+                output.scalar_sat_params = meta.get(f"{pfx}scalar_sat_params", {})
+                output.inputFile_gen = ""
+
+                # Restore all numpy arrays stored under this prefix
+                for key in data.files:
+                    if key.startswith(pfx) and not key.startswith(f"{pfx}tglf_model__"):
+                        attr = key[len(pfx):]
+                        setattr(output, attr, data[key].astype(np.float64))
+
+                # Restore tglf_model dict
+                output.tglf_model = {}
+                for key in data.files:
+                    if key.startswith(f"{pfx}tglf_model__"):
+                        sub = key[len(f"{pfx}tglf_model__"):]
+                        output.tglf_model[sub] = data[key].astype(np.float64)
+
+                # Scalar fluxes stored as 1-element arrays — unwrap to float
+                for attr in ["Ge", "Qe", "Qi", "Qifast", "Me", "Mt", "Se", "Si",
+                             "Qe_unn", "Qi_unn", "Qifast_unn", "Ge_unn", "Mt_unn", "Se_unn",
+                             "AmplitudeSpectrum_Te_level", "AmplitudeSpectrum_ne_level",
+                             "neTeSpectrum_level"]:
+                    if hasattr(output, attr):
+                        v = getattr(output, attr)
+                        if isinstance(v, np.ndarray) and v.size == 1:
+                            setattr(output, attr, float(v.flat[0]))
+
+                # Reconstruct TGLFinput from stored inputFile string
+                input_dict = SIMtools.buildDictFromInput(output.inputFile)
+                output.inputclass = TGLFinput.initialize_in_memory(input_dict)
+
+                # Re-derive postprocess metrics (requires SumFlux_* to be set)
+                output.postprocess()
+
+                outputs.append(output)
+                inputclasses.append(output.inputclass)
+                parseds.append({})
+
+            res["output"] = outputs
+            res["inputclasses"] = inputclasses
+            res["parsed"] = parseds
+            tglf.results[label] = res
+
+        print(f"> Loaded TGLF results from {IOtools.clipstr(file)} "
+              f"({len(tglf.results)} label(s), {len(tglf.rhos)} rho(s))")
+        return tglf
+
     def prep_using_tgyro(
         self,
         FolderGACODE,  # Main folder where all caculations happen (runs will be in subfolders)
@@ -4351,6 +4628,50 @@ class TGLFoutput(SIMtools.GACODEoutput):
             lines = fi.readlines()
         self.inputFile = "".join(lines)
 
+        if require_all_files:
+
+            # Generated input file (defaults filled in by TGLF)
+            gen_path = self.FolderGACODE / ("input.tglf.gen" + self.suffix)
+            if gen_path.exists():
+                with open(gen_path, "r") as fi:
+                    self.inputFile_gen = fi.read()
+            else:
+                self.inputFile_gen = ""
+
+            # TGLF version string
+            version_path = self.FolderGACODE / ("out.tglf.version" + self.suffix)
+            if version_path.exists():
+                with open(version_path, "r") as fi:
+                    self.tglf_version = fi.read().strip()
+            else:
+                self.tglf_version = ""
+
+            # Scalar saturation parameters
+            self.scalar_sat_params = {}
+            sat_path = self.FolderGACODE / ("out.tglf.scalar_saturation_parameters" + self.suffix)
+            if sat_path.exists():
+                with open(sat_path, "r") as fi:
+                    for line in fi:
+                        line = line.strip()
+                        if line.startswith("!") or "=" not in line:
+                            continue
+                        key, val = line.split("=", 1)
+                        key = key.strip()
+                        val = val.strip().split()[0]  # first token only
+                        try:
+                            val = int(val)
+                        except ValueError:
+                            try:
+                                val = float(val)
+                            except ValueError:
+                                pass
+                        self.scalar_sat_params[key] = val
+
+        else:
+            self.inputFile_gen = ""
+            self.tglf_version = ""
+            self.scalar_sat_params = {}
+
     def unnormalize(self, normalization, rho=None, convolution_fun_fluct=None, factorTot_to_Perp=1.0):
         if normalization is not None:
             rho_x = normalization["rho"]
@@ -4442,9 +4763,9 @@ class TGLFoutput(SIMtools.GACODEoutput):
             'sum_flux': ['nspecies', 'nfields', 'nky'],
         }
         data_type_mapper = {
-            'amplitude': ['density', 'temperature'],
+            'amplitude': ['temperature', 'density'],  # index 0 = temperature (dataT appended first), 1 = density
             'eigenvalue': ['imaginary', 'real'],
-            'field': ['density', 'temperature', 'parallel_velocity', 'parallel_energy'],
+            'field': ['v', 'phi', 'a_par', 'a_per'],  # FieldSpectrum[0]=v, [1]=phi, [2]=a_par, [3]=a_per
             'intensity': ['density', 'temperature', 'parallel_velocity', 'parallel_energy'],
             'ql_flux': ['particle', 'energy', 'toroidal_stress', 'parallel_stress', 'exchange'],
             'sum_flux': ['particle', 'energy', 'toroidal_stress', 'parallel_stress', 'exchange'],

--- a/src/mitim_tools/gacode_tools/scripts/read_vgen.py
+++ b/src/mitim_tools/gacode_tools/scripts/read_vgen.py
@@ -1,0 +1,49 @@
+"""
+Read and plot results from an existing profiles_gen -vgen run.
+
+    mitim_plot_vgen <folder> [--gacode input.gacode]
+
+<folder>  : directory containing the vgen run (i.e. the parent of the vgen/ sub-folder)
+--gacode  : optional path to the original input.gacode, used to show the w0 profile before VGEN
+"""
+
+import argparse
+from IPython import embed
+from mitim_tools.misc_tools import IOtools
+from mitim_tools.gacode_tools import NEOtools, PROFILEStools
+
+def main():
+
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("folder", type=str, help="Directory containing the VGEN run (parent of vgen/ sub-folder)")
+    parser.add_argument("--gacode", required=False, type=str, default=None,
+                        help="Original input.gacode (used to display w0 before VGEN)")
+
+    args = parser.parse_args()
+
+    folder     = IOtools.expandPath(args.folder)
+    gacode     = IOtools.expandPath(args.gacode) if args.gacode is not None else None
+
+    neo = NEOtools.NEO(rhos=[])
+
+    # Reconstruct the profiles attribute so plot_vgen() can show the before/after comparison
+    if gacode is not None:
+        neo.profiles = PROFILEStools.gacode_state(gacode, derive_quantities=True)
+    else:
+        # Fall back to the input.gacode written inside the vgen folder before VGEN was run
+        fallback = folder / "input.gacode"
+        if fallback.exists():
+            neo.profiles = PROFILEStools.gacode_state(fallback, derive_quantities=True)
+        else:
+            neo.profiles = None
+
+    # folder_vgen must be set so read_vgen() knows where to look
+    neo.FolderGACODE = folder.parent
+    neo.read_vgen(subfolder=folder.name)
+
+    neo.plot_vgen()
+    neo.fn.show()
+    embed()
+
+if __name__ == "__main__":
+    main()

--- a/src/mitim_tools/gacode_tools/scripts/read_vgen.py
+++ b/src/mitim_tools/gacode_tools/scripts/read_vgen.py
@@ -1,43 +1,28 @@
 """
 Read and plot results from an existing profiles_gen -vgen run.
 
-    mitim_plot_vgen <folder> [--gacode input.gacode]
+    mitim_plot_vgen <folder>
 
-<folder>  : directory containing the vgen run (i.e. the parent of the vgen/ sub-folder)
---gacode  : optional path to the original input.gacode, used to show the w0 profile before VGEN
+<folder>  : directory containing the vgen run (i.e. the parent of the vgen/ sub-folder).
+            When smooth_profiles=True was used, input.gacode.raw and input.gacode are both
+            read automatically so the raw vs. smoothed comparison tab is populated.
 """
 
 import argparse
 from IPython import embed
 from mitim_tools.misc_tools import IOtools
-from mitim_tools.gacode_tools import NEOtools, PROFILEStools
+from mitim_tools.gacode_tools import NEOtools
 
 def main():
 
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("folder", type=str, help="Directory containing the VGEN run (parent of vgen/ sub-folder)")
-    parser.add_argument("--gacode", required=False, type=str, default=None,
-                        help="Original input.gacode (used to display w0 before VGEN)")
 
     args = parser.parse_args()
 
-    folder     = IOtools.expandPath(args.folder)
-    gacode     = IOtools.expandPath(args.gacode) if args.gacode is not None else None
+    folder = IOtools.expandPath(args.folder)
 
     neo = NEOtools.NEO(rhos=[])
-
-    # Reconstruct the profiles attribute so plot_vgen() can show the before/after comparison
-    if gacode is not None:
-        neo.profiles = PROFILEStools.gacode_state(gacode, derive_quantities=True)
-    else:
-        # Fall back to the input.gacode written inside the vgen folder before VGEN was run
-        fallback = folder / "input.gacode"
-        if fallback.exists():
-            neo.profiles = PROFILEStools.gacode_state(fallback, derive_quantities=True)
-        else:
-            neo.profiles = None
-
-    # folder_vgen must be set so read_vgen() knows where to look
     neo.FolderGACODE = folder.parent
     neo.read_vgen(subfolder=folder.name)
 

--- a/src/mitim_tools/gacode_tools/utils/CGYROutils.py
+++ b/src/mitim_tools/gacode_tools/utils/CGYROutils.py
@@ -1,4 +1,5 @@
 import os
+import math
 import scipy
 import numpy as np
 from pathlib import Path
@@ -17,6 +18,57 @@ except ModuleNotFoundError:
     print("\t- Could not find pygacode module in this environment. Please install it if you need CGYRO capabilities", typeMsg='w')
 from IPython import embed
 import pandas as pd
+
+
+def compute_box_and_nradial(
+    q,
+    shear,
+    rmin,
+    ky_min,
+    L_x=90.0,
+    N_radial=256,
+    min_box_size=100,
+):
+    """
+    Pick CGYRO BOX_SIZE and N_RADIAL from local equilibrium quantities.
+
+    Port of an IDL recipe: targets a radial box length of ~L_x (in the IDL
+    author's convention) and ~N_radial radial modes, with N_RADIAL
+    constrained so N_RADIAL/BOX_SIZE is a positive integer and N_RADIAL
+    is even.
+
+    rmin is r/a (i.e., the CGYRO RMIN parameter), ky_min is the CGYRO KY
+    parameter (k_theta * rho_s at the surface). Returns (BOX_SIZE, N_RADIAL)
+    as Python ints.
+    """
+
+    rhostar_int = ky_min / (q / rmin)
+    box_fac = (rmin / (q * shear)) / rhostar_int
+    box_calc = L_x / box_fac
+
+    box_floor = int(math.floor(box_calc))
+    box_ceil = box_floor + 1
+
+    # Literal port of the IDL guard. The raw integer comparison only matches
+    # the original "never smaller than 100 rho_s" comment when box_fac ~ 1.
+    if box_floor < min_box_size:
+        box_size = box_ceil
+    else:
+        candidates = [box_floor, box_ceil]
+        deltas = [abs(c * box_fac - L_x) for c in candidates]
+        box_size = candidates[int(np.argmin(deltas))]
+
+    r_fac = N_radial / box_size
+    if (r_fac - math.floor(r_fac)) >= 0.5:
+        r_test = int(math.floor(r_fac)) + 1
+    else:
+        r_test = int(math.floor(r_fac))
+    if (r_test * box_size) % 2 != 0:
+        r_test += 1
+    n_radial_out = int(r_test * box_size)
+
+    return int(box_size), n_radial_out
+
 
 class CGYROlinear_scan:
     def __init__(self, labels, results, irho = 0):   

--- a/src/mitim_tools/gacode_tools/utils/GACODEinprocess.py
+++ b/src/mitim_tools/gacode_tools/utils/GACODEinprocess.py
@@ -342,9 +342,13 @@ class TGLFInProcess(_GACODEInProcessMixin):
         return _tip._parallel_worker
 
     def _inprocess_postprocess_input(self, input_sim_rho, code_settings, kwargs_control):
-        # TGLF: drop low-density / fast species and optionally enforce
+        # TGLF: drop low-density / fast species (gated by ApplyCorrections,
+        # mirroring SIMtools.change_and_write_code) and optionally enforce
         # quasineutrality before passing the input to the Fortran engine.
-        if code_settings is not None:
+        # PORTALS' transport_tglf passes ApplyCorrections=False — without
+        # this gate the in-process path would silently strip species the
+        # subprocess path keeps and produce different fluxes.
+        if code_settings is not None and kwargs_control.get("ApplyCorrections", True):
             input_sim_rho.removeLowDensitySpecie()
             input_sim_rho.remove_fast()
         if kwargs_control.get("Quasineutral", False):

--- a/src/mitim_tools/gacode_tools/utils/GACODEinprocess.py
+++ b/src/mitim_tools/gacode_tools/utils/GACODEinprocess.py
@@ -50,7 +50,9 @@ prefixes and log lines).
 from __future__ import annotations
 
 import copy
+import ctypes
 import os
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -59,6 +61,112 @@ from mitim_tools.simulation_tools.SIMtools import modifyInputs
 from mitim_tools.gacode_tools.utils import NORMtools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools.misc_tools.PLASMAtools import md_u
+
+
+# ---------------------------------------------------------------------------
+# BLAS thread budget control (runtime API, works after dlopen)
+#
+# When the in-process driver fans N codes out across N Python worker threads,
+# each worker enters Fortran code that calls into the underlying BLAS/LAPACK
+# library.  That BLAS library has its own thread pool and, by default, sizes
+# it to the entire node — so 18 workers on a 64-core node would each spin up
+# 64 BLAS threads, giving 18*64 ≈ 1152 OS threads competing for 64 cores.
+#
+# Setting OMP_NUM_THREADS / MKL_NUM_THREADS / OPENBLAS_NUM_THREADS in the
+# process environment is unreliable: env vars are read at library init time
+# (i.e. at dlopen) and pinning every BLAS to 1 thread globally also serialises
+# unrelated single-call paths that legitimately want multi-threaded BLAS
+# (laptop runs of TGLF visibly slow down 5-10x, since the per-call wins from
+# many BLAS threads dominate when there's no oversubscription pressure).
+#
+# Instead we use the BLAS library's own runtime API to set the per-pool
+# thread budget JUST BEFORE submitting a worker pool, sized to
+#     max(1, n_cpus // n_workers)
+# This is best-effort: we try every BLAS we know about (openblas, MKL,
+# Apple Accelerate / vecLib).  If none of them are loadable we print what
+# happened and carry on — no failure.
+# ---------------------------------------------------------------------------
+
+# Module-level cache so we don't keep re-dlopen'ing the same BLAS library.
+_BLAS_HANDLES: dict = {}     # name -> (cdll, setter_callable)
+
+
+def _try_load(libname: str):
+    """Best-effort dlopen.  Returns the CDLL handle or None."""
+    try:
+        return ctypes.CDLL(libname)
+    except OSError:
+        return None
+
+
+def _discover_blas_setters() -> list[tuple[str, callable]]:
+    """
+    Discover BLAS thread-count setters available in this process.
+
+    Returns a list of (name, setter) where setter(n: int) caps the BLAS
+    library at *n* threads.  Best effort: we don't error if a particular
+    BLAS isn't installed — most processes only have one anyway.
+    """
+    if _BLAS_HANDLES:
+        return [(name, setter) for name, (_lib, setter) in _BLAS_HANDLES.items()]
+
+    candidates: list[tuple[str, list[str], list[str]]] = []
+    # (display name, dlopen candidates, setter symbol candidates)
+    if sys.platform == "darwin":
+        candidates += [
+            ("openblas",   ["libopenblas.dylib", "libopenblas.0.dylib"],
+                           ["openblas_set_num_threads", "openblas_set_num_threads64_"]),
+            ("Accelerate", ["/System/Library/Frameworks/Accelerate.framework/Accelerate"],
+                           ["BLASSetThreading"]),  # rarely present, harmless if absent
+        ]
+    else:
+        candidates += [
+            ("openblas",   ["libopenblas.so.0", "libopenblas.so"],
+                           ["openblas_set_num_threads", "openblas_set_num_threads64_"]),
+            ("mkl",        ["libmkl_rt.so.2", "libmkl_rt.so.1", "libmkl_rt.so"],
+                           ["MKL_Set_Num_Threads", "mkl_set_num_threads_"]),
+        ]
+
+    found: list[tuple[str, callable]] = []
+    for name, libnames, syms in candidates:
+        for ln in libnames:
+            lib = _try_load(ln)
+            if lib is None:
+                continue
+            for sym in syms:
+                fn = getattr(lib, sym, None)
+                if fn is None:
+                    continue
+                fn.argtypes = [ctypes.c_int]
+                fn.restype  = None
+
+                def _setter(n: int, _fn=fn):
+                    _fn(ctypes.c_int(int(n)))
+
+                _BLAS_HANDLES[name] = (lib, _setter)
+                found.append((name, _setter))
+                break
+            if name in _BLAS_HANDLES:
+                break
+
+    return found
+
+
+def _set_blas_threads(n: int) -> list[str]:
+    """
+    Best-effort: cap every BLAS we can reach at *n* threads.
+
+    Returns the list of BLAS names we successfully pinned, for logging.
+    """
+    n = max(1, int(n))
+    pinned = []
+    for name, setter in _discover_blas_setters():
+        try:
+            setter(n)
+            pinned.append(name)
+        except Exception:  # noqa: BLE001 — best-effort, never fail the run
+            pass
+    return pinned
 
 
 # ===========================================================================
@@ -128,6 +236,18 @@ class _GACODEInProcessMixin:
         flat.update(input_obj.controls)
         flat.update(input_obj.plasma)
         return flat
+
+    def _inprocess_blas_threads_per_worker(self, n_cpus: int, n_workers: int) -> int:
+        """
+        How many BLAS threads each pool worker is allowed to use.
+
+        Default policy: divide cores evenly across workers, so the total
+        BLAS thread count never exceeds the available cores.  TGLF overrides
+        this to return 1 unconditionally because its eigensolves don't
+        amortise openblas's per-call thread sync (measured: 1 thread is
+        meaningfully faster than 8 for the full TGLF run).
+        """
+        return max(1, n_cpus // max(1, n_workers))
 
     def _inprocess_print_per_rho(self, rho, outputs):
         """Hook for per-rho post-run logging.  Default is silent."""
@@ -279,6 +399,7 @@ class _GACODEInProcessMixin:
         ``kwargs_run`` is accepted but ignored (subprocess-only options).
         """
         from concurrent.futures import ThreadPoolExecutor, as_completed
+        import time
 
         self._init_inprocess()
         worker = self._inprocess_load_worker()
@@ -297,27 +418,83 @@ class _GACODEInProcessMixin:
             self.simulation_job = None
             return
 
-        n_workers = os.cpu_count() or 1
+        n_cpus    = os.cpu_count() or 1
+        n_workers = min(n_cpus, n_jobs)
+        code_name = self._inprocess_code_name.upper()
+
+        # --- per-pool BLAS thread budget --------------------------------------
+        # Each worker thread will enter Fortran code that calls into BLAS.
+        # We pin the BLAS thread pool just before submitting so that
+        # n_workers * blas_threads_per_worker stays ≤ n_cpus, avoiding the
+        # 18*64-on-a-64-core-node oversubscription pattern that hammered
+        # the cluster previously.  Per-code subclasses override
+        # _inprocess_blas_threads_per_worker() — TGLF returns 1 unconditionally
+        # because its eigensolve sub-blocks don't amortise openblas thread
+        # sync (measured: 1 thread is faster than 8 threads per call).
+        blas_threads_per_worker = self._inprocess_blas_threads_per_worker(
+            n_cpus, n_workers
+        )
+        blas_pinned = _set_blas_threads(blas_threads_per_worker)
+
+        thread_env = {
+            "MKL":      os.environ.get("MKL_NUM_THREADS"),
+            "OPENBLAS": os.environ.get("OPENBLAS_NUM_THREADS"),
+            "OMP":      os.environ.get("OMP_NUM_THREADS"),
+        }
         print(
-            f"\t- [in-process] Submitting {n_jobs} {self._inprocess_code_name.upper()} "
-            f"cases across {min(n_workers, n_jobs)} workers"
+            f"\t- [in-process] Submitting {n_jobs} {code_name} cases "
+            f"across {n_workers} workers "
+            f"(BLAS threads/worker={blas_threads_per_worker}, "
+            f"runtime-pinned={blas_pinned or 'none'}; "
+            f"env MKL={thread_env['MKL']} OPENBLAS={thread_env['OPENBLAS']} "
+            f"OMP={thread_env['OMP']}; cpu_count={n_cpus})"
         )
 
+        # Per-job timing wrapper — measures wall time spent inside the Fortran
+        # call for each (subfolder, rho), so we can spot stragglers.
+        def _timed(flat):
+            t = time.perf_counter()
+            out = worker(flat)
+            return out, time.perf_counter() - t
+
         results_by_folder: dict = {}
-        with ThreadPoolExecutor(max_workers=min(n_workers, n_jobs)) as pool:
+        per_job_times: list[float] = []
+        t_pool_start = time.perf_counter()
+
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
             future_map = {
-                pool.submit(worker, flat): (subfolder_sim, rho, input_obj, folder_sim)
+                pool.submit(_timed, flat): (subfolder_sim, rho, input_obj, folder_sim)
                 for subfolder_sim, rho, flat, input_obj, folder_sim in work_items
             }
             for future in as_completed(future_map):
                 subfolder_sim, rho, input_obj, folder_sim = future_map[future]
-                outputs = future.result()
+                outputs, dt = future.result()
+                per_job_times.append(dt)
                 key = str(folder_sim)
                 if key not in results_by_folder:
                     results_by_folder[key] = {"raw": {}, "inputs": {}}
                 results_by_folder[key]["raw"][float(rho)]    = outputs
                 results_by_folder[key]["inputs"][float(rho)] = input_obj
                 self._inprocess_print_per_rho(rho, outputs)
+                print(
+                    f"\t  [in-process] {code_name} done  "
+                    f"subfolder={subfolder_sim!s:<24s} rho={float(rho):.3f}  "
+                    f"wall={dt:6.2f}s"
+                )
+
+        wall = time.perf_counter() - t_pool_start
+        if per_job_times:
+            t_min = min(per_job_times)
+            t_max = max(per_job_times)
+            t_sum = sum(per_job_times)
+            t_avg = t_sum / len(per_job_times)
+            speedup = t_sum / wall if wall > 0 else float("nan")
+            print(
+                f"\t- [in-process] {code_name} pool finished: "
+                f"{n_jobs} jobs in {wall:.2f}s wall  "
+                f"(per-job min/avg/max = {t_min:.2f}/{t_avg:.2f}/{t_max:.2f}s, "
+                f"sum={t_sum:.2f}s, parallel speedup={speedup:.1f}x / ideal {n_workers}x)"
+            )
 
         self._inprocess_cache.update(results_by_folder)
         self.simulation_job = None  # keep attribute consistent with mitim_simulation
@@ -340,6 +517,13 @@ class TGLFInProcess(_GACODEInProcessMixin):
     def _inprocess_load_worker(self):
         from mitim_tools.simulation_tools.interfaces import tglf_inprocess as _tip
         return _tip._parallel_worker
+
+    def _inprocess_blas_threads_per_worker(self, n_cpus: int, n_workers: int) -> int:
+        # TGLF eigensolves are too small to benefit from multi-threaded BLAS:
+        # measured 1 thread = ~700 ms/call, 8 threads = ~1280 ms/call.  This
+        # mirrors what gacode's `tglf` shell wrapper does (it exports
+        # OMP_NUM_THREADS=1 before invoking the binary).
+        return 1
 
     def _inprocess_postprocess_input(self, input_sim_rho, code_settings, kwargs_control):
         # TGLF: drop low-density / fast species (gated by ApplyCorrections,

--- a/src/mitim_tools/gacode_tools/utils/GACODEinprocess.py
+++ b/src/mitim_tools/gacode_tools/utils/GACODEinprocess.py
@@ -1,0 +1,470 @@
+"""
+GACODEinprocess.py
+==================
+Pure in-process logic for the GACODE-family simulation wrappers.
+
+This module contains **only** the in-process (ctypes) execution path —
+prep, run-prepare, run, read.  None of the methods here check
+``self.in_process`` or fall back to a subprocess engine; that decision
+lives in ``TGLFtools.TGLF`` / ``NEOtools.NEO``, which dispatch to the
+methods defined here when their ``in_process`` flag is set, and to the
+inherited ``mitim_simulation`` (subprocess) implementation otherwise.
+
+The classes are mixins — they do **not** inherit from
+``mitim_simulation``.  ``TGLF`` / ``NEO`` use multiple inheritance to
+combine the subprocess engine with the in-process mixin::
+
+    class TGLF(SIMtools.mitim_simulation, GACODEinprocess.TGLFInProcess):
+        def prep(self, ...):
+            if self.in_process:
+                return self.prep_inprocess(...)
+            return super().prep(...)
+        ...
+
+Method names are suffixed with ``_inprocess`` to make name collisions
+with the subprocess parent impossible.
+
+Class layout
+------------
+::
+
+    _GACODEInProcessMixin                 (shared in-process plumbing)
+            ▲
+            │       ┌──────────────┐
+            ├───────┤ TGLFInProcess │   (TGLF-specific hooks + read)
+            │       └──────────────┘
+            │       ┌──────────────┐
+            └───────┤  NEOInProcess │   (NEO-specific hooks + read)
+                    └──────────────┘
+
+Hooks subclasses customise:
+* ``_inprocess_load_worker()``        — return the per-code worker callable
+* ``_inprocess_postprocess_input()``  — apply per-rho input corrections
+* ``_inprocess_build_flat_dict()``    — build the flat input dict
+* ``_inprocess_print_per_rho()``      — per-rho post-run logging
+
+…and the class attribute ``_inprocess_code_name`` (used for tempdir
+prefixes and log lines).
+"""
+
+from __future__ import annotations
+
+import copy
+import os
+from pathlib import Path
+
+import numpy as np
+
+from mitim_tools.simulation_tools.SIMtools import modifyInputs
+from mitim_tools.gacode_tools.utils import NORMtools
+from mitim_tools.misc_tools.LOGtools import printMsg as print
+from mitim_tools.misc_tools.PLASMAtools import md_u
+
+
+# ===========================================================================
+# Shared in-process mixin
+# ===========================================================================
+
+class _GACODEInProcessMixin:
+    """
+    Shared in-process plumbing for the GACODE-family wrappers.
+
+    This is a **mixin** — it does not inherit from any simulation base
+    class.  It assumes the host instance provides the following
+    attributes (which ``mitim_simulation.__init__`` and the concrete
+    subclass set up):
+
+    * ``self.rhos``                — list of rho values
+    * ``self.run_specifications``  — populated by the concrete subclass
+    * ``self.FolderGACODE``        — set by ``prep_inprocess``
+    * ``self.FolderSimLast``       — set by ``_run_prepare_inprocess``
+    * ``self.NormalizationSets``   — populated by ``prep_inprocess``
+    * ``self.results``             — created by ``mitim_simulation.__init__``
+    * ``self.inputs_files``        — populated by ``prep_inprocess``
+    * ``self._inprocess_cache``    — created by ``_init_inprocess``
+
+    Concrete subclasses (``TGLFInProcess`` / ``NEOInProcess``) override
+    the small ``_inprocess_*`` hooks below to plug in code-specific
+    behaviour.
+    """
+
+    # Subclasses override.  Used for tempdir prefix + log lines.
+    _inprocess_code_name: str = "gacode"
+
+    # ------------------------------------------------------------------
+    # State initializer (call from the concrete class __init__)
+    # ------------------------------------------------------------------
+
+    def _init_inprocess(self) -> None:
+        """Initialise the in-process result cache.  Idempotent."""
+        if not hasattr(self, "_inprocess_cache"):
+            # {str(folder_sim): {"raw": {rho: outputs}, "inputs": {rho: input_obj}}}
+            self._inprocess_cache: dict = {}
+
+    # ------------------------------------------------------------------
+    # Hooks subclasses override
+    # ------------------------------------------------------------------
+
+    def _inprocess_load_worker(self):
+        """Return the module-level ``_parallel_worker`` callable for this code."""
+        raise NotImplementedError
+
+    def _inprocess_postprocess_input(self, input_sim_rho, code_settings, kwargs_control):
+        """
+        Apply per-rho corrections after ``modifyInputs()``.  Default is just
+        to call ``anticipate_problems``; TGLF additionally removes
+        low-density / fast species and optionally enforces quasineutrality.
+        """
+        input_sim_rho.anticipate_problems()
+
+    def _inprocess_build_flat_dict(self, input_obj) -> dict:
+        """
+        Convert an input object into the flat dict consumed by the
+        in-process worker.  Default merges ``controls`` and ``plasma``
+        (NEO species fields live in ``plasma`` already).  TGLF overrides
+        to also unpack the per-species sub-dicts.
+        """
+        flat: dict = {}
+        flat.update(input_obj.controls)
+        flat.update(input_obj.plasma)
+        return flat
+
+    def _inprocess_print_per_rho(self, rho, outputs):
+        """Hook for per-rho post-run logging.  Default is silent."""
+        pass
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _inprocess_get_cached(self, folder):
+        """
+        Look up the cached in-process result entry for ``folder`` (or for
+        ``self.FolderSimLast`` when *folder* is None).  Raises a clear
+        RuntimeError if nothing is cached.
+        """
+        subfolder = folder if folder is not None else self.FolderSimLast
+        cache_key = str(subfolder)
+        if cache_key not in self._inprocess_cache:
+            raise RuntimeError(
+                f"No in-process results cached for key '{cache_key}'. "
+                "Call run() first."
+            )
+        cached = self._inprocess_cache[cache_key]
+        return cached, cached["raw"], cached["inputs"]
+
+    # ------------------------------------------------------------------
+    # In-process implementations of prep / _run_prepare / _run
+    # No fallback to subprocess — that decision is made by the host class.
+    # ------------------------------------------------------------------
+
+    def prep_inprocess(self, mitim_state):
+        """
+        Prepare the run from a MITIM state (input.gacode path or object)
+        with zero file I/O — no folder is needed, no folder is created.
+
+        ``self.FolderGACODE`` is set to a synthetic in-memory ``Path``
+        like ``<tglf_inprocess>/`` that is **never** touched on disk; it
+        only serves as a logical base for cache keys + ``inp.file``
+        attributes that downstream code may inspect.
+        """
+        from mitim_tools.gacode_tools import PROFILEStools
+
+        self._init_inprocess()
+
+        # Synthetic, never-created logical base path. No tempfile.mkdtemp,
+        # no real directory anywhere on disk — purely an identifier used
+        # to construct cache keys (str(folder_sim)) further down.
+        self.FolderGACODE = Path(f"<{self._inprocess_code_name}_inprocess>")
+
+        # Load profiles
+        if isinstance(mitim_state, (str, Path)):
+            self.profiles = PROFILEStools.gacode_state(str(mitim_state))
+        else:
+            self.profiles = mitim_state
+
+        self.profiles.derive_quantities(mi_ref=md_u)
+
+        # Build per-rho input objects in memory — no files written
+        state_converter = self.run_specifications['state_converter']    # 'to_tglf' / 'to_neo'
+        input_class     = self.run_specifications['input_class']        # TGLFinput / NEOinput
+        input_file_stem = self.run_specifications['input_file']         # 'input.tglf' / 'input.neo'
+
+        raw = getattr(self.profiles, state_converter)(r=self.rhos, r_is_rho=True)
+        self.inputs_files = {}
+        for rho, d in raw.items():
+            inp = input_class.initialize_in_memory(d)
+            # Set a logical (never-created) file path so any later code
+            # that inspects inp.file does not hit AttributeError.
+            inp.file = self.FolderGACODE / f"{input_file_stem}_{float(rho):.4f}"
+            self.inputs_files[rho] = inp
+
+        # Normalizations (pure in-memory)
+        print("> Setting up normalizations")
+        self.NormalizationSets, cdf = NORMtools.normalizations(self.profiles)
+        return cdf
+
+    def _run_prepare_inprocess(self, subfolder_simulation,
+                               code_executor=None, code_executor_full=None,
+                               code_settings=None, extraOptions={},
+                               multipliers={}, minimum_delta_abs={},
+                               **kwargs_control):
+        """
+        Build per-rho input objects in memory via ``modifyInputs()`` —
+        no folder creation, no file writes.
+
+        ``kwargs_control`` accepts and silently ignores any subprocess-only
+        keyword arguments (cold_start, launchSlurm, slurm_setup, etc.) so
+        the host class can simply forward ``**kwargs`` without filtering.
+        """
+        if code_executor is None:
+            code_executor = {}
+        if code_executor_full is None:
+            code_executor_full = {}
+
+        # Compute the logical folder path — purely an in-memory cache
+        # key, never created on disk.  No `.resolve()` because the base
+        # path is synthetic (e.g. `<tglf_inprocess>`) and we want it to
+        # stay that way.
+        Folder_sim = self.FolderGACODE / subfolder_simulation
+
+        inputs = copy.deepcopy(self.inputs_files)
+
+        mod_input_file = {}
+        for i, rho in enumerate(self.rhos):
+            print(f"\t- [in-process] Preparing input for rho={rho:.4f}")
+            input_sim_rho = modifyInputs(
+                inputs[rho],
+                code_settings=code_settings,
+                extraOptions=extraOptions,
+                multipliers=multipliers,
+                minimum_delta_abs=minimum_delta_abs if minimum_delta_abs else {},
+                position_change=i,
+                addControlFunction=self.run_specifications["control_function"],
+                controls_file=self.run_specifications["controls_file"],
+                NS=inputs[rho].num_recorded,
+            )
+            self._inprocess_postprocess_input(input_sim_rho, code_settings, kwargs_control)
+            mod_input_file[rho] = input_sim_rho
+
+        code_executor_full[subfolder_simulation] = {}
+        code_executor[subfolder_simulation] = {}
+        for irho in self.rhos:
+            entry = {
+                "folder":     Folder_sim,
+                "dictionary": mod_input_file[irho],
+                "inputs":     None,
+                "extraOptions": extraOptions,
+                "multipliers":  multipliers,
+                "additional_files_to_send": None,
+            }
+            code_executor_full[subfolder_simulation][irho] = entry
+            code_executor[subfolder_simulation][irho]      = entry
+
+        self.FolderSimLast = Folder_sim
+        return code_executor, code_executor_full
+
+    def _run_inprocess(self, code_executor, **kwargs_run):
+        """
+        Execute the in-process ``ctypes`` engine for every ``(subfolder,
+        rho)`` in *code_executor*.
+
+        Each (subfolder, rho) is dispatched to a ``ThreadPoolExecutor``
+        running the per-code worker; ctypes releases the GIL during the
+        Fortran call, and each thread dlopens its own private copy of
+        the shared library so Fortran globals are independent — true
+        parallelism without macOS spawn/fork issues.
+
+        Results are stored in ``self._inprocess_cache[str(folder_sim)]``.
+        ``kwargs_run`` is accepted but ignored (subprocess-only options).
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        self._init_inprocess()
+        worker = self._inprocess_load_worker()
+
+        # Build work items — one per (subfolder_variation, rho)
+        work_items = []   # (subfolder_sim, rho, flat, input_obj, folder_sim)
+        for subfolder_sim, rho_dict in code_executor.items():
+            for rho, rho_info in rho_dict.items():
+                folder_sim = rho_info["folder"]
+                input_obj  = rho_info["dictionary"]
+                flat = self._inprocess_build_flat_dict(input_obj)
+                work_items.append((subfolder_sim, rho, flat, input_obj, folder_sim))
+
+        n_jobs = len(work_items)
+        if n_jobs == 0:
+            self.simulation_job = None
+            return
+
+        n_workers = os.cpu_count() or 1
+        print(
+            f"\t- [in-process] Submitting {n_jobs} {self._inprocess_code_name.upper()} "
+            f"cases across {min(n_workers, n_jobs)} workers"
+        )
+
+        results_by_folder: dict = {}
+        with ThreadPoolExecutor(max_workers=min(n_workers, n_jobs)) as pool:
+            future_map = {
+                pool.submit(worker, flat): (subfolder_sim, rho, input_obj, folder_sim)
+                for subfolder_sim, rho, flat, input_obj, folder_sim in work_items
+            }
+            for future in as_completed(future_map):
+                subfolder_sim, rho, input_obj, folder_sim = future_map[future]
+                outputs = future.result()
+                key = str(folder_sim)
+                if key not in results_by_folder:
+                    results_by_folder[key] = {"raw": {}, "inputs": {}}
+                results_by_folder[key]["raw"][float(rho)]    = outputs
+                results_by_folder[key]["inputs"][float(rho)] = input_obj
+                self._inprocess_print_per_rho(rho, outputs)
+
+        self._inprocess_cache.update(results_by_folder)
+        self.simulation_job = None  # keep attribute consistent with mitim_simulation
+
+
+# ===========================================================================
+# TGLF in-process mixin
+# ===========================================================================
+
+class TGLFInProcess(_GACODEInProcessMixin):
+    """
+    TGLF-specific in-process mixin.  Provides ``prep_inprocess``,
+    ``_run_prepare_inprocess``, ``_run_inprocess`` (inherited from the
+    base mixin) plus ``read_inprocess`` which builds ``TGLFoutput``
+    instances from the cached in-process results.
+    """
+
+    _inprocess_code_name = "tglf"
+
+    def _inprocess_load_worker(self):
+        from mitim_tools.simulation_tools.interfaces import tglf_inprocess as _tip
+        return _tip._parallel_worker
+
+    def _inprocess_postprocess_input(self, input_sim_rho, code_settings, kwargs_control):
+        # TGLF: drop low-density / fast species and optionally enforce
+        # quasineutrality before passing the input to the Fortran engine.
+        if code_settings is not None:
+            input_sim_rho.removeLowDensitySpecie()
+            input_sim_rho.remove_fast()
+        if kwargs_control.get("Quasineutral", False):
+            input_sim_rho.ensureQuasineutrality()
+        input_sim_rho.anticipate_problems()
+
+    def _inprocess_build_flat_dict(self, input_obj):
+        # TGLFinput stores species in a dedicated `species` dict, so we
+        # have to unpack it into KEY_<i> form for the worker.
+        flat: dict = {}
+        flat.update(input_obj.controls)
+        flat.update(input_obj.plasma)
+        for i, sp_data in input_obj.species.items():
+            for var, val in sp_data.items():
+                flat[f"{var}_{i}"] = val
+        return flat
+
+    def _inprocess_print_per_rho(self, rho, outputs):
+        print(
+            f"\t- [in-process] rho={rho:.4f}  "
+            f"Qe={outputs['elec_eflux']:.4f}  "
+            f"Qi[0]={outputs['ion_eflux'][0]:.4f}"
+        )
+
+    def read_inprocess(self, label="run1", folder=None):
+        """Build TGLF results from the in-process cache — pure in-process."""
+        # Local import avoids a circular dependency at module load time
+        from mitim_tools.gacode_tools.TGLFtools import TGLFoutput
+
+        cached, raw, inp_files = self._inprocess_get_cached(folder)
+
+        if "d_perp_dict" not in self.__dict__:
+            self.d_perp_dict = None
+
+        # `updateConvolution` and the convolution attributes are defined
+        # on the concrete TGLF subclass; the mixin assumes the host
+        # provides them.
+        self.updateConvolution()
+
+        output_list, inputclasses, parsed = [], [], []
+        for rho in self.rhos:
+            inputclass = inp_files.get(rho) or inp_files.get(float(rho))
+            outputs    = raw.get(rho)    or raw.get(float(rho))
+            out = TGLFoutput.from_inprocess(inputclass, outputs)
+            out.unnormalize(
+                self.NormalizationSets["SELECTED"],
+                rho=rho,
+                convolution_fun_fluct=self.convolution_fun_fluct,
+                factorTot_to_Perp=self.factorTot_to_Perp,
+            )
+            output_list.append(out)
+            inputclasses.append(inputclass)
+            parsed.append(
+                self._inprocess_build_flat_dict(inputclass) if inputclass is not None else {}
+            )
+
+        self.results[label] = {
+            "output":      output_list,
+            "inputclasses": inputclasses,
+            "parsed":      parsed,
+            "x":           np.array(self.rhos),
+            "convolution_fun_fluct": self.convolution_fun_fluct,
+            "DRMAJDX_LOC": self.DRMAJDX_LOC,
+            "profiles":    self.NormalizationSets.get("input_gacode"),
+            "wavefunction": {},
+        }
+        print(f"\t- [in-process] Read TGLF results for label '{label}' "
+              f"({len(self.rhos)} rho values)")
+
+
+# ===========================================================================
+# NEO in-process mixin
+# ===========================================================================
+
+class NEOInProcess(_GACODEInProcessMixin):
+    """
+    NEO-specific in-process mixin.  Provides ``prep_inprocess``,
+    ``_run_prepare_inprocess``, ``_run_inprocess`` (inherited from the
+    base mixin) plus ``read_inprocess`` which builds ``NEOoutput``
+    instances from the cached in-process results.
+    """
+
+    _inprocess_code_name = "neo"
+
+    def _inprocess_load_worker(self):
+        from mitim_tools.simulation_tools.interfaces import neo_inprocess as _nip
+        return _nip._parallel_worker
+
+    def _inprocess_print_per_rho(self, rho, outputs):
+        if outputs.get("error_status", 0) != 0:
+            print(
+                f"\t- [in-process] rho={rho:.4f}  "
+                f"WARNING error_status={outputs['error_status']}",
+                typeMsg="w",
+            )
+
+    def read_inprocess(self, label="run1", folder=None):
+        """Build NEO results from the in-process cache — pure in-process."""
+        # Local import avoids a circular dependency at module load time
+        from mitim_tools.gacode_tools.NEOtools import NEOoutput
+
+        cached, raw, inp_files = self._inprocess_get_cached(folder)
+
+        output_list = []
+        parsed_list = []
+        for rho in self.rhos:
+            inputclass = inp_files.get(rho) or inp_files.get(float(rho))
+            outputs    = raw.get(rho)    or raw.get(float(rho))
+            out = NEOoutput.from_inprocess(inputclass, outputs)
+            if 'NormalizationSets' in self.__dict__:
+                out.unnormalize(self.NormalizationSets["SELECTED"], rho=rho)
+            output_list.append(out)
+            parsed_list.append(
+                self._inprocess_build_flat_dict(inputclass) if inputclass is not None else {}
+            )
+
+        self.results[label] = {
+            "output": output_list,
+            "parsed": parsed_list,
+            "x":      np.array(self.rhos),
+        }
+        print(f"\t- [in-process] Read NEO results for label '{label}' "
+              f"({len(self.rhos)} rho values)")

--- a/src/mitim_tools/gacode_tools/utils/GACODEinprocess.py
+++ b/src/mitim_tools/gacode_tools/utils/GACODEinprocess.py
@@ -553,8 +553,8 @@ class TGLFInProcess(_GACODEInProcessMixin):
     def _inprocess_print_per_rho(self, rho, outputs):
         print(
             f"\t- [in-process] rho={rho:.4f}  "
-            f"Qe={outputs['elec_eflux']:.4f}  "
-            f"Qi[0]={outputs['ion_eflux'][0]:.4f}"
+            f"Qe={outputs['elec_eflux']:.4e}  "
+            f"Qi[0]={outputs['ion_eflux'][0]:.4e}"
         )
 
     def read_inprocess(self, label="run1", folder=None):
@@ -622,6 +622,12 @@ class NEOInProcess(_GACODEInProcessMixin):
         return _nip._parallel_worker
 
     def _inprocess_print_per_rho(self, rho, outputs):
+        Qe = outputs.get("efluxtot_dke", [0])[0] + outputs.get("efluxtot_gv", [0])[0]
+        Qi0 = (outputs.get("efluxtot_dke", [0, 0])[1] + outputs.get("efluxtot_gv", [0, 0])[1]) if outputs.get("ns", 0) > 1 else 0.0
+        print(
+            f"\t- [in-process] rho={rho:.4f}  "
+            f"Qe={Qe:.4e}  Qi[0]={Qi0:.4e}"
+        )
         if outputs.get("error_status", 0) != 0:
             print(
                 f"\t- [in-process] rho={rho:.4f}  "

--- a/src/mitim_tools/gacode_tools/utils/GACODErun.py
+++ b/src/mitim_tools/gacode_tools/utils/GACODErun.py
@@ -471,7 +471,8 @@ def obtainNTphase(
     else:
         gaussW = np.ones(len(x))
 
-    neTe = np.sum(y * gaussW) / np.sum(gaussW)
+    sumW = np.sum(gaussW)
+    neTe = np.sum(y * gaussW) / sumW if sumW != 0.0 else np.nan
 
     return neTe
 

--- a/src/mitim_tools/gacode_tools/utils/GACODErun.py
+++ b/src/mitim_tools/gacode_tools/utils/GACODErun.py
@@ -377,18 +377,14 @@ def runVGEN(
         },
     )
 
-    print(
-        f"\t- Running NEO (with {vgenOptions['numspecies']} species) to populate w0(rad/s) in input.gacode file"
-    )
+    print(f"\t- Running NEO (with {vgenOptions['numspecies']} species) to populate w0(rad/s) in input.gacode file")
     print(f"\t\t> Matching ion {vgenOptions['matched_ion']} Vtor")
 
     options = f"-er {vgenOptions['er']} -vel {vgenOptions['vel']} -in {vgenOptions['numspecies']} -ix {vgenOptions['matched_ion']} -nth {vgenOptions['nth']}"
 
     # ***********************************
 
-    print(
-        f"\t\t- Proceeding to generate Er from NEO run using profiles_gen -vgen ({options})"
-    )
+    print(f"\t\t- Proceeding to generate Er from NEO run using profiles_gen -vgen ({options})")
 
     inputgacode_file = workingFolder / f"input.gacode"
 
@@ -405,7 +401,7 @@ def runVGEN(
     vgen_job.prep(
         command,
         input_files=[inputgacode_file, workingFolder / f"profiles_vgen.sh"],
-        output_files=["slurm_output.dat", "slurm_error.dat"],
+        output_folders=["vgen"],
     )
 
     vgen_job.run()

--- a/src/mitim_tools/misc_tools/FARMINGtools.py
+++ b/src/mitim_tools/misc_tools/FARMINGtools.py
@@ -1132,6 +1132,7 @@ def create_slurm_execution_files(
     cpuspertask = slurm_settings.setdefault("cpuspertask", None)
     ntaskspernode = slurm_settings.setdefault("ntaskspernode", None)
     gpuspertask = slurm_settings.setdefault("gpuspertask", None)
+    gpuspernode = slurm_settings.setdefault("gpuspernode", None)
 
     job_array = slurm_settings.setdefault("job_array", None)
     job_array_limit = slurm_settings.setdefault("job_array_limit", None)
@@ -1216,6 +1217,8 @@ def create_slurm_execution_files(
         commandSBATCH.append(f"#SBATCH --cpus-per-task {cpuspertask}")
     if gpuspertask is not None:
         commandSBATCH.append(f"#SBATCH --gpus-per-task {gpuspertask}")
+    if gpuspernode is not None:
+        commandSBATCH.append(f"#SBATCH --gpus-per-node={gpuspernode}")
     if exclude is not None:
         commandSBATCH.append(f"#SBATCH --exclude={exclude}")
 
@@ -1225,6 +1228,8 @@ def create_slurm_execution_files(
     # ~~~~ Commands ~~~~~~~~~~~~~~~
     commandSBATCH.append("")
     commandSBATCH.append("export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK")
+    if gpuspernode is not None:
+        commandSBATCH.append('export SLURM_CPU_BIND="cores"')
     commandSBATCH.append('echo "MITIM: Submitting SLURM job $SLURM_JOBID in $HOSTNAME (host: $SLURM_SUBMIT_HOST)"')
     commandSBATCH.append('echo "MITIM: Nodes have $SLURM_CPUS_ON_NODE cores and $SLURM_JOB_NUM_NODES node(s) were allocated for this job"')
     commandSBATCH.append('echo "MITIM: Each of the $SLURM_NTASKS tasks allocated will run with $SLURM_CPUS_PER_TASK cores, allocating $SRUN_CPUS_PER_TASK CPUs per srun"')

--- a/src/mitim_tools/misc_tools/IOtools.py
+++ b/src/mitim_tools/misc_tools/IOtools.py
@@ -2003,9 +2003,15 @@ def print_machine_info(output_file=None):
 
     # System Information
     info_lines.append("=== System Information ===")
+    info_lines.append(f"Python:    {platform.python_version()} ({platform.python_implementation()})")
     info_lines.append(f"System:    {platform.system()} {platform.release()}  ({platform.machine()})")
     info_lines.append(f"Node:      {platform.node()}")
     info_lines.append(f"Processor: {platform.processor()}")
+    try:
+        from mitim_tools import __version__ as mitim_version
+        info_lines.append(f"MITIM:     {mitim_version}")
+    except Exception:
+        pass
 
     # CPU Information
     info_lines.append("\n=== CPU Information ===")
@@ -2022,6 +2028,8 @@ def print_machine_info(output_file=None):
         mem = psutil.virtual_memory()
         info_lines.append(f"RAM:           {mem.total / 2**30:.1f} GB total, {mem.available / 2**30:.1f} GB available")
         proc = psutil.Process()
+        proc_mem = proc.memory_info()
+        info_lines.append(f"Process RSS:   {proc_mem.rss / 2**30:.2f} GB")
         if hasattr(proc, "cpu_affinity"):
             affinity = proc.cpu_affinity()
             info_lines.append(f"CPU affinity:  {len(affinity)} cores {affinity}")
@@ -2042,12 +2050,34 @@ def print_machine_info(output_file=None):
 
     # PyTorch threading state
     info_lines.append("\n=== PyTorch Information ===")
+    info_lines.append(f"Default dtype:  {torch.get_default_dtype()}")
     info_lines.append(f"Intraop threads (current): {torch.get_num_threads()}")
     info_lines.append(f"Interop threads (current): {torch.get_num_interop_threads()}")
     openmp_enabled = getattr(torch.backends, 'openmp', None)
     mkl_enabled    = getattr(torch.backends, 'mkl', None)
     info_lines.append(f"OpenMP: {openmp_enabled.is_available() if openmp_enabled else 'N/A'}   "
                       f"MKL: {mkl_enabled.is_available() if mkl_enabled else 'N/A'}")
+
+    # GPU / CUDA
+    info_lines.append("\n=== GPU / CUDA ===")
+    if torch.cuda.is_available():
+        info_lines.append(f"CUDA available:  True  (version {torch.version.cuda})")
+        for i in range(torch.cuda.device_count()):
+            props = torch.cuda.get_device_properties(i)
+            mem_total = props.total_mem / 2**30
+            mem_alloc = torch.cuda.memory_allocated(i) / 2**30
+            mem_reserved = torch.cuda.memory_reserved(i) / 2**30
+            info_lines.append(f"  GPU {i}: {props.name}  ({mem_total:.1f} GB total, {mem_alloc:.2f} GB allocated, {mem_reserved:.2f} GB reserved)")
+        if torch.backends.cudnn.is_available():
+            info_lines.append(f"  cuDNN: {torch.backends.cudnn.version()}  (enabled={torch.backends.cudnn.enabled})")
+        else:
+            info_lines.append("  cuDNN: not available")
+    elif hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        info_lines.append(f"CUDA available:  False")
+        info_lines.append(f"MPS available:   True  (Apple Silicon GPU)")
+    else:
+        info_lines.append(f"CUDA available:  False")
+        info_lines.append(f"MPS available:   False")
 
     # BLAS thread pool state (threadpoolctl, if available)
     try:
@@ -2079,12 +2109,12 @@ def print_machine_info(output_file=None):
 
     # Package versions
     info_lines.append("\n=== Package Versions ===")
-    for pkg in ["torch", "gpytorch", "botorch", "linear_operator"]:
+    for pkg in ["numpy", "scipy", "torch", "gpytorch", "botorch", "linear_operator", "tensorflow"]:
         try:
             mod = __import__(pkg)
-            info_lines.append(f"  {pkg}: {mod.__version__}")
+            info_lines.append(f"  {pkg:<20s} {mod.__version__}")
         except Exception:
-            info_lines.append(f"  {pkg}: not available")
+            info_lines.append(f"  {pkg:<20s} not installed")
 
     info_lines.append("=============================\n")
 

--- a/src/mitim_tools/misc_tools/IOtools.py
+++ b/src/mitim_tools/misc_tools/IOtools.py
@@ -2256,15 +2256,41 @@ class CPU_Unpickler(pickle_dill.Unpickler):
 
 def read_mitim_yaml(path: str):
 
+    yaml_dir = Path(path).resolve().parent
+
+    def _import_from_string(modattr):
+        """Import a function/class from an 'import::' string, with sidecar file support."""
+        import importlib
+        import importlib.util
+
+        if modattr.startswith("import::"):
+            modattr = modattr[len("import::"):]
+        module_name, attr = modattr.rsplit(".", 1)
+
+        # If the module is a sidecar file next to this YAML, load it from disk
+        sidecar = yaml_dir / f"{module_name}.py"
+        if sidecar.exists():
+            spec = importlib.util.spec_from_file_location(module_name, sidecar)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return getattr(mod, attr)
+
+        return getattr(importlib.import_module(module_name), attr)
+
     def resolve(x):
         if isinstance(x, dict):
+            # Reconstruct functools.partial from serialized form
+            if "_partial_import" in x:
+                import functools
+                func = _import_from_string(x["_partial_import"])
+                args = resolve(x.get("args", []))
+                kwargs = resolve(x.get("kwargs", {}))
+                return functools.partial(func, *args, **kwargs)
             return {k: resolve(v) for k, v in x.items()}
         if isinstance(x, list):
             return [resolve(v) for v in x]
         if isinstance(x, str) and x.startswith("import::"):
-            modattr = x[len("import::"):]
-            module_name, attr = modattr.rsplit(".", 1)
-            return getattr(importlib.import_module(module_name), attr)
+            return _import_from_string(x)
         return x
 
     with open(path, "r") as f:
@@ -2275,13 +2301,22 @@ def read_mitim_yaml(path: str):
 import yaml
 import numpy as np
 import inspect
+import functools
 from pathlib import Path
 from typing import Any, Mapping
+
+# Module-level collector for __main__ functions encountered during YAML normalization.
+# Populated by _as_import_string, consumed and cleared by write_mitim_yaml.
+_main_functions_to_save = {}
+
+_SIDECAR_MODULE = "_saved_functions"
 
 def _as_import_string(obj: Any) -> str:
     """
     Return an 'import::module.qualname' for callables/classes.
-    Falls back to str(obj) if module/name aren't available.
+    If the callable is from __main__, its source is collected into
+    _main_functions_to_save for later writing to a sidecar file,
+    and the import string references the sidecar module instead.
     """
     # Handle bound methods
     if inspect.ismethod(obj):
@@ -2289,6 +2324,8 @@ def _as_import_string(obj: Any) -> str:
         mod = func.__module__
         qn = getattr(func, "__qualname__", func.__name__)
         qn = qn.replace("<locals>.", "")
+        if mod == "__main__":
+            return _collect_main_function(func, qn)
         return f"import::{mod}.{qn}"
     # Handle functions, classes, other callables with module/name
     if inspect.isfunction(obj) or inspect.isbuiltin(obj) or inspect.isclass(obj) or callable(obj):
@@ -2296,6 +2333,8 @@ def _as_import_string(obj: Any) -> str:
         name = getattr(obj, "__qualname__", getattr(obj, "__name__", None))
         if mod and name:
             name = name.replace("<locals>.", "")
+            if mod == "__main__":
+                return _collect_main_function(obj, name)
             return f"import::{mod}.{name}"
         return f"import::{str(obj)}"
 
@@ -2306,12 +2345,59 @@ def _as_import_string(obj: Any) -> str:
     # Fallback
     return f"import::{str(obj)}"
 
+
+def _collect_main_function(func, name):
+    """
+    Collect a __main__ function's source code for saving to a sidecar file.
+    Returns the import string referencing the sidecar module.
+    """
+    try:
+        source = inspect.getsource(func)
+        # Dedent in case the function was defined inside a block
+        import textwrap
+        source = textwrap.dedent(source)
+        _main_functions_to_save[name] = source
+    except (OSError, TypeError):
+        from mitim_tools.misc_tools.LOGtools import printMsg as _print
+        _print(
+            f"Could not extract source for __main__ function '{name}'. "
+            f"It will not be reproducible from the saved namelist.",
+            typeMsg="w",
+        )
+    return f"import::{_SIDECAR_MODULE}.{name}"
+
+
+def _extract_imports_from_main():
+    """
+    Extract all import statements from the __main__ module's source file.
+    These are needed so the saved functions can find their dependencies.
+    """
+    import sys
+    main_mod = sys.modules.get("__main__")
+    if main_mod is None:
+        return ""
+
+    main_file = getattr(main_mod, "__file__", None)
+    if main_file is None or not Path(main_file).exists():
+        return ""
+
+    import_lines = []
+    with open(main_file, "r") as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped.startswith("import ") or stripped.startswith("from "):
+                import_lines.append(line.rstrip())
+
+    return "\n".join(import_lines)
+
+
 def _normalize_for_yaml(obj: Any) -> Any:
     """
     Recursively convert objects into YAML-safe Python builtins.
     - NumPy arrays/scalars -> lists/scalars
     - Paths -> str
     - sets -> lists
+    - functools.partial -> structured dict with _partial_import/args/kwargs
     - callables/classes/methods -> 'import::module.qualname'
     Leaves basic builtins as-is.
     """
@@ -2335,12 +2421,20 @@ def _normalize_for_yaml(obj: Any) -> Any:
 
     # Mappings
     if isinstance(obj, Mapping):
-        # ensure keys are YAML-safe (coerce to str if needed)
         return {str(k): _normalize_for_yaml(v) for k, v in obj.items()}
 
     # Sequences
     if isinstance(obj, (list, tuple)):
         return [_normalize_for_yaml(v) for v in obj]
+
+    # functools.partial -> structured dict with function + args + kwargs
+    if isinstance(obj, functools.partial):
+        result = {"_partial_import": _as_import_string(obj.func)}
+        if obj.args:
+            result["args"] = [_normalize_for_yaml(a) for a in obj.args]
+        if obj.keywords:
+            result["kwargs"] = {str(k): _normalize_for_yaml(v) for k, v in obj.keywords.items()}
+        return result
 
     # Anything callable or class-like -> import string
     if inspect.ismethod(obj) or inspect.isfunction(obj) or inspect.isbuiltin(obj) or inspect.isclass(obj) or callable(obj):
@@ -2360,10 +2454,18 @@ def write_mitim_yaml(parameters: Mapping[str, Any], path: str) -> None:
     General YAML writer:
     - No assumptions about keys (works for solution/transport/target and also optimization_options).
     - Normalizes everything to YAML-safe types, including function objects.
+    - Functions defined in __main__ are saved to a sidecar _saved_functions.py
+      file next to the YAML, and referenced via import::_saved_functions.func_name.
     """
     if not isinstance(parameters, Mapping):
         raise TypeError("parameters must be a dict-like mapping")
+
+    # Clear the collector before normalization
+    _main_functions_to_save.clear()
+
     clean = _normalize_for_yaml(parameters)
+
+    path = Path(path)
 
     with open(path, "w", encoding="utf-8") as f:
         yaml.dump(
@@ -2375,3 +2477,20 @@ def write_mitim_yaml(parameters: Mapping[str, Any], path: str) -> None:
             allow_unicode=True,
             width=1000,
         )
+
+    # Write sidecar file with __main__ functions if any were collected
+    if _main_functions_to_save:
+        imports = _extract_imports_from_main()
+        sidecar_path = path.parent / f"{_SIDECAR_MODULE}.py"
+
+        with open(sidecar_path, "w", encoding="utf-8") as f:
+            f.write(f"# Auto-generated by MITIM write_mitim_yaml — source extracted from __main__\n")
+            if imports:
+                f.write(f"\n{imports}\n")
+            for name, source in _main_functions_to_save.items():
+                f.write(f"\n{source}\n")
+
+        from mitim_tools.misc_tools.LOGtools import printMsg as _print
+        _print(f"Saved {len(_main_functions_to_save)} __main__ function(s) to {sidecar_path}", typeMsg="i")
+
+        _main_functions_to_save.clear()

--- a/src/mitim_tools/opt_tools/optimizers/multivariate_tools.py
+++ b/src/mitim_tools/opt_tools/optimizers/multivariate_tools.py
@@ -208,7 +208,9 @@ def simple_relaxation( flux_residual_evaluator, x_initial, bounds=None, solver_o
     # Initial condition
     # ********************************************************************************************
 
-    # Convert relax to tensor of the same dimensions as x, such that it can be dynamically changed per channel
+    # Convert relax to tensor of the same dimensions as x, such that it can be dynamically changed per channel.
+    # Any of {relax0, dx_max, dx_max_abs, dx_min_abs} may arrive as a per-batch tensor (shape
+    # broadcastable to x_initial); torch.where in _sr_step handles either case transparently.
     relax = torch.ones_like(x_initial) * relax0
 
     x_history, y_history, metric_history = [], [], []
@@ -227,7 +229,13 @@ def simple_relaxation( flux_residual_evaluator, x_initial, bounds=None, solver_o
         tol = tol_rel * M.max().item()
         print(f"\t* Relative tolerance of {tol_rel:.1e} will be used, resulting in an absolute tolerance of {tol:.1e}")
 
-    print(f"\t* Flux-grad relationship of {relax0} and maximum gradient jump of {dx_max}")
+    def _fmt_knob(v):
+        if isinstance(v, torch.Tensor):
+            flat = v.flatten().tolist()
+            return flat[0] if len(flat) == 1 else flat
+        return v
+
+    print(f"\t* Flux-grad relationship of {_fmt_knob(relax0)} and maximum gradient jump of {_fmt_knob(dx_max)}")
 
     # ********************************************************************************************
     # Iterative strategy
@@ -400,27 +408,27 @@ def simple_relaxation( flux_residual_evaluator, x_initial, bounds=None, solver_o
     return x_best, y_history, x_history, metric_history, relax_history, tol, osc_check_iters
 
 def _sr_step(x, Q, QT, relax, dx_max, dx_max_abs = None, dx_min_abs = None, threshold_zero_flux_issue=1e-10, bounds=None, thr_bounds=1e-4):
-    
+
     # Calculate step in gradient (if target > transport, dx>0 because I want to increase gradients)
     dx = relax * (QT - Q) / (Q**2 + QT**2).clamp(min=threshold_zero_flux_issue) ** 0.5
 
-    # Prevent big steps - Clamp to the max step (with the right sign)
-    ix = dx.abs() > dx_max
-    dx[ix] = dx_max * (dx[ix] / dx[ix].abs())
+    # Prevent big steps - Clamp to the max step (with the right sign). Use torch.where so
+    # dx_max can be either a scalar float or a tensor broadcastable against dx (per-batch).
+    dx = torch.where(dx.abs() > dx_max, dx.sign() * dx_max, dx)
 
     # Define absolute step (Note for PRF: abs() was added by me, I think it performs better that way!)
     x_step = dx * x.abs()
-    
-    # Absolute steps limits
+
+    # Absolute steps limits. Both dx_max_abs and dx_min_abs also accept scalar or broadcastable tensor.
+    # Preserve the original convention of using sign=+1 when x_step is exactly 0 (matches the old
+    # nan_to_num(0/0 -> 1.0) path).
     if dx_max_abs is not None:
-        ix = x_step.abs() > dx_max_abs
-        direction = torch.nan_to_num(x_step[ix] / x_step[ix].abs(), nan=1.0)
-        x_step[ix] = dx_max_abs * direction
-    
+        direction = torch.where(x_step != 0, x_step.sign(), torch.ones_like(x_step))
+        x_step = torch.where(x_step.abs() > dx_max_abs, direction * dx_max_abs, x_step)
+
     if dx_min_abs is not None:
-        ix = x_step.abs() < dx_min_abs
-        direction = torch.nan_to_num(x_step[ix] / x_step[ix].abs(), nan=1.0)
-        x_step[ix] = dx_min_abs * direction
+        direction = torch.where(x_step != 0, x_step.sign(), torch.ones_like(x_step))
+        x_step = torch.where(x_step.abs() < dx_min_abs, direction * dx_min_abs, x_step)
 
     # Update
     x_new = x + x_step

--- a/src/mitim_tools/plasmastate_tools/MITIMstate.py
+++ b/src/mitim_tools/plasmastate_tools/MITIMstate.py
@@ -1291,6 +1291,84 @@ class mitim_state:
 
         print(f"\t\t- Resolution of profiles changed to {n} points with function {interpolation_function}")
 
+    def smooth_profiles(self, variables=None, relative_smoothing=0.005):
+        """
+        Smooth kinetic profiles in-place by:
+          1. fitting a smoothing spline to the normalised log-gradient (aLTe, aLne, …)
+          2. integrating that smoothed gradient inward from the edge boundary value
+
+        This preserves the edge value exactly and produces profiles whose gradients
+        are smooth — which is what VGEN uses to compute Er.
+
+        The smoothing spline operates on the normalised gradient (divided by its
+        peak absolute value) so the smoothing parameter is scale-independent:
+
+            s = len(rho) * relative_smoothing²
+
+        Parameters
+        ----------
+        variables : list of str, optional
+            Profile keys to smooth.  Defaults to ['te(keV)', 'ti(keV)',
+            'ne(10^19/m^3)', 'ni(10^19/m^3)'].
+        relative_smoothing : float, optional
+            Target RMS deviation of the spline relative to the peak gradient
+            (default 0.02 = 2 %).  Larger → smoother but less faithful.
+        """
+        from scipy.interpolate import UnivariateSpline
+        from scipy.integrate import cumulative_trapezoid
+
+        if variables is None:
+            variables = ["te(keV)", "ti(keV)", "ne(10^19/m^3)", "ni(10^19/m^3)"]
+
+        rho = self.profiles["rho(-)"]
+        r   = self.derived["r"]           # geometric minor radius [m]
+        a   = float(self.derived["a"])    # minor radius at LCFS [m]
+        s_norm = float(len(rho)) * relative_smoothing ** 2
+
+        # Map profile key → derived log-gradient key
+        _grad_map = {
+            "te(keV)":       "aLTe",
+            "ti(keV)":       "aLTi",
+            "ne(10^19/m^3)": "aLne",
+            "ni(10^19/m^3)": "aLni",
+        }
+
+        def _smooth_and_integrate_1d(X, aLX):
+            """Smooth the log-gradient then integrate inward from the edge."""
+            scale_g = np.max(np.abs(aLX))
+            if scale_g == 0:
+                return X.copy()
+            spl = UnivariateSpline(rho, aLX / scale_g, k=3, s=s_norm)
+            aLX_smooth = spl(rho) * scale_g
+            # d(ln X)/dr = -aLX/a; integrate from axis outward, anchor at edge
+            dlnX_dr = -aLX_smooth / a
+            cum = cumulative_trapezoid(dlnX_dr, r, initial=0.0)
+            # cum[i] = ln X[i] - ln X[0]  (unknown); re-anchor at edge
+            lnX = np.log(np.maximum(X[-1], 1e-30)) + (cum - cum[-1])
+            return np.exp(lnX)
+
+        for key in variables:
+            if key not in self.profiles:
+                continue
+            grad_key = _grad_map.get(key)
+            if grad_key is None or grad_key not in self.derived:
+                continue
+
+            arr  = self.profiles[key]
+            aLXX = self.derived[grad_key]
+
+            if arr.ndim == 1:
+                self.profiles[key] = _smooth_and_integrate_1d(arr, aLXX)
+            else:
+                smoothed = np.empty_like(arr)
+                for col in range(arr.shape[1]):
+                    aLXX_col = aLXX[:, col] if np.ndim(aLXX) == 2 else aLXX
+                    smoothed[:, col] = _smooth_and_integrate_1d(arr[:, col], aLXX_col)
+                self.profiles[key] = smoothed
+
+        self.derive_quantities()
+        print(f"\t\t- Profiles smoothed via gradient-integration (relative_smoothing={relative_smoothing:.3f}): {variables}", typeMsg="i")
+
     def DTplasma(self):
         self.Dion, self.Tion = None, None
         try:

--- a/src/mitim_tools/plasmastate_tools/MITIMstate.py
+++ b/src/mitim_tools/plasmastate_tools/MITIMstate.py
@@ -2391,14 +2391,14 @@ class mitim_state:
 
     def to_tglf(self, r=[0.5], code_settings='SAT0', r_is_rho = True):
 
-        # <> Function to interpolate a curve <> 
+        # <> Function to interpolate a curve <>
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
-        # Determine if the input radius is rho toroidal or r/a
+        # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
+        r_labels = r  # preserve original values for dict keys / filenames
         if r_is_rho:
-            r_interpolation = self.profiles['rho(-)']
-        else:
-            r_interpolation = self.derived['roa']
+            r = interpolation_function(np.atleast_1d(r), self.profiles['rho(-)'], self.derived['roa']).tolist()
+        r_interpolation = self.derived['roa']
 
         # Determine the number of species to use in TGLF
         max_species_tglf = 6  # TGLF only accepts up to 6 species  
@@ -2463,19 +2463,19 @@ class mitim_state:
         # ---------------------------------------------------------------------------------------------------------------------------------------
 
         input_parameters = {}
-        for rho in r:
+        for roa, rho_label in zip(r, r_labels):
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
-            # Define interpolator at this rho
+            # Define interpolator at this r/a
             # ---------------------------------------------------------------------------------------------------------------------------------------
 
             def interpolator(y):
-                return interpolation_function(rho, r_interpolation,y).item()
-            
+                return interpolation_function(roa, r_interpolation,y).item()
+
             # ---------------------------------------------------------------------------------------------------------------------------------------
             # Controls come from options
             # ---------------------------------------------------------------------------------------------------------------------------------------
-            
+
             controls = GACODEdefaults.addTGLFcontrol(code_settings)
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
@@ -2548,17 +2548,17 @@ class mitim_state:
                 'Q_PRIME_LOC':  self.derived['s_q'],
                 'P_PRIME_LOC':  pprime,
             }
-            
+
             # Add MXH and derivatives
             for ikey in self.profiles:
                 if 'shape_cos' in ikey or 'shape_sin' in ikey:
-                    
+
                     # TGLF only accepts 6, as of July 2025
                     if int(ikey[-4]) > 6:
                         continue
-                    
+
                     key_mod = ikey.upper().split('(')[0]
-                    
+
                     parameters[key_mod] = self.profiles[ikey]
                     parameters[f"{key_mod.split('_')[0]}_S_{key_mod.split('_')[-1]}"] = self.derived["r"] * self._deriv_gacode(self.profiles[ikey])
 
@@ -2579,20 +2579,20 @@ class mitim_state:
                 for k in species[i+1]:
                     input_dict[f'{k}_{i+1}'] = species[i+1][k]
 
-            input_parameters[rho] = input_dict
-            
+            input_parameters[rho_label] = input_dict
+
         return input_parameters
 
     def to_neo(self, r=[0.5], r_is_rho = True, code_settings='Sonic'):
 
-        # <> Function to interpolate a curve <> 
+        # <> Function to interpolate a curve <>
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
-        # Determine if the input radius is rho toroidal or r/a
+        # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
+        r_labels = r  # preserve original values for dict keys / filenames
         if r_is_rho:
-            r_interpolation = self.profiles['rho(-)']
-        else:
-            r_interpolation = self.derived['roa']
+            r = interpolation_function(np.atleast_1d(r), self.profiles['rho(-)'], self.derived['roa']).tolist()
+        r_interpolation = self.derived['roa']
 
         # ---------------------------------------------------------------------------------------------------------------------------------------
         # Prepare the inputs
@@ -2624,19 +2624,19 @@ class mitim_state:
         self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', self.derived["a"], 1.0, mass_ref)
 
         input_parameters = {}
-        for rho in r:
+        for roa, rho_label in zip(r, r_labels):
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
-            # Define interpolator at this rho
+            # Define interpolator at this r/a
             # ---------------------------------------------------------------------------------------------------------------------------------------
 
             def interpolator(y):
-                return interpolation_function(rho, r_interpolation,y).item()
+                return interpolation_function(roa, r_interpolation,y).item()
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
             # Controls come from options
             # ---------------------------------------------------------------------------------------------------------------------------------------
-            
+
             controls = GACODEdefaults.addNEOcontrol(code_settings)
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
@@ -2729,20 +2729,20 @@ class mitim_state:
                 for k in species[i+1]:
                     input_dict[f'{k}_{i+1}'] = species[i+1][k]
 
-            input_parameters[rho] = input_dict
+            input_parameters[rho_label] = input_dict
 
         return input_parameters
 
     def to_cgyro(self, r=[0.5], r_is_rho = True, code_settings = 'Linear'):
 
-        # <> Function to interpolate a curve <> 
+        # <> Function to interpolate a curve <>
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
-        # Determine if the input radius is rho toroidal or r/a
+        # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
+        r_labels = r  # preserve original values for dict keys / filenames
         if r_is_rho:
-            r_interpolation = self.profiles['rho(-)']
-        else:
-            r_interpolation = self.derived['roa']
+            r = interpolation_function(np.atleast_1d(r), self.profiles['rho(-)'], self.derived['roa']).tolist()
+        r_interpolation = self.derived['roa']
             
         # ---------------------------------------------------------------------------------------------------------------------------------------
         # Prepare the inputs
@@ -2780,19 +2780,19 @@ class mitim_state:
         self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', self.derived["a"], 1.0, mass_ref)
             
         input_parameters = {}
-        for rho in r:
+        for roa, rho_label in zip(r, r_labels):
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
-            # Define interpolator at this rho
+            # Define interpolator at this r/a
             # ---------------------------------------------------------------------------------------------------------------------------------------
 
             def interpolator(y):
-                return interpolation_function(rho, r_interpolation,y).item()
+                return interpolation_function(roa, r_interpolation,y).item()
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
             # Controls come from options
             # ---------------------------------------------------------------------------------------------------------------------------------------
-            
+
             controls = GACODEdefaults.addCGYROcontrol(code_settings)
             controls['PROFILE_MODEL'] = 1
 
@@ -2885,20 +2885,20 @@ class mitim_state:
                 for k in species[i+1]:
                     input_dict[f'{k}_{i+1}'] = species[i+1][k]
 
-            input_parameters[rho] = input_dict
+            input_parameters[rho_label] = input_dict
 
         return input_parameters
 
     def to_gx(self, r=[0.5], r_is_rho = True, code_settings = 'Linear Tokamak'):
 
-        # <> Function to interpolate a curve <> 
+        # <> Function to interpolate a curve <>
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
-        # Determine if the input radius is rho toroidal or r/a
+        # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
+        r_labels = r  # preserve original values for dict keys / filenames
         if r_is_rho:
-            r_interpolation = self.profiles['rho(-)']
-        else:
-            r_interpolation = self.derived['roa']
+            r = interpolation_function(np.atleast_1d(r), self.profiles['rho(-)'], self.derived['roa']).tolist()
+        r_interpolation = self.derived['roa']
             
         # ---------------------------------------------------------------------------------------------------------------------------------------
         # Prepare the inputs
@@ -2921,19 +2921,19 @@ class mitim_state:
         self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', self.derived["a"], 1.0, mass_ref)
             
         input_parameters = {}
-        for rho in r:
+        for roa, rho_label in zip(r, r_labels):
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
-            # Define interpolator at this rho
+            # Define interpolator at this r/a
             # ---------------------------------------------------------------------------------------------------------------------------------------
 
             def interpolator(y):
-                return interpolation_function(rho, r_interpolation,y).item()
+                return interpolation_function(roa, r_interpolation,y).item()
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
             # Controls come from options
             # ---------------------------------------------------------------------------------------------------------------------------------------
-            
+
             controls = GACODEdefaults.addGXcontrol(code_settings)
 
             # ---------------------------------------------------------------------------------------------------------------------------------------
@@ -3023,10 +3023,10 @@ class mitim_state:
                 for k in species[i+1]:
                     input_dict[f'{k}_{i+1}'] = species[i+1][k]
 
-            input_parameters[rho] = input_dict
+            input_parameters[rho_label] = input_dict
 
         return input_parameters
-    
+
 
     def to_transp(self, folder = '~/scratch/', shot = '12345', runid = 'P01', times = [0.0,1.0], Vsurf = 0.0, mxh_coeffs_smooth = 5):
 

--- a/src/mitim_tools/simulation_tools/SIMtools.py
+++ b/src/mitim_tools/simulation_tools/SIMtools.py
@@ -721,6 +721,179 @@ class mitim_simulation:
         else:
             print("\t\t- Some files were not retrieved", typeMsg="w")
 
+    def run_over_plasmas(
+        self,
+        list_of_states,           # List of mitim_state / input.gacode path / gacode_state objects, one per plasma
+        base_subfolder,           # 'base' -> produces subfolder labels base_plasma0, base_plasma1, ...
+        cold_start=False,
+        forceIfcold_start=False,
+        code_settings=None,
+        extraOptions=None,
+        multipliers=None,
+        minimum_delta_abs=None,
+        ApplyCorrections=True,
+        Quasineutral=False,
+        launchSlurm=True,
+        extra_name="exe",
+        slurm_setup=None,
+        attempts_execution=1,
+        only_minimal_files=False,
+        run_type='normal',
+        additional_files_to_send=None,
+        helper_lostconnection=False,
+    ):
+        '''
+        Phase-1 multi-plasma runner. Runs the same simulation configuration (same rhos,
+        same code_settings, same non-scan multipliers, ...) for N independent plasma
+        states in a single parallel submission by reusing the subfolder_simulation
+        axis that scans already rely on.
+
+        Each plasma p ends up under subfolder_simulation = f"{base_subfolder}_plasma{p}"
+        and its prep-time state (profiles, inputs_files, normalizations, FolderSim) is
+        cached on self.results_per_plasma[p] so the caller can read each plasma's
+        results afterwards via self.read_plasma(p).
+
+        Notes:
+            - Requires self.FolderGACODE to be set. Call prep(...) once before this
+              helper, or rely on the first iteration's prep call to create it.
+            - The i-th prep(...) call overwrites the single staging input.gacode_torun
+              under self.FolderGACODE, then this helper copies it to
+              input.gacode_torun_plasma{p} for traceability. The in-memory
+              self.inputs_files is snapshotted into the code_executor before the next
+              plasma's prep touches it, so per-plasma inputs do not leak across.
+        '''
+
+        if extraOptions is None:
+            extraOptions = {}
+        if multipliers is None:
+            multipliers = {}
+        if minimum_delta_abs is None:
+            minimum_delta_abs = {}
+
+        if slurm_setup is None:
+            slurm_setup = {"cores": self.run_specifications['default_cores'], "minutes": 10}
+
+        if not hasattr(self, 'FolderGACODE') or self.FolderGACODE is None:
+            raise Exception(
+                "[MITIM] run_over_plasmas requires FolderGACODE to be set. Either call "
+                "prep(...) once before run_over_plasmas or pass FolderGACODE via a "
+                "preceding prep call."
+            )
+
+        code_executor, code_executor_full = {}, {}
+        self.results_per_plasma = {}
+        plasma_labels = {}
+
+        for p, state in enumerate(list_of_states):
+            subfolder_simulation = f"{base_subfolder}_plasma{p}"
+            plasma_labels[p] = subfolder_simulation
+
+            print(f"\n=============================================================")
+            print(f"  run_over_plasmas: preparing plasma {p} -> {subfolder_simulation}")
+            print(f"=============================================================")
+
+            # Populate self.profiles / self.inputs_files / self.NormalizationSets for plasma p.
+            # Only the first prep may need to create FolderGACODE; subsequent plasmas reuse it.
+            self.prep(
+                state,
+                self.FolderGACODE,
+                cold_start=cold_start if p == 0 else False,
+                forceIfcold_start=forceIfcold_start,
+            )
+
+            # Keep a per-plasma copy of the input.gacode alongside the shared staging one.
+            shutil.copy2(
+                self.FolderGACODE / "input.gacode_torun",
+                self.FolderGACODE / f"input.gacode_torun_plasma{p}",
+            )
+
+            # _run_prepare snapshots self.inputs_files into code_executor[subfolder][rho]['inputs']
+            # so plasma p's inputs are frozen here; subsequent per-plasma prep calls do not
+            # corrupt already-queued work.
+            self._run_prepare(
+                subfolder_simulation,
+                code_executor=code_executor,
+                code_executor_full=code_executor_full,
+                code_settings=code_settings,
+                extraOptions=extraOptions,
+                multipliers=multipliers,
+                cold_start=cold_start,
+                forceIfcold_start=forceIfcold_start,
+                only_minimal_files=only_minimal_files,
+                launchSlurm=launchSlurm,
+                slurm_setup=slurm_setup,
+                additional_files_to_send=additional_files_to_send,
+                ApplyCorrections=ApplyCorrections,
+                minimum_delta_abs=minimum_delta_abs,
+                Quasineutral=Quasineutral,
+            )
+
+            self.results_per_plasma[p] = {
+                'subfolder': subfolder_simulation,
+                'folder': self.FolderSimLast,
+                'profiles': self.profiles,
+                'inputs_files': copy.deepcopy(self.inputs_files),
+                'NormalizationSets': self.NormalizationSets,
+            }
+
+        # Parallel dispatch of every (plasma, rho) work unit via the existing _run path.
+        self._run(
+            code_executor,
+            code_executor_full=code_executor_full,
+            code_settings=code_settings,
+            ApplyCorrections=ApplyCorrections,
+            Quasineutral=Quasineutral,
+            launchSlurm=launchSlurm,
+            cold_start=cold_start,
+            forceIfcold_start=forceIfcold_start,
+            extra_name=extra_name,
+            slurm_setup=slurm_setup,
+            only_minimal_files=only_minimal_files,
+            attempts_execution=attempts_execution,
+            run_type=run_type,
+            helper_lostconnection=helper_lostconnection,
+        )
+
+        return plasma_labels
+
+    def read_plasma(self, plasma_idx, label=None, **read_kwargs):
+        '''
+        Read results for a specific plasma produced by run_over_plasmas.
+
+        Temporarily activates that plasma's in-memory prep state (profiles /
+        inputs_files / NormalizationSets / FolderSimLast) so that the existing
+        read(...) path can reuse per-plasma profiles and normalizations without
+        being aware of the plasma axis.
+        '''
+        if not hasattr(self, 'results_per_plasma') or plasma_idx not in self.results_per_plasma:
+            raise KeyError(
+                f"No cached plasma run for index {plasma_idx}. Call run_over_plasmas(...) first."
+            )
+
+        info = self.results_per_plasma[plasma_idx]
+        effective_label = label if label is not None else info['subfolder']
+
+        saved_profiles = self.profiles
+        saved_inputs_files = self.inputs_files
+        saved_NormalizationSets = self.NormalizationSets
+        saved_FolderSimLast = getattr(self, 'FolderSimLast', None)
+
+        self.profiles = info['profiles']
+        self.inputs_files = info['inputs_files']
+        self.NormalizationSets = info['NormalizationSets']
+        self.FolderSimLast = info['folder']
+
+        try:
+            self.read(label=effective_label, folder=info['folder'], **read_kwargs)
+        finally:
+            self.profiles = saved_profiles
+            self.inputs_files = saved_inputs_files
+            self.NormalizationSets = saved_NormalizationSets
+            if saved_FolderSimLast is not None:
+                self.FolderSimLast = saved_FolderSimLast
+
+        return effective_label
+
     def run_scan(
         self,
         subfolder,  # 'scan1',

--- a/src/mitim_tools/simulation_tools/SIMtools.py
+++ b/src/mitim_tools/simulation_tools/SIMtools.py
@@ -801,11 +801,12 @@ class mitim_simulation:
                 forceIfcold_start=forceIfcold_start,
             )
 
-            # Keep a per-plasma copy of the input.gacode alongside the shared staging one.
-            shutil.copy2(
-                self.FolderGACODE / "input.gacode_torun",
-                self.FolderGACODE / f"input.gacode_torun_plasma{p}",
-            )
+            # Keep a per-plasma copy of the input.gacode alongside the shared staging one
+            # (subprocess path writes this file; in-process prep uses synthetic in-memory
+            # paths that never touch disk, so the file may not exist — skip gracefully).
+            src_gacode = self.FolderGACODE / "input.gacode_torun"
+            if src_gacode.exists():
+                shutil.copy2(src_gacode, self.FolderGACODE / f"input.gacode_torun_plasma{p}")
 
             # _run_prepare snapshots self.inputs_files into code_executor[subfolder][rho]['inputs']
             # so plasma p's inputs are frozen here; subsequent per-plasma prep calls do not

--- a/src/mitim_tools/simulation_tools/SIMtools.py
+++ b/src/mitim_tools/simulation_tools/SIMtools.py
@@ -469,11 +469,15 @@ class mitim_simulation:
                 print(f"\t- Detected {machineSettings['gpus_per_node']} GPUs in machine, using this value as maximum for non-array execution (vs {max_cores_per_node} specified as available)",typeMsg="i")
                 max_cores_per_node_compare = machineSettings['gpus_per_node']
 
+            force_submission_type = self.run_specifications.get('force_submission_type', None)
+
             if not (launchSlurm and ("partition" in self.simulation_job.machineSettings["slurm"])):
                 type_of_submission = "bash"
+            elif force_submission_type is not None:
+                type_of_submission = force_submission_type
             elif total_cores_required < max_cores_per_node_compare:
                 type_of_submission = "slurm_standard"
-            elif total_cores_required >= max_cores_per_node_compare:
+            else:
                 type_of_submission = "slurm_array"
 
             shellPreCommands, shellPostCommands = None, None

--- a/src/mitim_tools/simulation_tools/interfaces/.gitignore
+++ b/src/mitim_tools/simulation_tools/interfaces/.gitignore
@@ -1,0 +1,8 @@
+# Build artefacts from build_tglf_lib.sh — platform-specific, never commit.
+tglf_build/
+
+# f2py generated stubs and build logs
+*.c
+*.f
+*.log
+__pycache__/

--- a/src/mitim_tools/simulation_tools/interfaces/.gitignore
+++ b/src/mitim_tools/simulation_tools/interfaces/.gitignore
@@ -1,6 +1,7 @@
-# Build artefacts from build_tglf_lib.sh / build_neo_lib.sh — platform-specific, never commit.
+# Build artefacts from build_tglf_lib.sh / build_neo_lib.sh / build_vgen_lib.sh — platform-specific, never commit.
 tglf_build/
 neo_build/
+vgen_build/
 
 # f2py generated stubs and build logs
 *.c

--- a/src/mitim_tools/simulation_tools/interfaces/.gitignore
+++ b/src/mitim_tools/simulation_tools/interfaces/.gitignore
@@ -1,5 +1,6 @@
-# Build artefacts from build_tglf_lib.sh — platform-specific, never commit.
+# Build artefacts from build_tglf_lib.sh / build_neo_lib.sh — platform-specific, never commit.
 tglf_build/
+neo_build/
 
 # f2py generated stubs and build logs
 *.c

--- a/src/mitim_tools/simulation_tools/interfaces/build_neo_lib.sh
+++ b/src/mitim_tools/simulation_tools/interfaces/build_neo_lib.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# =============================================================================
+# build_neo_lib.sh
+#
+# Build libneo_serial.so — a shared library for in-process NEO execution.
+#
+# Strategy
+# --------
+# NEO is already compiled by the GACODE build system in ${GACODE_ROOT}/neo/src/.
+# We reuse those pre-built object files (which include -fPIC from the GACODE
+# platform config) and compile only our thin C-binding wrapper neo_c_api.f90.
+#
+# Excluded objects (they call MPI primitives):
+#   neo.o          — main program
+#   neo_init.o     — parallel initializer (uses MPI_COMM_RANK / SIZE)
+#
+# We keep neo_init_serial.o so the wrapper can set i_proc/n_proc/path.
+# Several other NEO files `use mpi` (neo_do, neo_neural.fann) for the module
+# only — they don't actually call any MPI routines, so linking against an MPI
+# wrapper is enough to satisfy any residual symbols.
+#
+# Prerequisites
+# -------------
+#   - GACODE_ROOT set and gacode already built (neo/src/*.o must exist)
+#   - mpifort / mpif90 (provided by openmpi-mpifort in the pixi env)
+#   - liblapack + libblas + libfftw3
+#
+# Usage
+# -----
+#   cd <this directory>
+#   bash build_neo_lib.sh            # build
+#   bash build_neo_lib.sh --clean    # remove build artefacts and library
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- validate environment ----------------------------------------------------
+if [[ -z "${GACODE_ROOT:-}" ]]; then
+    echo "ERROR: GACODE_ROOT is not set. Source your gacode_setup script first."
+    exit 1
+fi
+
+NEO_SRC="${GACODE_ROOT}/neo/src"
+GACODE_MOD="${GACODE_ROOT}/modules"
+
+if [[ ! -d "${NEO_SRC}" ]]; then
+    echo "ERROR: NEO source directory not found: ${NEO_SRC}"
+    exit 1
+fi
+
+REQUIRED_OBJ="${NEO_SRC}/neo_run.o"
+if [[ ! -f "${REQUIRED_OBJ}" ]]; then
+    echo "ERROR: ${REQUIRED_OBJ} not found."
+    echo "       Build GACODE first: cd \${GACODE_ROOT} && make"
+    exit 1
+fi
+
+# --- optional clean ----------------------------------------------------------
+if [[ "${1:-}" == "--clean" ]]; then
+    echo "Cleaning build artefacts (neo_build/)..."
+    rm -rf "${SCRIPT_DIR}/neo_build"
+    echo "Done."
+    exit 0
+fi
+
+# --- detect Fortran compiler -------------------------------------------------
+# Prefer the MPI wrapper because several NEO objects `use mpi` and a few of
+# the gacode shared libs (expro_comm.o) actually call mpi_bcast / mpi_comm_*
+# at link time.  We force the MPI wrapper unless the user explicitly opts
+# out via NEO_FC=...
+if [[ -n "${NEO_FC:-}" ]]; then
+    FC="${NEO_FC}"
+elif command -v mpifort &>/dev/null; then
+    FC=mpifort
+elif command -v mpif90 &>/dev/null; then
+    FC=mpif90
+else
+    echo "ERROR: no MPI Fortran wrapper found (mpifort / mpif90)."
+    echo "       In a pixi env, ensure openmpi-mpifort is installed."
+    exit 1
+fi
+
+# --- detect library prefix ---------------------------------------------------
+if [[ -n "${CONDA_PREFIX:-}" ]]; then
+    LIB_DIRS=(-L"${CONDA_PREFIX}/lib")
+elif [[ -n "${PREFIX:-}" ]]; then
+    LIB_DIRS=(-L"${PREFIX}/lib")
+else
+    LIB_DIRS=(-L/usr/local/lib -L/usr/lib)
+fi
+
+# All build artefacts (including the .so) live in neo_build/ — gitignored.
+BUILD_DIR="${SCRIPT_DIR}/neo_build"
+mkdir -p "${BUILD_DIR}"
+
+echo "Building libneo_serial.so"
+echo "  FC         : $FC"
+echo "  NEO_SRC    : $NEO_SRC  (pre-built .o files)"
+echo "  OUTPUT     : ${BUILD_DIR}/libneo_serial.so"
+
+# ---------------------------------------------------------------------------
+# Compile neo_c_api.f90  (only this file needs compiling)
+# Flags must match the GACODE build: -fdefault-real-8 makes REAL == c_double.
+# -I${GACODE_MOD} provides pre-built .mod files (neo_interface.mod etc.)
+# ---------------------------------------------------------------------------
+echo "  Compiling neo_c_api.f90 ..."
+"$FC" -O2 -fPIC \
+    -fdefault-real-8 -fdefault-double-8 \
+    -fallow-argument-mismatch \
+    -fall-intrinsics \
+    -I"${GACODE_MOD}" \
+    -J"${BUILD_DIR}" \
+    -c "${SCRIPT_DIR}/neo_c_api.f90" \
+    -o "${BUILD_DIR}/neo_c_api.o"
+
+# ---------------------------------------------------------------------------
+# Collect the pre-built NEO object files
+# Excluded: neo.o (main program), neo_init.o (calls MPI_COMM_RANK/SIZE)
+# ---------------------------------------------------------------------------
+OBJECTS=()
+for name in \
+    neo_globals \
+    neo_energy_grid \
+    neo_interface \
+    neo_allocate_profile \
+    neo_umfpack \
+    neo_sparse_solve \
+    neo_equilibrium \
+    neo_g_velocitygrids \
+    neo_rotation \
+    neo_nclass_dr \
+    neo_theory \
+    neo_transport \
+    neo_3d_driver \
+    neo_check \
+    neo_compute_fcoll \
+    neo_neural \
+    neo_do \
+    neo_error \
+    neo_init_serial \
+    neo_make_profiles \
+    neo_read_input \
+    neo_run \
+    neo_spitzer \
+    matconv; do
+
+    obj="${NEO_SRC}/${name}.o"
+    if [[ ! -f "$obj" ]]; then
+        echo "ERROR: pre-built object not found: $obj"
+        echo "       Rebuild GACODE: cd \${GACODE_ROOT} && make"
+        exit 1
+    fi
+    OBJECTS+=("$obj")
+done
+OBJECTS+=("${BUILD_DIR}/neo_c_api.o")
+
+# ---------------------------------------------------------------------------
+# Pull in the gacode shared static archives that NEO depends on.
+# These mirror EXTRA_LIBS from gacode/neo/Makefile.
+# ---------------------------------------------------------------------------
+EXTRA_LIBS=(
+    "${GACODE_ROOT}/f2py/expro/expro_lib.a"
+    "${GACODE_ROOT}/f2py/geo/geo_lib.a"
+    "${GACODE_ROOT}/shared/math/math_lib.a"
+    "${GACODE_ROOT}/shared/UMFPACK/UMFPACK_lib.a"
+    "${GACODE_ROOT}/shared/nclass/nclass_lib.a"
+)
+for a in "${EXTRA_LIBS[@]}"; do
+    if [[ ! -f "$a" ]]; then
+        echo "ERROR: required gacode archive not found: $a"
+        echo "       Build GACODE first: cd \${GACODE_ROOT} && make"
+        exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Link shared library
+# ---------------------------------------------------------------------------
+echo "  Linking libneo_serial.so ..."
+"$FC" -shared -fPIC \
+    "${OBJECTS[@]}" \
+    "${EXTRA_LIBS[@]}" \
+    "${LIB_DIRS[@]}" \
+    -llapack -lblas \
+    -o "${BUILD_DIR}/libneo_serial.so"
+
+echo ""
+echo "SUCCESS: ${BUILD_DIR}/libneo_serial.so"
+ls -lh "${BUILD_DIR}/libneo_serial.so"

--- a/src/mitim_tools/simulation_tools/interfaces/build_tglf_lib.sh
+++ b/src/mitim_tools/simulation_tools/interfaces/build_tglf_lib.sh
@@ -97,8 +97,12 @@ echo "  OUTPUT     : ${BUILD_DIR}/libtglf_serial.so"
 # Common flags. -fdefault-real-8/-fdefault-double-8 must match the GACODE
 # build so REAL == c_double on the C-binding side. -fPIC is mandatory on
 # Linux for shared-library linking; harmless on macOS.
+#
+# -O3 mirrors gacode's PIXI_OPENMP FOPT.  At -O2 the in-process .so was
+# measurably ~1.5-1.7x slower than the subprocess gacode binary (which
+# is built at -O3) on the same input — the gap closed when we matched -O3.
 # ---------------------------------------------------------------------------
-FFLAGS=(-O2 -fPIC
+FFLAGS=(-O3 -fPIC
         -fdefault-real-8 -fdefault-double-8
         -fallow-argument-mismatch
         -fall-intrinsics)

--- a/src/mitim_tools/simulation_tools/interfaces/build_tglf_lib.sh
+++ b/src/mitim_tools/simulation_tools/interfaces/build_tglf_lib.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# =============================================================================
+# build_tglf_lib.sh
+#
+# Build libtglf_serial.so — a shared library for in-process TGLF execution.
+#
+# Strategy
+# --------
+# TGLF is already compiled by the GACODE build system in ${GACODE_ROOT}/tglf/src/.
+# We reuse those pre-built object files (which include -fPIC from the GACODE
+# platform config) and compile only our thin C-binding wrapper tglf_c_api.f90.
+# This avoids re-fighting GACODE's legacy Fortran compiler quirks.
+#
+# MPI files excluded (they reference `use mpi` or `use tglf_mpi`):
+#   tglf_init_mpi.o  tglf_run_mpi.o  tglf_TM_mpi.o
+#
+# The tglf_run.o in GACODE's src was compiled WITHOUT -DMPI_TGLF, so it
+# provides the serial tglf_run() subroutine we need.
+#
+# Prerequisites
+# -------------
+#   - GACODE_ROOT set and gacode already built (tglf/src/*.o must exist)
+#   - gfortran (for compiling tglf_c_api.f90 only)
+#   - liblapack + libblas
+#
+# Usage
+# -----
+#   cd <this directory>
+#   bash build_tglf_lib.sh            # build
+#   bash build_tglf_lib.sh --clean    # remove build artefacts and library
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- validate environment ----------------------------------------------------
+if [[ -z "${GACODE_ROOT:-}" ]]; then
+    echo "ERROR: GACODE_ROOT is not set. Source your gacode_setup script first."
+    exit 1
+fi
+
+TGLF_SRC="${GACODE_ROOT}/tglf/src"
+GACODE_MOD="${GACODE_ROOT}/modules"
+
+if [[ ! -d "${TGLF_SRC}" ]]; then
+    echo "ERROR: TGLF source directory not found: ${TGLF_SRC}"
+    exit 1
+fi
+
+# Quick sanity check: ensure the gacode build produced the required .o files
+REQUIRED_OBJ="${TGLF_SRC}/tglf_run.o"
+if [[ ! -f "${REQUIRED_OBJ}" ]]; then
+    echo "ERROR: ${REQUIRED_OBJ} not found."
+    echo "       Build GACODE first: cd \${GACODE_ROOT} && make"
+    exit 1
+fi
+
+# --- optional clean ----------------------------------------------------------
+if [[ "${1:-}" == "--clean" ]]; then
+    echo "Cleaning build artefacts (tglf_build/)..."
+    rm -rf "${SCRIPT_DIR}/tglf_build"
+    echo "Done."
+    exit 0
+fi
+
+# --- detect Fortran compiler -------------------------------------------------
+FC="${FC:-gfortran}"
+if ! command -v "$FC" &>/dev/null; then
+    echo "ERROR: Fortran compiler '$FC' not found. Install gfortran or set FC."
+    exit 1
+fi
+
+# --- detect library prefix ---------------------------------------------------
+if [[ -n "${CONDA_PREFIX:-}" ]]; then
+    LIB_DIRS=(-L"${CONDA_PREFIX}/lib")
+elif [[ -n "${PREFIX:-}" ]]; then
+    LIB_DIRS=(-L"${PREFIX}/lib")
+else
+    LIB_DIRS=(-L/usr/local/lib -L/usr/lib)
+fi
+
+# All build artefacts (including the .so) live in tglf_build/ — gitignored.
+BUILD_DIR="${SCRIPT_DIR}/tglf_build"
+mkdir -p "${BUILD_DIR}"
+
+echo "Building libtglf_serial.so"
+echo "  FC         : $FC"
+echo "  TGLF_SRC   : $TGLF_SRC  (pre-built .o files)"
+echo "  OUTPUT     : ${BUILD_DIR}/libtglf_serial.so"
+
+# ---------------------------------------------------------------------------
+# Compile tglf_c_api.f90  (only this file needs compiling)
+# Flags must match the GACODE build: -fdefault-real-8 makes REAL == c_double.
+# -I${GACODE_MOD} provides pre-built .mod files (tglf_interface.mod etc.)
+# ---------------------------------------------------------------------------
+echo "  Compiling tglf_c_api.f90 ..."
+"$FC" -O2 -fPIC \
+    -fdefault-real-8 -fdefault-double-8 \
+    -fallow-argument-mismatch \
+    -fall-intrinsics \
+    -I"${GACODE_MOD}" \
+    -J"${BUILD_DIR}" \
+    -c "${SCRIPT_DIR}/tglf_c_api.f90" \
+    -o "${BUILD_DIR}/tglf_c_api.o"
+
+# ---------------------------------------------------------------------------
+# Collect the pre-built non-MPI TGLF object files
+# MPI files excluded: tglf_init_mpi.o  tglf_run_mpi.o  tglf_TM_mpi.o
+# ---------------------------------------------------------------------------
+OBJECTS=()
+for name in \
+    tglf_isnan \
+    tglf_isinf \
+    tglf_modules \
+    tglf_pkg \
+    tglf_allocate \
+    tglf_deallocate \
+    tglf_startup \
+    tglf_hermite \
+    tglf_inout \
+    tglf_setup_geometry \
+    tglf_LS \
+    tglf_eigensolver \
+    tglf_geometry \
+    tglf_matrix \
+    tglf_max \
+    tglf_interface \
+    tglf_error \
+    tglf_shutdown \
+    tglf_read_input \
+    tglf_multiscale_spectrum \
+    tglf_kygrid \
+    tglf_run \
+    tglf_TM \
+    tglf_nn_TM; do
+
+    obj="${TGLF_SRC}/${name}.o"
+    if [[ ! -f "$obj" ]]; then
+        echo "ERROR: pre-built object not found: $obj"
+        echo "       Rebuild GACODE: cd \${GACODE_ROOT} && make"
+        exit 1
+    fi
+    OBJECTS+=("$obj")
+done
+OBJECTS+=("${BUILD_DIR}/tglf_c_api.o")
+
+# ---------------------------------------------------------------------------
+# Link shared library
+# ---------------------------------------------------------------------------
+echo "  Linking libtglf_serial.so ..."
+"$FC" -shared -fPIC \
+    "${OBJECTS[@]}" \
+    "${LIB_DIRS[@]}" \
+    -llapack -lblas \
+    -o "${BUILD_DIR}/libtglf_serial.so"
+
+echo ""
+echo "SUCCESS: ${BUILD_DIR}/libtglf_serial.so"
+ls -lh "${BUILD_DIR}/libtglf_serial.so"

--- a/src/mitim_tools/simulation_tools/interfaces/build_tglf_lib.sh
+++ b/src/mitim_tools/simulation_tools/interfaces/build_tglf_lib.sh
@@ -6,21 +6,26 @@
 #
 # Strategy
 # --------
-# TGLF is already compiled by the GACODE build system in ${GACODE_ROOT}/tglf/src/.
-# We reuse those pre-built object files (which include -fPIC from the GACODE
-# platform config) and compile only our thin C-binding wrapper tglf_c_api.f90.
-# This avoids re-fighting GACODE's legacy Fortran compiler quirks.
+# We do NOT reuse GACODE's pre-built tglf .o files: most GACODE platform
+# configs (e.g. PIXI_OPENMP) build without -fPIC, which is fine on macOS
+# (PIC implicit) but breaks shared-library linking on Linux x86_64 with:
+#   "relocation R_X86_64_PC32 ... can not be used when making a shared object;
+#    recompile with -fPIC"
 #
-# MPI files excluded (they reference `use mpi` or `use tglf_mpi`):
-#   tglf_init_mpi.o  tglf_run_mpi.o  tglf_TM_mpi.o
+# Instead we compile the non-MPI TGLF .f90/.F90 sources ourselves with -fPIC
+# into BUILD_DIR, then link them together with our thin C-binding wrapper
+# tglf_c_api.f90 to produce libtglf_serial.so. This is fully self-contained
+# and platform-agnostic.
 #
-# The tglf_run.o in GACODE's src was compiled WITHOUT -DMPI_TGLF, so it
-# provides the serial tglf_run() subroutine we need.
+# MPI files excluded (they `use mpi` or `use tglf_mpi`):
+#   tglf_init_mpi  tglf_run_mpi  tglf_TM_mpi
+# tglf_run.F90 is compiled WITHOUT -DMPI_TGLF, giving the serial tglf_run().
 #
 # Prerequisites
 # -------------
-#   - GACODE_ROOT set and gacode already built (tglf/src/*.o must exist)
-#   - gfortran (for compiling tglf_c_api.f90 only)
+#   - GACODE_ROOT set, with tglf/src/*.f90 sources present (no need to have
+#     run `make` in gacode beforehand)
+#   - gfortran (or any Fortran compiler exposing the same flags)
 #   - liblapack + libblas
 #
 # Usage
@@ -41,18 +46,17 @@ if [[ -z "${GACODE_ROOT:-}" ]]; then
 fi
 
 TGLF_SRC="${GACODE_ROOT}/tglf/src"
-GACODE_MOD="${GACODE_ROOT}/modules"
 
 if [[ ! -d "${TGLF_SRC}" ]]; then
     echo "ERROR: TGLF source directory not found: ${TGLF_SRC}"
     exit 1
 fi
 
-# Quick sanity check: ensure the gacode build produced the required .o files
-REQUIRED_OBJ="${TGLF_SRC}/tglf_run.o"
-if [[ ! -f "${REQUIRED_OBJ}" ]]; then
-    echo "ERROR: ${REQUIRED_OBJ} not found."
-    echo "       Build GACODE first: cd \${GACODE_ROOT} && make"
+# Sanity check: ensure the .f90 sources exist (we compile from source, so we
+# do NOT require gacode itself to have been built).
+REQUIRED_SRC="${TGLF_SRC}/tglf_modules.f90"
+if [[ ! -f "${REQUIRED_SRC}" ]]; then
+    echo "ERROR: ${REQUIRED_SRC} not found. Is GACODE_ROOT correct?"
     exit 1
 fi
 
@@ -86,63 +90,90 @@ mkdir -p "${BUILD_DIR}"
 
 echo "Building libtglf_serial.so"
 echo "  FC         : $FC"
-echo "  TGLF_SRC   : $TGLF_SRC  (pre-built .o files)"
+echo "  TGLF_SRC   : $TGLF_SRC  (compiling from source with -fPIC)"
 echo "  OUTPUT     : ${BUILD_DIR}/libtglf_serial.so"
 
 # ---------------------------------------------------------------------------
-# Compile tglf_c_api.f90  (only this file needs compiling)
-# Flags must match the GACODE build: -fdefault-real-8 makes REAL == c_double.
-# -I${GACODE_MOD} provides pre-built .mod files (tglf_interface.mod etc.)
+# Common flags. -fdefault-real-8/-fdefault-double-8 must match the GACODE
+# build so REAL == c_double on the C-binding side. -fPIC is mandatory on
+# Linux for shared-library linking; harmless on macOS.
 # ---------------------------------------------------------------------------
-echo "  Compiling tglf_c_api.f90 ..."
-"$FC" -O2 -fPIC \
-    -fdefault-real-8 -fdefault-double-8 \
-    -fallow-argument-mismatch \
-    -fall-intrinsics \
-    -I"${GACODE_MOD}" \
-    -J"${BUILD_DIR}" \
-    -c "${SCRIPT_DIR}/tglf_c_api.f90" \
-    -o "${BUILD_DIR}/tglf_c_api.o"
+FFLAGS=(-O2 -fPIC
+        -fdefault-real-8 -fdefault-double-8
+        -fallow-argument-mismatch
+        -fall-intrinsics)
 
-# ---------------------------------------------------------------------------
-# Collect the pre-built non-MPI TGLF object files
-# MPI files excluded: tglf_init_mpi.o  tglf_run_mpi.o  tglf_TM_mpi.o
-# ---------------------------------------------------------------------------
-OBJECTS=()
-for name in \
-    tglf_isnan \
-    tglf_isinf \
-    tglf_modules \
-    tglf_pkg \
-    tglf_allocate \
-    tglf_deallocate \
-    tglf_startup \
-    tglf_hermite \
-    tglf_inout \
-    tglf_setup_geometry \
-    tglf_LS \
-    tglf_eigensolver \
-    tglf_geometry \
-    tglf_matrix \
-    tglf_max \
-    tglf_interface \
-    tglf_error \
-    tglf_shutdown \
-    tglf_read_input \
-    tglf_multiscale_spectrum \
-    tglf_kygrid \
-    tglf_run \
-    tglf_TM \
-    tglf_nn_TM; do
+# Order matters: module-providing files must precede their users. This list
+# mirrors the OBJECTS order in ${TGLF_SRC}/Makefile, with the *_mpi files
+# omitted and tglf_run.F90 (capital F) handled explicitly.
+TGLF_SOURCES_F90=(
+    tglf_isnan
+    tglf_modules
+    tglf_pkg
+    tglf_allocate
+    tglf_deallocate
+    tglf_startup
+    tglf_hermite
+    tglf_inout
+    tglf_setup_geometry
+    tglf_LS
+    tglf_eigensolver
+    tglf_geometry
+    tglf_matrix
+    tglf_max
+    tglf_interface
+    tglf_error
+    tglf_isinf
+    tglf_shutdown
+    tglf_read_input
+    tglf_multiscale_spectrum
+    tglf_kygrid
+    tglf_TM
+    tglf_nn_TM
+)
 
-    obj="${TGLF_SRC}/${name}.o"
-    if [[ ! -f "$obj" ]]; then
-        echo "ERROR: pre-built object not found: $obj"
-        echo "       Rebuild GACODE: cd \${GACODE_ROOT} && make"
+# Stage .f90/.F90 sources into BUILD_DIR before compiling. gfortran always
+# searches the source file's directory for .mod files, and ${TGLF_SRC} may
+# contain stale .mod files left over from a prior gacode build (possibly
+# from a different gfortran version), which would otherwise be picked up
+# and cause "Cannot read module file ... different version" errors.
+# Compiling out of BUILD_DIR isolates us from those stale artefacts.
+echo "  Staging sources into ${BUILD_DIR} ..."
+for name in "${TGLF_SOURCES_F90[@]}"; do
+    src="${TGLF_SRC}/${name}.f90"
+    if [[ ! -f "$src" ]]; then
+        echo "ERROR: source file not found: $src"
         exit 1
     fi
+    cp -f "$src" "${BUILD_DIR}/${name}.f90"
+done
+cp -f "${TGLF_SRC}/tglf_run.F90" "${BUILD_DIR}/tglf_run.F90"
+
+OBJECTS=()
+for name in "${TGLF_SOURCES_F90[@]}"; do
+    obj="${BUILD_DIR}/${name}.o"
+    echo "  Compiling ${name}.f90 ..."
+    ( cd "${BUILD_DIR}" && "$FC" "${FFLAGS[@]}" \
+        -I"${BUILD_DIR}" -J"${BUILD_DIR}" \
+        -c "${name}.f90" -o "${name}.o" )
     OBJECTS+=("$obj")
 done
+
+# tglf_run is .F90 (preprocessed). Build the SERIAL variant: do NOT define
+# MPI_TGLF.
+echo "  Compiling tglf_run.F90 (serial) ..."
+( cd "${BUILD_DIR}" && "$FC" "${FFLAGS[@]}" \
+    -I"${BUILD_DIR}" -J"${BUILD_DIR}" \
+    -c "tglf_run.F90" -o "tglf_run.o" )
+OBJECTS+=("${BUILD_DIR}/tglf_run.o")
+
+# Finally compile our thin C-binding wrapper. -I${BUILD_DIR} picks up the
+# tglf_interface.mod we just produced.
+echo "  Compiling tglf_c_api.f90 ..."
+"$FC" "${FFLAGS[@]}" \
+    -I"${BUILD_DIR}" -J"${BUILD_DIR}" \
+    -c "${SCRIPT_DIR}/tglf_c_api.f90" \
+    -o "${BUILD_DIR}/tglf_c_api.o"
 OBJECTS+=("${BUILD_DIR}/tglf_c_api.o")
 
 # ---------------------------------------------------------------------------

--- a/src/mitim_tools/simulation_tools/interfaces/build_vgen_lib.sh
+++ b/src/mitim_tools/simulation_tools/interfaces/build_vgen_lib.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# =============================================================================
+# build_vgen_lib.sh
+#
+# Build libvgen_serial.so — a shared library that runs the gacode "vgen"
+# velocity-generation workflow in-process via ctypes (vgen_inprocess.py).
+#
+# Strategy
+# --------
+# Compile only the thin C-binding wrapper (vgen_c_api.f90) and link it
+# against the prebuilt vgen objects (vgen_globals.o, vgen_compute_neo.o,
+# vgen_getgeo.o) plus the same gacode static archives the standard vgen
+# binary uses (neo_lib.a, expro_lib.a, geo_lib.a, math_lib.a, UMFPACK_lib.a,
+# nclass_lib.a).
+#
+# Excluded objects
+# ----------------
+#   vgen.o         — main program (calls MPI_INIT directly)
+#   vgen_init.o    — uses MPI_finalize on errors and hard-codes MPI_COMM_WORLD;
+#                    its body is reproduced inside vgen_c_api.f90 with comm=0
+#   vgen_reduce.o  — calls MPI_ALLREDUCE; with one rank we just skip it
+#
+# vgen_compute_neo.o uses MPI_Wtime() but with timing_flag=0 (set in
+# vgen_globals) the timer is read but never written, so a stub library
+# isn't needed.  We still link via the MPI Fortran wrapper to satisfy the
+# residual `use mpi` references that the gacode shared libs carry.
+#
+# Prerequisites
+# -------------
+#   - GACODE_ROOT set and gacode already built (vgen/src/*.o + neo/src/*.o)
+#   - mpifort / mpif90 (provided by openmpi-mpifort in the pixi env)
+#   - liblapack + libblas
+#
+# Usage
+# -----
+#   bash build_vgen_lib.sh            # build
+#   bash build_vgen_lib.sh --clean    # remove build artefacts and library
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- validate environment ----------------------------------------------------
+if [[ -z "${GACODE_ROOT:-}" ]]; then
+    echo "ERROR: GACODE_ROOT is not set. Source your gacode_setup script first."
+    exit 1
+fi
+
+VGEN_SRC="${GACODE_ROOT}/vgen/src"
+GACODE_MOD="${GACODE_ROOT}/modules"
+
+if [[ ! -d "${VGEN_SRC}" ]]; then
+    echo "ERROR: vgen source directory not found: ${VGEN_SRC}"
+    exit 1
+fi
+
+REQUIRED_OBJ="${VGEN_SRC}/vgen_compute_neo.o"
+if [[ ! -f "${REQUIRED_OBJ}" ]]; then
+    echo "ERROR: ${REQUIRED_OBJ} not found."
+    echo "       Build GACODE first: cd \${GACODE_ROOT} && make"
+    exit 1
+fi
+
+# --- optional clean ----------------------------------------------------------
+if [[ "${1:-}" == "--clean" ]]; then
+    echo "Cleaning build artefacts (vgen_build/)..."
+    rm -rf "${SCRIPT_DIR}/vgen_build"
+    echo "Done."
+    exit 0
+fi
+
+# --- detect Fortran compiler -------------------------------------------------
+# Force the MPI wrapper unless the user explicitly opts out via VGEN_FC=...
+if [[ -n "${VGEN_FC:-}" ]]; then
+    FC="${VGEN_FC}"
+elif command -v mpifort &>/dev/null; then
+    FC=mpifort
+elif command -v mpif90 &>/dev/null; then
+    FC=mpif90
+else
+    echo "ERROR: no MPI Fortran wrapper found (mpifort / mpif90)."
+    echo "       In a pixi env, ensure openmpi-mpifort is installed."
+    exit 1
+fi
+
+# --- detect library prefix ---------------------------------------------------
+if [[ -n "${CONDA_PREFIX:-}" ]]; then
+    LIB_DIRS=(-L"${CONDA_PREFIX}/lib")
+elif [[ -n "${PREFIX:-}" ]]; then
+    LIB_DIRS=(-L"${PREFIX}/lib")
+else
+    LIB_DIRS=(-L/usr/local/lib -L/usr/lib)
+fi
+
+# All build artefacts (including the .so) live in vgen_build/ — gitignored.
+BUILD_DIR="${SCRIPT_DIR}/vgen_build"
+mkdir -p "${BUILD_DIR}"
+
+echo "Building libvgen_serial.so"
+echo "  FC         : $FC"
+echo "  VGEN_SRC   : $VGEN_SRC  (pre-built .o files)"
+echo "  OUTPUT     : ${BUILD_DIR}/libvgen_serial.so"
+
+# ---------------------------------------------------------------------------
+# Compile vgen_c_api.f90
+# ---------------------------------------------------------------------------
+echo "  Compiling vgen_c_api.f90 ..."
+"$FC" -O2 -fPIC \
+    -fdefault-real-8 -fdefault-double-8 \
+    -fallow-argument-mismatch \
+    -fall-intrinsics \
+    -I"${GACODE_MOD}" \
+    -J"${BUILD_DIR}" \
+    -c "${SCRIPT_DIR}/vgen_c_api.f90" \
+    -o "${BUILD_DIR}/vgen_c_api.o"
+
+# ---------------------------------------------------------------------------
+# Collect the prebuilt vgen object files we need
+# Excluded: vgen.o, vgen_init.o, vgen_reduce.o (see header comment)
+# ---------------------------------------------------------------------------
+OBJECTS=()
+for name in vgen_globals vgen_compute_neo vgen_getgeo; do
+    obj="${VGEN_SRC}/${name}.o"
+    if [[ ! -f "$obj" ]]; then
+        echo "ERROR: pre-built object not found: $obj"
+        echo "       Rebuild GACODE: cd \${GACODE_ROOT} && make"
+        exit 1
+    fi
+    OBJECTS+=("$obj")
+done
+OBJECTS+=("${BUILD_DIR}/vgen_c_api.o")
+
+# ---------------------------------------------------------------------------
+# Pull in the gacode shared static archives that vgen depends on.
+# Mirrors EXTRA_LIBS from gacode/vgen/Makefile.
+# ---------------------------------------------------------------------------
+EXTRA_LIBS=(
+    "${GACODE_ROOT}/neo/src/neo_lib.a"
+    "${GACODE_ROOT}/f2py/expro/expro_lib.a"
+    "${GACODE_ROOT}/f2py/geo/geo_lib.a"
+    "${GACODE_ROOT}/shared/math/math_lib.a"
+    "${GACODE_ROOT}/shared/UMFPACK/UMFPACK_lib.a"
+    "${GACODE_ROOT}/shared/nclass/nclass_lib.a"
+)
+for a in "${EXTRA_LIBS[@]}"; do
+    if [[ ! -f "$a" ]]; then
+        echo "ERROR: required gacode archive not found: $a"
+        echo "       Build GACODE first: cd \${GACODE_ROOT} && make"
+        exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Link shared library
+# ---------------------------------------------------------------------------
+echo "  Linking libvgen_serial.so ..."
+"$FC" -shared -fPIC \
+    "${OBJECTS[@]}" \
+    "${EXTRA_LIBS[@]}" \
+    "${LIB_DIRS[@]}" \
+    -llapack -lblas \
+    -o "${BUILD_DIR}/libvgen_serial.so"
+
+echo ""
+echo "SUCCESS: ${BUILD_DIR}/libvgen_serial.so"
+ls -lh "${BUILD_DIR}/libvgen_serial.so"

--- a/src/mitim_tools/simulation_tools/interfaces/neo_c_api.f90
+++ b/src/mitim_tools/simulation_tools/interfaces/neo_c_api.f90
@@ -1,0 +1,156 @@
+!---------------------------------------------------------------------------
+! neo_c_api.f90
+!
+! PURPOSE:
+!   Thin Fortran wrapper exposing NEO subroutines and output variables
+!   through C-compatible interfaces (iso_c_binding).  This file lives in
+!   MITIM-fusion and is compiled together with the NEO sources to produce
+!   libneo_serial.so, loaded by neo_inprocess.py via ctypes.
+!
+! NOTES:
+!   * NEO is built with -fdefault-real-8, so Fortran REAL == 8 bytes ==
+!     c_double, matching all the neo_*_in / neo_*_out module variables.
+!   * Per-species output arrays are dimension(11) (n_species_max).
+!   * Geometry output array is dimension(5).
+!   * neo_init_serial(path) sets path/i_proc/n_proc and stubs the MPI
+!     communicator (NEO_COMM_WORLD = -1) so neo_do() runs serially.
+!   * Two entry points are exposed:
+!       - c_neo_run_file()  : read input.neo.gen from disk, then run
+!       - c_neo_run_iface() : run with whatever was set in neo_*_in
+!---------------------------------------------------------------------------
+
+module neo_c_api
+
+  use iso_c_binding
+  use neo_interface
+  use neo_globals, only: path, silent_flag, i_proc, n_proc, NEO_COMM_WORLD
+
+  implicit none
+
+contains
+
+  ! -------------------------------------------------------------------------
+  ! c_neo_set_path
+  !   Initialise NEO for serial use and set the working directory path.
+  !   `path_cstr` is a null-terminated C string ending with '/'.
+  ! -------------------------------------------------------------------------
+  subroutine c_neo_set_path(path_cstr) bind(C, name="c_neo_set_path")
+    character(kind=c_char), dimension(*), intent(in) :: path_cstr
+    integer :: i
+
+    path = ' '
+    do i = 1, len(path)
+      if (path_cstr(i) == c_null_char) exit
+      path(i:i) = path_cstr(i)
+    end do
+
+    ! Mimic neo_init_serial: serial execution, fake communicator.
+    i_proc         = 0
+    n_proc         = 1
+    NEO_COMM_WORLD = -1
+
+    ! Always quiet.
+    neo_silent_flag_in = 1
+
+  end subroutine c_neo_set_path
+
+  ! -------------------------------------------------------------------------
+  ! c_neo_read_input
+  !   Read parameters from input.neo.gen located at the path set above
+  !   and copy them into the neo_interface module variables, so the next
+  !   call to c_neo_run_iface() picks them up.
+  ! -------------------------------------------------------------------------
+  subroutine c_neo_read_input() bind(C, name="c_neo_read_input")
+    call neo_read_input()
+    call map_global2interface()
+  end subroutine c_neo_read_input
+
+  ! -------------------------------------------------------------------------
+  ! c_neo_run
+  !   Run NEO using whatever values are currently in the neo_*_in module
+  !   variables.  This is the high-level subroutine entry point: neo_run()
+  !   internally calls map_interface2global() and neo_do().
+  ! -------------------------------------------------------------------------
+  subroutine c_neo_run() bind(C, name="c_neo_run")
+    call neo_run()
+  end subroutine c_neo_run
+
+  ! -------------------------------------------------------------------------
+  ! c_neo_get_outputs
+  !   Copy output module variables into C-accessible arguments.  All
+  !   per-species arrays have length 11 (= n_species_max).
+  ! -------------------------------------------------------------------------
+  subroutine c_neo_get_outputs(                                  &
+       ns_out,                                                   &
+       pflux_thHH, eflux_thHHi, eflux_thHHe, eflux_thCHi,        &
+       jpar_thS, jpar_thK, jpar_thN, jtor_thS,                   &
+       jpar_thSmod, jtor_thSmod,                                 &
+       pflux_thHS, eflux_thHS,                                   &
+       pflux_dke, efluxtot_dke, efluxncv_dke, mflux_dke,         &
+       vpol_dke, vtor_dke, jpar_dke, jtor_dke,                   &
+       pflux_gv, efluxtot_gv, efluxncv_gv, mflux_gv,             &
+       nclassvis, pflux_nclass, efluxtot_nclass,                 &
+       vpol_nclass, vtor_nclass, jpar_nclass,                    &
+       geoparams,                                                &
+       error_status                                              &
+       ) bind(C, name="c_neo_get_outputs")
+
+    integer(c_int), intent(out) :: ns_out
+    real(c_double), intent(out) :: pflux_thHH, eflux_thHHi, eflux_thHHe, eflux_thCHi
+    real(c_double), intent(out) :: jpar_thS, jpar_thK, jpar_thN, jtor_thS
+    real(c_double), intent(out) :: jpar_thSmod, jtor_thSmod
+    real(c_double), intent(out) :: pflux_thHS(11), eflux_thHS(11)
+    real(c_double), intent(out) :: pflux_dke(11), efluxtot_dke(11), efluxncv_dke(11)
+    real(c_double), intent(out) :: mflux_dke(11), vpol_dke(11), vtor_dke(11)
+    real(c_double), intent(out) :: jpar_dke, jtor_dke
+    real(c_double), intent(out) :: pflux_gv(11), efluxtot_gv(11), efluxncv_gv(11), mflux_gv(11)
+    real(c_double), intent(out) :: nclassvis(11), pflux_nclass(11), efluxtot_nclass(11)
+    real(c_double), intent(out) :: vpol_nclass(11), vtor_nclass(11)
+    real(c_double), intent(out) :: jpar_nclass
+    real(c_double), intent(out) :: geoparams(5)
+    integer(c_int), intent(out) :: error_status
+
+    ns_out          = neo_n_species_in
+
+    pflux_thHH      = neo_pflux_thHH_out
+    eflux_thHHi     = neo_eflux_thHHi_out
+    eflux_thHHe     = neo_eflux_thHHe_out
+    eflux_thCHi     = neo_eflux_thCHi_out
+    jpar_thS        = neo_jpar_thS_out
+    jpar_thK        = neo_jpar_thK_out
+    jpar_thN        = neo_jpar_thN_out
+    jtor_thS        = neo_jtor_thS_out
+    jpar_thSmod     = neo_jpar_thSmod_out
+    jtor_thSmod     = neo_jtor_thSmod_out
+
+    pflux_thHS      = neo_pflux_thHS_out
+    eflux_thHS      = neo_eflux_thHS_out
+
+    pflux_dke       = neo_pflux_dke_out
+    efluxtot_dke    = neo_efluxtot_dke_out
+    efluxncv_dke    = neo_efluxncv_dke_out
+    mflux_dke       = neo_mflux_dke_out
+    vpol_dke        = neo_vpol_dke_out
+    vtor_dke        = neo_vtor_dke_out
+    jpar_dke        = neo_jpar_dke_out
+    jtor_dke        = neo_jtor_dke_out
+
+    pflux_gv        = neo_pflux_gv_out
+    efluxtot_gv     = neo_efluxtot_gv_out
+    efluxncv_gv     = neo_efluxncv_gv_out
+    mflux_gv        = neo_mflux_gv_out
+
+    nclassvis       = neo_nclassvis_out
+    pflux_nclass    = neo_pflux_nclass_out
+    efluxtot_nclass = neo_efluxtot_nclass_out
+    vpol_nclass     = neo_vpol_nclass_out
+    vtor_nclass     = neo_vtor_nclass_out
+    jpar_nclass     = neo_jpar_nclass_out
+
+    geoparams       = neo_geoparams_out
+
+    error_status    = neo_error_status_out
+
+  end subroutine c_neo_get_outputs
+
+end module neo_c_api

--- a/src/mitim_tools/simulation_tools/interfaces/neo_inprocess.py
+++ b/src/mitim_tools/simulation_tools/interfaces/neo_inprocess.py
@@ -1,0 +1,740 @@
+"""
+neo_inprocess.py
+================
+In-process NEO execution via a ctypes-loaded shared library (libneo_serial.so).
+
+Three entry points are provided:
+
+1. ``runner.prepare(profiles_or_path, rhos, code_settings, ...)`` +
+   ``runner.run_all()`` / ``runner.run_rho(rho)``
+   **Standalone fully in-memory path** — pass an ``input.gacode`` file path or
+   a live ``PROFILES_GACODE`` object; inputs are built via ``to_neo()`` and
+   cached in memory.  All subsequent run calls are zero file I/O.
+
+2. ``runner.run_from_dict(input_dict)``
+   Sets all Fortran module variables directly from a flat Python dict — zero
+   file I/O.  The dict is exactly what ``PROFILES_GACODE.to_neo()`` returns
+   for one rho value.
+
+3. ``runner.run(gen_file_dir)``
+   Legacy path — reads an ``input.neo.gen`` file from disk.
+
+All paths call ``c_neo_run()`` in-process and return the same output dict.
+
+API
+---
+    from mitim_tools.simulation_tools.interfaces.neo_inprocess import (
+        NEOInProcess,
+        generate_input_gen,
+        write_transport_flux,
+    )
+
+    # --- standalone in-memory path (preferred) ---
+    runner = NEOInProcess()
+    runner.prepare("path/to/input.gacode", rhos=[0.4, 0.6], code_settings="Sonic")
+    results = runner.run_all()        # {rho: output_dict}
+    out     = runner.run_rho(0.4)
+
+    # --- dict-based path ---
+    runner  = NEOInProcess()
+    outputs = runner.run_from_dict(input_dict)  # dict from to_neo()
+
+    # --- file-based path (requires GACODE_ROOT) ---
+    gen_file = generate_input_gen("/path/to/input.neo")
+    outputs  = runner.run(gen_file)
+
+Prerequisites
+-------------
+    Build the shared library once per machine::
+
+        cd <MITIM-fusion>/src/mitim_tools/simulation_tools/interfaces
+        bash build_neo_lib.sh
+
+Thread safety
+-------------
+The Fortran library uses global module variables.  A single loaded instance
+is NOT safe to call from multiple threads simultaneously.
+
+For parallel in-process runs we copy the .so to unique temporary paths so
+each worker thread gets its own ``dlopen`` handle with independent Fortran
+globals.  ``ctypes`` releases the GIL during Fortran calls, so threads give
+true parallelism without any of the macOS multiprocessing pitfalls.
+"""
+
+from __future__ import annotations
+
+import atexit
+import ctypes
+import os
+import shutil
+import tempfile
+import threading
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# All build artefacts live in neo_build/ (gitignored) inside this directory.
+# ---------------------------------------------------------------------------
+_INTERFACES_DIR = Path(__file__).parent
+_LIB_PATH = _INTERFACES_DIR / "neo_build" / "libneo_serial.so"
+
+# ---------------------------------------------------------------------------
+# Lazy singleton: load libneo_serial.so once per process (sequential use)
+# ---------------------------------------------------------------------------
+_lib: Any = None
+
+# ---------------------------------------------------------------------------
+# Thread-parallel support: each worker thread gets its own private copy of
+# the .so so Fortran module-level globals are truly independent.
+# ---------------------------------------------------------------------------
+_thread_local = threading.local()
+_temp_lib_paths: list[str] = []
+_temp_lib_lock = threading.Lock()
+
+
+@atexit.register
+def _cleanup_temp_libs() -> None:
+    """Remove per-thread .so copies created for parallel runs."""
+    for p in _temp_lib_paths:
+        try:
+            os.unlink(p)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# NEO output array sizes
+# ---------------------------------------------------------------------------
+_NSM = 11           # n_species_max — per-species arrays are dimension(11)
+_NGEO = 5           # neo_geoparams_out is dimension(5)
+_double11 = ctypes.c_double * _NSM
+_double5  = ctypes.c_double * _NGEO
+
+
+def _setup_lib_signatures(lib: ctypes.CDLL) -> ctypes.CDLL:
+    """Attach ctypes argument/return-type annotations to *lib*. Returns *lib*."""
+    lib.c_neo_set_path.restype  = None
+    lib.c_neo_set_path.argtypes = [ctypes.c_char_p]
+
+    lib.c_neo_read_input.restype  = None
+    lib.c_neo_read_input.argtypes = []
+
+    lib.c_neo_run.restype  = None
+    lib.c_neo_run.argtypes = []
+
+    lib.c_neo_get_outputs.restype = None
+    lib.c_neo_get_outputs.argtypes = [
+        ctypes.POINTER(ctypes.c_int),         # ns_out
+        # 10 scalar theory outputs
+        ctypes.POINTER(ctypes.c_double),      # pflux_thHH
+        ctypes.POINTER(ctypes.c_double),      # eflux_thHHi
+        ctypes.POINTER(ctypes.c_double),      # eflux_thHHe
+        ctypes.POINTER(ctypes.c_double),      # eflux_thCHi
+        ctypes.POINTER(ctypes.c_double),      # jpar_thS
+        ctypes.POINTER(ctypes.c_double),      # jpar_thK
+        ctypes.POINTER(ctypes.c_double),      # jpar_thN
+        ctypes.POINTER(ctypes.c_double),      # jtor_thS
+        ctypes.POINTER(ctypes.c_double),      # jpar_thSmod
+        ctypes.POINTER(ctypes.c_double),      # jtor_thSmod
+        # Hirshman-Sigmar
+        ctypes.POINTER(_double11),            # pflux_thHS
+        ctypes.POINTER(_double11),            # eflux_thHS
+        # DKE
+        ctypes.POINTER(_double11),            # pflux_dke
+        ctypes.POINTER(_double11),            # efluxtot_dke
+        ctypes.POINTER(_double11),            # efluxncv_dke
+        ctypes.POINTER(_double11),            # mflux_dke
+        ctypes.POINTER(_double11),            # vpol_dke
+        ctypes.POINTER(_double11),            # vtor_dke
+        ctypes.POINTER(ctypes.c_double),      # jpar_dke
+        ctypes.POINTER(ctypes.c_double),      # jtor_dke
+        # Gyro-viscosity
+        ctypes.POINTER(_double11),            # pflux_gv
+        ctypes.POINTER(_double11),            # efluxtot_gv
+        ctypes.POINTER(_double11),            # efluxncv_gv
+        ctypes.POINTER(_double11),            # mflux_gv
+        # NCLASS
+        ctypes.POINTER(_double11),            # nclassvis
+        ctypes.POINTER(_double11),            # pflux_nclass
+        ctypes.POINTER(_double11),            # efluxtot_nclass
+        ctypes.POINTER(_double11),            # vpol_nclass
+        ctypes.POINTER(_double11),            # vtor_nclass
+        ctypes.POINTER(ctypes.c_double),      # jpar_nclass
+        # Geometry
+        ctypes.POINTER(_double5),             # geoparams
+        # Error status
+        ctypes.POINTER(ctypes.c_int),         # error_status
+    ]
+    return lib
+
+
+def _load_lib() -> ctypes.CDLL:
+    global _lib
+    if _lib is not None:
+        return _lib
+
+    if not _LIB_PATH.exists():
+        raise RuntimeError(
+            f"libneo_serial.so not found at {_LIB_PATH}\n"
+            "  Build it once with:\n"
+            f"    cd {_INTERFACES_DIR} && bash build_neo_lib.sh"
+        )
+
+    try:
+        lib = ctypes.CDLL(str(_LIB_PATH))
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to load {_LIB_PATH}: {exc}\n"
+            "Check that the library was compiled for the current platform."
+        ) from exc
+
+    _lib = _setup_lib_signatures(lib)
+    return _lib
+
+
+def _load_unique_lib() -> ctypes.CDLL:
+    """
+    Load a PRIVATE copy of the shared library so each thread gets independent
+    Fortran module-level globals.  See tglf_inprocess.py for rationale.
+    """
+    if not _LIB_PATH.exists():
+        raise RuntimeError(
+            f"libneo_serial.so not found at {_LIB_PATH}\n"
+            "  Build it once with:\n"
+            f"    cd {_INTERFACES_DIR} && bash build_neo_lib.sh"
+        )
+    fd, tmp_path = tempfile.mkstemp(suffix="_neo_thread.so")
+    os.close(fd)
+    shutil.copy(str(_LIB_PATH), tmp_path)
+    with _temp_lib_lock:
+        _temp_lib_paths.append(tmp_path)
+    try:
+        lib = ctypes.CDLL(tmp_path)
+    except OSError as exc:
+        raise RuntimeError(f"Failed to load private lib copy {tmp_path}: {exc}") from exc
+    return _setup_lib_signatures(lib)
+
+
+def _get_thread_lib() -> ctypes.CDLL:
+    """Return the calling thread's private library instance, creating it on first use."""
+    if not hasattr(_thread_local, "lib"):
+        _thread_local.lib = _load_unique_lib()
+    return _thread_local.lib
+
+
+# ---------------------------------------------------------------------------
+# Direct module-variable access — maps dict keys → Fortran neo_interface vars
+# ---------------------------------------------------------------------------
+#
+# gfortran mangles  module::var  →  __module_MOD_var
+# All neo_interface inputs are named  neo_<var>_in  (one exception:
+# neo_subroutine_flag has no `_in` suffix).
+#
+def _sym(var: str) -> str:
+    if var == "subroutine_flag":
+        return "__neo_interface_MOD_neo_subroutine_flag"
+    return f"__neo_interface_MOD_neo_{var}_in"
+
+
+# Per-species real arrays (dim 11)
+_SPECIES_REAL_BASES = frozenset([
+    "z", "mass", "dens", "temp", "dlnndr", "dlntdr",
+    "temp_para", "dlntdr_para", "temp_perp", "dlntdr_perp",
+    "profile_dlnndr_scale", "profile_dlntdr_scale",
+])
+
+# Per-species integer arrays (dim 11)
+_SPECIES_INT_BASES = frozenset([
+    "aniso_model",
+])
+
+# Scalar Fortran INTEGER variables (stored as 4-byte integer)
+_INTEGERS = frozenset([
+    "n_energy", "n_xi", "n_theta", "n_radial", "matsz_scalefac",
+    "silent_flag", "sim_model", "equilibrium_model", "collision_model",
+    "profile_model", "profile_erad0_model", "ipccw", "btccw",
+    "rotation_model", "spitzer_model",
+    "coll_uncoupledei_model", "coll_uncoupledaniso_model",
+    "ae_flag", "n_species", "threed_model", "threed_exb_model",
+    "threed_drift_model", "laguerre_method", "write_cmoments_flag",
+    "subroutine_flag", "test_flag",
+])
+
+
+def _zero_species_arrays(lib: ctypes.CDLL) -> None:
+    """
+    Zero all per-species arrays so stale values from a prior call don't
+    persist.  Integer arrays with required default values (e.g.
+    aniso_model = 1 = isotropic) are reset to that default rather than 0,
+    so the input dict is allowed to omit them.
+    """
+    for base in _SPECIES_REAL_BASES:
+        arr = (ctypes.c_double * _NSM).in_dll(lib, _sym(base))
+        ctypes.memset(arr, 0, ctypes.sizeof(arr))
+    # Integer arrays — reset to NEO defaults (aniso_model = 1 means
+    # isotropic single-temperature; 0 is invalid).
+    arr = (ctypes.c_int * _NSM).in_dll(lib, _sym("aniso_model"))
+    for k in range(_NSM):
+        arr[k] = 1
+
+
+def _set_inputs_from_dict(lib: ctypes.CDLL, input_dict: dict) -> None:
+    """
+    Write every entry in *input_dict* directly into the neo_interface Fortran
+    module variables.  This replaces the ``neo_read_input()`` file-read.
+
+    Key conventions (matching ``PROFILES_GACODE.to_neo()`` output):
+    - Scalar controls / plasma:  ``"NU_1"``, ``"RMIN_OVER_A"``, ``"SIM_MODEL"`` …
+    - Species arrays:            ``"Z_1"``, ``"DLNTDR_2"`` … (1-based index)
+    - Profile-scale arrays:      ``"PROFILE_DLNNDR_1_SCALE"`` (index in the middle)
+    - Shape harmonics:           ``"SHAPE_COS0"``, ``"SHAPE_S_SIN3"`` …
+    - rbf_dir:                   ``"RBF_DIR"`` → ``character(len=16)``
+    """
+    _zero_species_arrays(lib)
+
+    for key, val in input_dict.items():
+        ku = key.upper()
+        kl = ku.lower()
+
+        # ---- profile_<base>_N_scale → profile_<base>_scale[N-1] ----
+        if kl.startswith("profile_") and kl.endswith("_scale"):
+            mid = kl[len("profile_"):-len("_scale")]
+            head, _, tail = mid.rpartition("_")
+            if tail.isdigit():
+                base = f"profile_{head}_scale"
+                if base in _SPECIES_REAL_BASES:
+                    idx = int(tail) - 1
+                    arr = (ctypes.c_double * _NSM).in_dll(lib, _sym(base))
+                    arr[idx] = float(val)
+                    continue
+
+        # ---- species array: KEY_N (e.g. Z_1, DLNTDR_2) ----
+        head, _, tail = kl.rpartition("_")
+        if tail.isdigit():
+            idx = int(tail) - 1
+            if head in _SPECIES_REAL_BASES:
+                arr = (ctypes.c_double * _NSM).in_dll(lib, _sym(head))
+                arr[idx] = float(val)
+                continue
+            if head in _SPECIES_INT_BASES:
+                arr = (ctypes.c_int * _NSM).in_dll(lib, _sym(head))
+                arr[idx] = int(val)
+                continue
+
+        # ---- scalar variable ----
+        var = kl
+        # alias: NEO uses RMIN_OVER_A_2 in the .gen file → neo_rmin_over_a_2_in
+        # all other names map directly.
+
+        sym = _sym(var)
+
+        if var == "rbf_dir":
+            CharT = ctypes.c_char * 16
+            s = CharT.in_dll(lib, sym)
+            enc = str(val).encode("ascii")[:16].ljust(16)
+            ctypes.memmove(s, enc, 16)
+
+        elif var in _INTEGERS:
+            ctypes.c_int.in_dll(lib, sym).value = int(val)
+
+        else:
+            # real — c_double because the library was built with -fdefault-real-8
+            try:
+                ctypes.c_double.in_dll(lib, sym).value = float(val)
+            except OSError:
+                pass   # unknown key (e.g. a MITIM-only field) — skip silently
+
+    # Force quiet AFTER applying the dict, so an explicit SILENT_FLAG=0
+    # in the input does not re-enable file output (interfacelocaldump
+    # would otherwise try to open out.neo.localdump in cwd).
+    ctypes.c_int.in_dll(lib, _sym("silent_flag")).value = 1
+
+
+def _collect_outputs(lib: ctypes.CDLL) -> dict:
+    """Read neo_*_out variables via c_neo_get_outputs and return a dict."""
+    ns_out         = ctypes.c_int(0)
+
+    pflux_thHH     = ctypes.c_double(0.0)
+    eflux_thHHi    = ctypes.c_double(0.0)
+    eflux_thHHe    = ctypes.c_double(0.0)
+    eflux_thCHi    = ctypes.c_double(0.0)
+    jpar_thS       = ctypes.c_double(0.0)
+    jpar_thK       = ctypes.c_double(0.0)
+    jpar_thN       = ctypes.c_double(0.0)
+    jtor_thS       = ctypes.c_double(0.0)
+    jpar_thSmod    = ctypes.c_double(0.0)
+    jtor_thSmod    = ctypes.c_double(0.0)
+
+    z11 = lambda: _double11(*([0.0] * _NSM))
+    pflux_thHS     = z11()
+    eflux_thHS     = z11()
+
+    pflux_dke      = z11()
+    efluxtot_dke   = z11()
+    efluxncv_dke   = z11()
+    mflux_dke      = z11()
+    vpol_dke       = z11()
+    vtor_dke       = z11()
+    jpar_dke       = ctypes.c_double(0.0)
+    jtor_dke       = ctypes.c_double(0.0)
+
+    pflux_gv       = z11()
+    efluxtot_gv    = z11()
+    efluxncv_gv    = z11()
+    mflux_gv       = z11()
+
+    nclassvis      = z11()
+    pflux_nclass   = z11()
+    efluxtot_nclass= z11()
+    vpol_nclass    = z11()
+    vtor_nclass    = z11()
+    jpar_nclass    = ctypes.c_double(0.0)
+
+    geoparams      = _double5(*([0.0] * _NGEO))
+    error_status   = ctypes.c_int(0)
+
+    lib.c_neo_get_outputs(
+        ctypes.byref(ns_out),
+        ctypes.byref(pflux_thHH),
+        ctypes.byref(eflux_thHHi),
+        ctypes.byref(eflux_thHHe),
+        ctypes.byref(eflux_thCHi),
+        ctypes.byref(jpar_thS),
+        ctypes.byref(jpar_thK),
+        ctypes.byref(jpar_thN),
+        ctypes.byref(jtor_thS),
+        ctypes.byref(jpar_thSmod),
+        ctypes.byref(jtor_thSmod),
+        ctypes.byref(pflux_thHS),
+        ctypes.byref(eflux_thHS),
+        ctypes.byref(pflux_dke),
+        ctypes.byref(efluxtot_dke),
+        ctypes.byref(efluxncv_dke),
+        ctypes.byref(mflux_dke),
+        ctypes.byref(vpol_dke),
+        ctypes.byref(vtor_dke),
+        ctypes.byref(jpar_dke),
+        ctypes.byref(jtor_dke),
+        ctypes.byref(pflux_gv),
+        ctypes.byref(efluxtot_gv),
+        ctypes.byref(efluxncv_gv),
+        ctypes.byref(mflux_gv),
+        ctypes.byref(nclassvis),
+        ctypes.byref(pflux_nclass),
+        ctypes.byref(efluxtot_nclass),
+        ctypes.byref(vpol_nclass),
+        ctypes.byref(vtor_nclass),
+        ctypes.byref(jpar_nclass),
+        ctypes.byref(geoparams),
+        ctypes.byref(error_status),
+    )
+
+    ns = int(ns_out.value)
+    return {
+        "ns":              ns,
+        # ---- theory ----
+        "pflux_thHH":      float(pflux_thHH.value),
+        "eflux_thHHi":     float(eflux_thHHi.value),
+        "eflux_thHHe":     float(eflux_thHHe.value),
+        "eflux_thCHi":     float(eflux_thCHi.value),
+        "jpar_thS":        float(jpar_thS.value),
+        "jpar_thK":        float(jpar_thK.value),
+        "jpar_thN":        float(jpar_thN.value),
+        "jtor_thS":        float(jtor_thS.value),
+        "jpar_thSmod":     float(jpar_thSmod.value),
+        "jtor_thSmod":     float(jtor_thSmod.value),
+        "pflux_thHS":      list(pflux_thHS[:ns]),
+        "eflux_thHS":      list(eflux_thHS[:ns]),
+        # ---- DKE ----
+        "pflux_dke":       list(pflux_dke[:ns]),
+        "efluxtot_dke":    list(efluxtot_dke[:ns]),
+        "efluxncv_dke":    list(efluxncv_dke[:ns]),
+        "mflux_dke":       list(mflux_dke[:ns]),
+        "vpol_dke":        list(vpol_dke[:ns]),
+        "vtor_dke":        list(vtor_dke[:ns]),
+        "jpar_dke":        float(jpar_dke.value),
+        "jtor_dke":        float(jtor_dke.value),
+        # ---- gyro-viscosity ----
+        "pflux_gv":        list(pflux_gv[:ns]),
+        "efluxtot_gv":     list(efluxtot_gv[:ns]),
+        "efluxncv_gv":     list(efluxncv_gv[:ns]),
+        "mflux_gv":        list(mflux_gv[:ns]),
+        # ---- NCLASS ----
+        "nclassvis":       list(nclassvis[:ns]),
+        "pflux_nclass":    list(pflux_nclass[:ns]),
+        "efluxtot_nclass": list(efluxtot_nclass[:ns]),
+        "vpol_nclass":     list(vpol_nclass[:ns]),
+        "vtor_nclass":     list(vtor_nclass[:ns]),
+        "jpar_nclass":     float(jpar_nclass.value),
+        # ---- geometry ----
+        "geoparams":       list(geoparams[:]),
+        # ---- status ----
+        "error_status":    int(error_status.value),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Input preprocessing: input.neo → input.neo.gen  (file-based path)
+# ---------------------------------------------------------------------------
+
+def generate_input_gen(input_neo_path: str | Path) -> Path:
+    """
+    Convert an ``input.neo`` file to ``input.neo.gen`` using GACODE's
+    ``neo_parse.py`` logic.  Requires ``GACODE_ROOT`` to be set.
+    """
+    input_neo_path = Path(input_neo_path).resolve()
+    if not input_neo_path.exists():
+        raise FileNotFoundError(f"input.neo not found: {input_neo_path}")
+
+    gacode_root = os.environ.get("GACODE_ROOT")
+    if not gacode_root:
+        raise RuntimeError(
+            "GACODE_ROOT environment variable is not set. "
+            "Source your gacode_setup script before using neo_inprocess."
+        )
+
+    # neo_parse.py uses argv[0] dirname-style discovery; the simplest way to
+    # invoke it correctly is to import it from neo/bin and run it from a cwd
+    # that contains the input.neo file (it hardcodes 'input.neo').
+    neo_bin = Path(gacode_root) / "neo" / "bin"
+    parser_path = neo_bin / "neo_parse.py"
+    if not parser_path.exists():
+        raise FileNotFoundError(f"neo_parse.py not found: {parser_path}")
+
+    # neo_parse.py reads 'input.neo' from cwd and writes 'input.neo.gen'.
+    # Use a subprocess so its sys.exit() doesn't kill the host process, and
+    # so its hard-coded relative paths work.
+    import subprocess
+    result = subprocess.run(
+        ["python", str(parser_path)],
+        cwd=str(input_neo_path.parent),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"NEO input parsing failed for {input_neo_path}:\n"
+            f"  stdout: {result.stdout}\n  stderr: {result.stderr}"
+        )
+
+    gen_path = input_neo_path.with_name("input.neo.gen")
+    if not gen_path.exists():
+        raise RuntimeError(f"neo_parse produced no output — expected {gen_path}")
+    return gen_path
+
+
+# ---------------------------------------------------------------------------
+# Output writer: outputs dict → out.neo.transport_flux (subset)
+# ---------------------------------------------------------------------------
+
+def write_transport_flux(outputs: dict, filepath: str | Path, roa: float = 0.5) -> None:
+    """
+    Write a minimal ``out.neo.transport_flux`` from the output dict returned
+    by :meth:`NEOInProcess.run` or :meth:`NEOInProcess.run_from_dict`.
+
+    The on-disk format produced by NEO is structured into three sections —
+    DKE, GV, and TGYRO (= DKE + GV).  Each section starts with a comment
+    line and contains one row per species: ``Z  Gamma  Q  Pi``.
+
+    This is intentionally a small writer; full output reconstruction would
+    require regenerating all the per-radius/per-theta files.
+    """
+    ns = outputs["ns"]
+
+    # We only know per-species DKE and GV; reconstruct Z from neo input by
+    # asking the caller to pass it in via outputs (or default to integer
+    # placeholder).  For the typical use of this writer (smoke-tests), the
+    # caller passes a dict that came from to_neo() and Z is not retained
+    # here, so we just emit zeros for the Z column.
+    Z = [0.0] * ns
+
+    def _section(header: str, G, Q, M):
+        out = [f"#  {header}"]
+        for k in range(ns):
+            out.append(f" {Z[k]:6.3f}  {G[k]:13.5e}  {Q[k]:13.5e}  {M[k]:13.5e}")
+        return "\n".join(out)
+
+    G_dke = outputs["pflux_dke"]
+    Q_dke = outputs["efluxtot_dke"]
+    M_dke = outputs["mflux_dke"]
+    G_gv  = outputs["pflux_gv"]
+    Q_gv  = outputs["efluxtot_gv"]
+    M_gv  = outputs["mflux_gv"]
+    G_tg  = [a + b for a, b in zip(G_dke, G_gv)]
+    Q_tg  = [a + b for a, b in zip(Q_dke, Q_gv)]
+    M_tg  = [a + b for a, b in zip(M_dke, M_gv)]
+
+    text = "\n".join([
+        f" r/a {roa:13.5e}",
+        _section("pflux_dke",   G_dke, Q_dke, M_dke),
+        _section("pflux_gv",    G_gv,  Q_gv,  M_gv),
+        _section("pflux_tgyro", G_tg,  Q_tg,  M_tg),
+        "",
+    ])
+    Path(filepath).write_text(text)
+
+
+# ---------------------------------------------------------------------------
+# Main in-process runner
+# ---------------------------------------------------------------------------
+
+class NEOInProcess:
+    """
+    Run NEO in-process via ctypes — no subprocess fork, no physics file I/O.
+
+    Three usage modes:
+
+    **Standalone / fully in-memory** (preferred)::
+
+        runner = NEOInProcess()
+        runner.prepare("path/to/input.gacode", rhos=[0.4, 0.6], code_settings="Sonic")
+        results = runner.run_all()   # {rho: output_dict} — zero file I/O
+        out     = runner.run_rho(0.4)
+
+    **Dict-based** (when you already have a flat input dict)::
+
+        neo_inputs = profiles.to_neo(r=rhos, code_settings="Sonic")
+        out = runner.run_from_dict(neo_inputs[0.5])
+
+    **File-based** (legacy, requires GACODE_ROOT)::
+
+        gen = generate_input_gen("/work/run1/input.neo")
+        out = runner.run(gen)
+
+    Sequential calls are safe; for parallel use thread-private library copies
+    via ``_get_thread_lib()`` (see ``_parallel_worker``).
+    """
+
+    def __init__(self) -> None:
+        self._lib = _load_lib()
+        self._inputs: dict = {}  # {float(rho): flat_dict} — populated by prepare()
+
+    # ------------------------------------------------------------------
+    # Standalone in-memory path
+    # ------------------------------------------------------------------
+
+    def prepare(
+        self,
+        profiles,
+        rhos: list = [0.5],
+        code_settings = "Sonic",
+        extraOptions: dict = {},
+        multipliers: dict = {},
+    ) -> None:
+        """
+        Build and cache NEO input dicts in memory from a PROFILES_GACODE object
+        or an ``input.gacode`` file path.
+
+        Calls ``profiles.to_neo()`` once, applies *multipliers* and
+        *extraOptions*, and stores the flat dicts in ``self._inputs``.
+        After this call, :meth:`run_all` and :meth:`run_rho` are zero file I/O.
+        """
+        if isinstance(profiles, (str, Path)):
+            from mitim_tools.gacode_tools.PROFILEStools import gacode_state
+            profiles = gacode_state(str(profiles))
+
+        raw = profiles.to_neo(r=list(rhos), code_settings=code_settings)
+
+        self._inputs = {}
+        for rho, d in raw.items():
+            flat = dict(d)
+            for key, factor in multipliers.items():
+                ku = key.upper()
+                if ku in flat:
+                    flat[ku] = flat[ku] * factor
+            flat.update({k.upper(): v for k, v in extraOptions.items()})
+            self._inputs[float(rho)] = flat
+
+    def run_all(self) -> dict:
+        """Run NEO for every rho prepared by :meth:`prepare`."""
+        if not self._inputs:
+            raise RuntimeError("No inputs prepared — call prepare() first.")
+        return {rho: self.run_from_dict(d) for rho, d in self._inputs.items()}
+
+    def run_rho(self, rho: float) -> dict:
+        """Run NEO for a single rho prepared by :meth:`prepare`."""
+        if rho not in self._inputs:
+            raise KeyError(
+                f"rho={rho} not in prepared inputs. "
+                f"Available: {sorted(self._inputs)}"
+            )
+        return self.run_from_dict(self._inputs[rho])
+
+    # ------------------------------------------------------------------
+    # File-based path
+    # ------------------------------------------------------------------
+
+    def run(self, gen_file_path: str | Path) -> dict:
+        """
+        Execute NEO reading inputs from ``input.neo.gen`` on disk.
+
+        Parameters
+        ----------
+        gen_file_path:
+            Path to ``input.neo.gen`` produced by :func:`generate_input_gen`,
+            **or** the directory containing it.
+        """
+        gen_file_path = Path(gen_file_path).resolve()
+        if gen_file_path.is_dir():
+            gen_dir = gen_file_path
+        else:
+            gen_dir = gen_file_path.parent
+        if not (gen_dir / "input.neo.gen").exists():
+            raise FileNotFoundError(f"input.neo.gen not found in {gen_dir}")
+
+        # NEO's `path` global is character(len=80), so we cannot store an
+        # absolute path longer than that.  Instead, chdir into the run
+        # directory and pass "./" as the path — NEO then opens
+        # "./input.neo.gen" which is always short enough.
+        prev_cwd = os.getcwd()
+        try:
+            os.chdir(str(gen_dir))
+            self._lib.c_neo_set_path(b"./")
+            self._lib.c_neo_read_input()
+            self._lib.c_neo_run()
+            return _collect_outputs(self._lib)
+        finally:
+            os.chdir(prev_cwd)
+
+    # ------------------------------------------------------------------
+    # In-memory path
+    # ------------------------------------------------------------------
+
+    def run_from_dict(self, input_dict: dict) -> dict:
+        """
+        Execute NEO setting all inputs directly from *input_dict* — no file I/O.
+
+        *input_dict* is the value for one rho from ``PROFILES_GACODE.to_neo()``.
+        Species arrays use 1-based index suffixes (``"Z_1"``, ``"DLNTDR_2"``…).
+        """
+        # Set a benign path so any internal file paths NEO might touch are
+        # written to /tmp rather than the user's cwd.  This is mostly defensive.
+        if not getattr(self, "_path_set", False):
+            tmp = tempfile.mkdtemp(prefix="neo_inproc_")
+            self._lib.c_neo_set_path((tmp + "/").encode("ascii"))
+            self._path_set = True
+
+        _set_inputs_from_dict(self._lib, input_dict)
+        self._lib.c_neo_run()
+        return _collect_outputs(self._lib)
+
+
+# ------------------------------------------------------------------
+# Module-level worker — picklable / thread-safe entry point.
+# ------------------------------------------------------------------
+
+def _parallel_worker(flat: dict) -> dict:
+    """
+    Run one NEO case on the calling thread's private library instance.
+
+    Each worker thread loads its own independent copy of the shared library
+    (via ``_get_thread_lib()``), giving isolated Fortran module-level globals.
+    """
+    lib = _get_thread_lib()
+    _set_inputs_from_dict(lib, flat)
+    lib.c_neo_run()
+    return _collect_outputs(lib)

--- a/src/mitim_tools/simulation_tools/interfaces/neo_inprocess.py
+++ b/src/mitim_tools/simulation_tools/interfaces/neo_inprocess.py
@@ -63,9 +63,24 @@ true parallelism without any of the macOS multiprocessing pitfalls.
 
 from __future__ import annotations
 
+import os
+
+# ---------------------------------------------------------------------------
+# Pin BLAS / OpenMP to one thread per *worker* BEFORE any ctypes import.
+# See the matching block in tglf_inprocess.py for the full rationale: the
+# in-process driver fans cases out across a Python ThreadPoolExecutor and
+# MKL/openblas inside each worker would otherwise spin up a full per-node
+# thread pool, causing severe oversubscription on multi-core nodes.
+# These vars must be set BEFORE the .so is dlopen'd because BLAS libraries
+# read them once at init time.
+# ---------------------------------------------------------------------------
+os.environ.setdefault("MKL_NUM_THREADS",      "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("OMP_NUM_THREADS",      "1")
+os.environ.setdefault("MKL_DYNAMIC",          "FALSE")
+
 import atexit
 import ctypes
-import os
 import shutil
 import tempfile
 import threading

--- a/src/mitim_tools/simulation_tools/interfaces/neo_inprocess.py
+++ b/src/mitim_tools/simulation_tools/interfaces/neo_inprocess.py
@@ -63,24 +63,9 @@ true parallelism without any of the macOS multiprocessing pitfalls.
 
 from __future__ import annotations
 
-import os
-
-# ---------------------------------------------------------------------------
-# Pin BLAS / OpenMP to one thread per *worker* BEFORE any ctypes import.
-# See the matching block in tglf_inprocess.py for the full rationale: the
-# in-process driver fans cases out across a Python ThreadPoolExecutor and
-# MKL/openblas inside each worker would otherwise spin up a full per-node
-# thread pool, causing severe oversubscription on multi-core nodes.
-# These vars must be set BEFORE the .so is dlopen'd because BLAS libraries
-# read them once at init time.
-# ---------------------------------------------------------------------------
-os.environ.setdefault("MKL_NUM_THREADS",      "1")
-os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
-os.environ.setdefault("OMP_NUM_THREADS",      "1")
-os.environ.setdefault("MKL_DYNAMIC",          "FALSE")
-
 import atexit
 import ctypes
+import os
 import shutil
 import tempfile
 import threading

--- a/src/mitim_tools/simulation_tools/interfaces/tglf_c_api.f90
+++ b/src/mitim_tools/simulation_tools/interfaces/tglf_c_api.f90
@@ -1,0 +1,115 @@
+!---------------------------------------------------------------------------
+! tglf_c_api.f90
+!
+! PURPOSE:
+!   Thin Fortran wrapper exposing TGLF subroutines and output variables
+!   through C-compatible interfaces (iso_c_binding).  This file lives in
+!   MITIM-fusion and is compiled together with the TGLF non-MPI sources
+!   to produce libtglf_serial.so, loaded by tglf_inprocess.py via ctypes.
+!
+! NOTES:
+!   * All real quantities come from tglf_interface which is compiled with
+!     -fdefault-real-8, making Fortran REAL == 8 bytes == c_double.
+!   * Arrays are sized to nsm-1 = 11 (maximum ion species count).
+!   * tglf_error() calls STOP on fatal errors — only valid inputs should be
+!     passed from MITIM's workflow.
+!---------------------------------------------------------------------------
+
+module tglf_c_api
+
+  use iso_c_binding
+  use tglf_interface, only: &
+    tglf_path_in,           &
+    tglf_quiet_flag_in,     &
+    tglf_dump_flag_in,      &
+    tglf_ns_in,             &
+    tglf_elec_pflux_out,    &
+    tglf_elec_eflux_out,    &
+    tglf_elec_eflux_low_out,&
+    tglf_elec_mflux_out,    &
+    tglf_elec_expwd_out,    &
+    tglf_ion_pflux_out,     &
+    tglf_ion_eflux_out,     &
+    tglf_ion_eflux_low_out, &
+    tglf_ion_mflux_out,     &
+    tglf_ion_expwd_out
+
+  implicit none
+
+contains
+
+  ! -------------------------------------------------------------------------
+  ! c_tglf_set_path
+  !   Set tglf_path_in (null-terminated C string) and disable verbose output.
+  ! -------------------------------------------------------------------------
+  subroutine c_tglf_set_path(path_cstr) bind(C, name="c_tglf_set_path")
+    character(kind=c_char), dimension(*), intent(in) :: path_cstr
+    integer :: i
+
+    tglf_path_in = ' '
+    do i = 1, 256
+      if (path_cstr(i) == c_null_char) exit
+      tglf_path_in(i:i) = path_cstr(i)
+    end do
+    tglf_quiet_flag_in = .true.
+    tglf_dump_flag_in  = .false.
+
+  end subroutine c_tglf_set_path
+
+  ! -------------------------------------------------------------------------
+  ! c_tglf_read_input
+  !   Read parameters from input.tglf.gen located in the path set by
+  !   c_tglf_set_path.  Fortran reads: trim(tglf_path_in)//'input.tglf.gen'
+  ! -------------------------------------------------------------------------
+  subroutine c_tglf_read_input() bind(C, name="c_tglf_read_input")
+    call tglf_read_input()
+  end subroutine c_tglf_read_input
+
+  ! -------------------------------------------------------------------------
+  ! c_tglf_run
+  !   Execute TGLF transport model (serial path; no file writes).
+  ! -------------------------------------------------------------------------
+  subroutine c_tglf_run() bind(C, name="c_tglf_run")
+    call tglf_run()
+  end subroutine c_tglf_run
+
+  ! -------------------------------------------------------------------------
+  ! c_tglf_get_outputs
+  !   Copy output module variables into C-accessible arguments.
+  !   ion arrays have length 11 (nsm-1 where nsm=12).
+  ! -------------------------------------------------------------------------
+  subroutine c_tglf_get_outputs(              &
+       ns_out,                                &
+       elec_pflux, elec_eflux, elec_eflux_low,&
+       elec_mflux, elec_expwd,                &
+       ion_pflux, ion_eflux, ion_eflux_low,   &
+       ion_mflux,  ion_expwd                  &
+       ) bind(C, name="c_tglf_get_outputs")
+
+    integer(c_int), intent(out) :: ns_out
+    real(c_double), intent(out) :: elec_pflux
+    real(c_double), intent(out) :: elec_eflux
+    real(c_double), intent(out) :: elec_eflux_low
+    real(c_double), intent(out) :: elec_mflux
+    real(c_double), intent(out) :: elec_expwd
+    real(c_double), intent(out) :: ion_pflux(11)
+    real(c_double), intent(out) :: ion_eflux(11)
+    real(c_double), intent(out) :: ion_eflux_low(11)
+    real(c_double), intent(out) :: ion_mflux(11)
+    real(c_double), intent(out) :: ion_expwd(11)
+
+    ns_out          = tglf_ns_in
+    elec_pflux      = tglf_elec_pflux_out
+    elec_eflux      = tglf_elec_eflux_out
+    elec_eflux_low  = tglf_elec_eflux_low_out
+    elec_mflux      = tglf_elec_mflux_out
+    elec_expwd      = tglf_elec_expwd_out
+    ion_pflux       = tglf_ion_pflux_out
+    ion_eflux       = tglf_ion_eflux_out
+    ion_eflux_low   = tglf_ion_eflux_low_out
+    ion_mflux       = tglf_ion_mflux_out
+    ion_expwd       = tglf_ion_expwd_out
+
+  end subroutine c_tglf_get_outputs
+
+end module tglf_c_api

--- a/src/mitim_tools/simulation_tools/interfaces/tglf_inprocess.py
+++ b/src/mitim_tools/simulation_tools/interfaces/tglf_inprocess.py
@@ -1,0 +1,590 @@
+"""
+tglf_inprocess.py
+=================
+In-process TGLF execution via a ctypes-loaded shared library (libtglf_serial.so).
+
+Three entry points are provided:
+
+1. ``runner.prepare(profiles_or_path, rhos, code_settings, ...)`` +
+   ``runner.run_all()`` / ``runner.run_rho(rho)``
+   **Standalone fully in-memory path** — pass an ``input.gacode`` file path or
+   a live ``PROFILES_GACODE`` object; inputs are built via ``to_tglf()`` and
+   cached in memory.  All subsequent run calls are zero file I/O.
+
+2. ``runner.run_from_dict(input_dict)``
+   Sets all Fortran module variables directly from a flat Python dict — zero
+   file I/O.  The dict is exactly what ``PROFILES_GACODE.to_tglf()`` returns
+   for one rho value.
+
+3. ``runner.run(gen_file)``
+   Legacy path — reads an ``input.tglf.gen`` file from disk.
+
+All paths call ``c_tglf_run()`` in-process and return the same output dict.
+
+API
+---
+    from mitim_tools.simulation_tools.interfaces.tglf_inprocess import (
+        TGLFInProcess,
+        generate_input_gen,
+        write_gbflux,
+    )
+
+    # --- standalone in-memory path (preferred) ---
+    runner = TGLFInProcess()
+    runner.prepare("path/to/input.gacode", rhos=[0.4, 0.6], code_settings="SAT1")
+    results = runner.run_all()        # {rho: output_dict}
+    out     = runner.run_rho(0.4)
+
+    # --- dict-based path ---
+    runner  = TGLFInProcess()
+    outputs = runner.run_from_dict(input_dict)  # dict from to_tglf()
+
+    # --- file-based path (requires GACODE_ROOT) ---
+    gen_file = generate_input_gen("/path/to/input.tglf")
+    outputs  = runner.run(gen_file)
+
+    write_gbflux(outputs, "/path/to/out.tglf.gbflux")
+
+Prerequisites
+-------------
+    Build the shared library once per machine::
+
+        cd <MITIM-fusion>/src/mitim_tools/simulation_tools/interfaces
+        bash build_tglf_lib.sh
+
+Thread safety
+-------------
+The Fortran library uses global module variables.  A single loaded instance
+is NOT safe to call from multiple threads simultaneously.
+
+For parallel in-process runs we copy the .so to unique temporary paths so
+each worker thread gets its own ``dlopen`` handle with independent Fortran
+globals.  ``ctypes`` releases the GIL during Fortran calls, so threads give
+true parallelism without any of the macOS multiprocessing pitfalls (no
+spawn/fork/forkserver issues, no ``if __name__ == '__main__':`` requirement).
+"""
+
+from __future__ import annotations
+
+import atexit
+import ctypes
+import os
+import shutil
+import tempfile
+import threading
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# All build artefacts live in tglf_build/ (gitignored) inside this directory.
+# ---------------------------------------------------------------------------
+_INTERFACES_DIR = Path(__file__).parent
+_LIB_PATH = _INTERFACES_DIR / "tglf_build" / "libtglf_serial.so"
+
+# ---------------------------------------------------------------------------
+# Lazy singleton: load libtglf_serial.so once per process (sequential use)
+# ---------------------------------------------------------------------------
+_lib: Any = None
+
+# ---------------------------------------------------------------------------
+# Thread-parallel support: each worker thread gets its own private copy of
+# the .so so Fortran module-level globals are truly independent.
+# ---------------------------------------------------------------------------
+_thread_local = threading.local()
+_temp_lib_paths: list[str] = []
+_temp_lib_lock  = threading.Lock()
+
+
+@atexit.register
+def _cleanup_temp_libs() -> None:
+    """Remove per-thread .so copies created for parallel runs."""
+    for p in _temp_lib_paths:
+        try:
+            os.unlink(p)
+        except OSError:
+            pass
+
+
+def _setup_lib_signatures(lib: ctypes.CDLL) -> ctypes.CDLL:
+    """Attach ctypes argument/return-type annotations to *lib*. Returns *lib*."""
+    lib.c_tglf_set_path.restype  = None
+    lib.c_tglf_set_path.argtypes = [ctypes.c_char_p]
+
+    lib.c_tglf_read_input.restype  = None
+    lib.c_tglf_read_input.argtypes = []
+
+    lib.c_tglf_run.restype  = None
+    lib.c_tglf_run.argtypes = []
+
+    _double11 = ctypes.c_double * 11
+    lib.c_tglf_get_outputs.restype = None
+    lib.c_tglf_get_outputs.argtypes = [
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(ctypes.c_double),
+        ctypes.POINTER(_double11),
+        ctypes.POINTER(_double11),
+        ctypes.POINTER(_double11),
+        ctypes.POINTER(_double11),
+        ctypes.POINTER(_double11),
+    ]
+    return lib
+
+
+def _load_lib() -> ctypes.CDLL:
+    global _lib
+    if _lib is not None:
+        return _lib
+
+    if not _LIB_PATH.exists():
+        raise RuntimeError(
+            f"libtglf_serial.so not found at {_LIB_PATH}\n"
+            "  Build it once with:\n"
+            f"    cd {_INTERFACES_DIR} && bash build_tglf_lib.sh"
+        )
+
+    try:
+        lib = ctypes.CDLL(str(_LIB_PATH))
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to load {_LIB_PATH}: {exc}\n"
+            "Check that the library was compiled for the current platform."
+        ) from exc
+
+    _lib = _setup_lib_signatures(lib)
+    return _lib
+
+
+def _load_unique_lib() -> ctypes.CDLL:
+    """
+    Load a PRIVATE copy of the shared library.
+
+    ``dlopen`` (and ctypes.CDLL) caches handles by realpath, so calling
+    ``CDLL(same_path)`` from multiple threads returns the same instance —
+    and the same Fortran module-level globals.  Copying the file to a unique
+    temp path forces a new ``dlopen`` handle with independent globals, making
+    truly parallel ctypes calls safe.
+
+    The temp file is registered for deletion at process exit.
+    """
+    if not _LIB_PATH.exists():
+        raise RuntimeError(
+            f"libtglf_serial.so not found at {_LIB_PATH}\n"
+            "  Build it once with:\n"
+            f"    cd {_INTERFACES_DIR} && bash build_tglf_lib.sh"
+        )
+    fd, tmp_path = tempfile.mkstemp(suffix="_tglf_thread.so")
+    os.close(fd)
+    shutil.copy(str(_LIB_PATH), tmp_path)
+    with _temp_lib_lock:
+        _temp_lib_paths.append(tmp_path)
+    try:
+        lib = ctypes.CDLL(tmp_path)
+    except OSError as exc:
+        raise RuntimeError(f"Failed to load private lib copy {tmp_path}: {exc}") from exc
+    return _setup_lib_signatures(lib)
+
+
+def _get_thread_lib() -> ctypes.CDLL:
+    """Return the calling thread's private library instance, creating it on first use."""
+    if not hasattr(_thread_local, "lib"):
+        _thread_local.lib = _load_unique_lib()
+    return _thread_local.lib
+
+
+# ---------------------------------------------------------------------------
+# Direct module-variable access — maps dict keys → Fortran tglf_interface vars
+# ---------------------------------------------------------------------------
+
+# gfortran mangles   module::var   →   __module_MOD_var
+# On macOS the linker adds one more leading _ (seen in `nm` as ___module_MOD_var),
+# but ctypes/dlsym uses the name without that extra leading _.
+_MOD = "__tglf_interface_MOD_tglf_{}_in"
+
+# nsm = 12 (from tglf_max_dimensions); species arrays have 12 elements
+_NSM = 12
+
+# Base names of per-species array variables (without the _N index suffix)
+_SPECIES_BASES = frozenset([
+    "zs", "mass", "rlns", "rlts", "taus", "as", "vpar",
+    "vpar_shear", "vns_shear", "vts_shear",
+])
+
+# Fortran LOGICAL variables → stored as 4-byte integer (1 = .true.)
+_LOGICALS = frozenset([
+    "use_transport_model", "dump_flag", "quiet_flag",
+    "iflux", "use_bper", "use_bpar", "use_mhd_rule", "use_bisection",
+    "use_inboard_detrapped", "use_ave_ion_grid", "adiabatic_elec",
+    "find_width", "new_eikonal",
+])
+
+# Fortran INTEGER variables → stored as 4-byte integer
+_INTEGERS = frozenset([
+    "test_flag", "geometry_flag", "write_wavefunction_flag",
+    "ibranch", "nmodes", "nbasis_max", "nbasis_min",
+    "nxgrid", "nky", "sat_rule", "kygrid_model", "xnu_model",
+    "vpar_model", "vpar_shear_model", "ns", "nwidth",
+    "b_model_sa", "ft_model_sa",
+])
+
+
+def _set_inputs_from_dict(lib: ctypes.CDLL, input_dict: dict) -> None:
+    """
+    Write every entry in *input_dict* directly into the tglf_interface Fortran
+    module variables.  This replaces the ``tglf_read_input()`` file-read.
+
+    Key conventions (matching ``PROFILES_GACODE.to_tglf()`` output):
+    - Scalar controls / plasma:  ``"BETAE"``, ``"RMIN_LOC"``, ``"SAT_RULE"`` …
+    - Species arrays:            ``"ZS_1"``, ``"RLTS_2"`` … (1-based index)
+    - Shape harmonics:           ``"SHAPE_COS0"``, ``"SHAPE_S_SIN3"`` …
+      (Fortran names append ``_loc``: ``tglf_shape_cos0_loc_in``)
+    - Units string:              ``"UNITS"``  → ``character(len=8)``
+    """
+    # Always suppress output — these are not part of the physics dict
+    ctypes.c_int32.in_dll(lib, _MOD.format("quiet_flag")).value = 1
+    ctypes.c_int32.in_dll(lib, _MOD.format("dump_flag")).value  = 0
+
+    # Zero all species arrays so stale values from a prior call never persist
+    for base in _SPECIES_BASES:
+        arr = (ctypes.c_double * _NSM).in_dll(lib, _MOD.format(base))
+        ctypes.memset(arr, 0, ctypes.sizeof(arr))
+
+    for key, val in input_dict.items():
+        ku = key.upper()
+
+        # ---- species array: KEY_N (e.g. ZS_1, VPAR_SHEAR_2) ----
+        head, _, tail = ku.rpartition("_")
+        if tail.isdigit() and head.lower() in _SPECIES_BASES:
+            idx = int(tail) - 1          # Fortran 1-based → 0-based
+            arr = (ctypes.c_double * _NSM).in_dll(lib, _MOD.format(head.lower()))
+            arr[idx] = float(val)
+            continue
+
+        # ---- shape harmonics: SHAPE_* → tglf_shape_*_loc_in ----
+        kl = ku.lower()
+        var = (kl + "_loc") if kl.startswith("shape_") else kl
+
+        sym = _MOD.format(var)
+
+        if ku == "UNITS":
+            CharT = ctypes.c_char * 8
+            s = CharT.in_dll(lib, sym)
+            enc = str(val).encode("ascii")[:8].ljust(8)
+            ctypes.memmove(s, enc, 8)
+
+        elif var in _LOGICALS:
+            ctypes.c_int32.in_dll(lib, sym).value = 1 if val else 0
+
+        elif var in _INTEGERS:
+            ctypes.c_int.in_dll(lib, sym).value = int(val)
+
+        else:
+            # real — c_double because the library was built with -fdefault-real-8
+            try:
+                ctypes.c_double.in_dll(lib, sym).value = float(val)
+            except OSError:
+                pass   # unknown key (e.g. a MITIM-only field) — skip silently
+
+
+def _collect_outputs(lib: ctypes.CDLL, double11: type) -> dict:
+    """Read tglf_*_out variables via c_tglf_get_outputs and return a dict."""
+    ns_out         = ctypes.c_int(0)
+    elec_pflux     = ctypes.c_double(0.0)
+    elec_eflux     = ctypes.c_double(0.0)
+    elec_eflux_low = ctypes.c_double(0.0)
+    elec_mflux     = ctypes.c_double(0.0)
+    elec_expwd     = ctypes.c_double(0.0)
+    ion_pflux      = double11(*([0.0] * 11))
+    ion_eflux      = double11(*([0.0] * 11))
+    ion_eflux_low  = double11(*([0.0] * 11))
+    ion_mflux      = double11(*([0.0] * 11))
+    ion_expwd      = double11(*([0.0] * 11))
+
+    lib.c_tglf_get_outputs(
+        ctypes.byref(ns_out),
+        ctypes.byref(elec_pflux),
+        ctypes.byref(elec_eflux),
+        ctypes.byref(elec_eflux_low),
+        ctypes.byref(elec_mflux),
+        ctypes.byref(elec_expwd),
+        ctypes.byref(ion_pflux),
+        ctypes.byref(ion_eflux),
+        ctypes.byref(ion_eflux_low),
+        ctypes.byref(ion_mflux),
+        ctypes.byref(ion_expwd),
+    )
+
+    ns = int(ns_out.value)
+    ni = ns - 1
+    return {
+        "ns":             ns,
+        "elec_pflux":     float(elec_pflux.value),
+        "elec_eflux":     float(elec_eflux.value),
+        "elec_eflux_low": float(elec_eflux_low.value),
+        "elec_mflux":     float(elec_mflux.value),
+        "elec_expwd":     float(elec_expwd.value),
+        "ion_pflux":      list(ion_pflux[:ni]),
+        "ion_eflux":      list(ion_eflux[:ni]),
+        "ion_eflux_low":  list(ion_eflux_low[:ni]),
+        "ion_mflux":      list(ion_mflux[:ni]),
+        "ion_expwd":      list(ion_expwd[:ni]),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Input preprocessing: input.tglf → input.tglf.gen  (file-based path)
+# ---------------------------------------------------------------------------
+
+def generate_input_gen(input_tglf_path: str | Path) -> Path:
+    """
+    Convert an ``input.tglf`` file to ``input.tglf.gen`` using GACODE's
+    ``tglf_parse.py`` logic.  Requires ``GACODE_ROOT`` to be set.
+    """
+    input_tglf_path = Path(input_tglf_path).resolve()
+    if not input_tglf_path.exists():
+        raise FileNotFoundError(f"input.tglf not found: {input_tglf_path}")
+
+    gacode_root = os.environ.get("GACODE_ROOT")
+    if not gacode_root:
+        raise RuntimeError(
+            "GACODE_ROOT environment variable is not set. "
+            "Source your gacode_setup script before using tglf_inprocess."
+        )
+    tglf_bin = Path(gacode_root) / "tglf" / "bin"
+
+    def _load_from_bin(name: str):
+        spec = importlib.util.spec_from_file_location(
+            f"_tglf_gacode_{name}", tglf_bin / f"{name}.py"
+        )
+        if spec is None:
+            raise ImportError(f"Cannot locate {name}.py in {tglf_bin}")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    tglf_defaults_mod = _load_from_bin("tglf_defaults")
+    x = tglf_defaults_mod.set_defaults()
+    x.set_extension(".gen")
+    x.read_input(str(input_tglf_path))
+
+    if x.error:
+        raise RuntimeError(
+            f"TGLF input parsing failed for {input_tglf_path}:\n{x.error_msg}"
+        )
+
+    gen_path = Path(str(input_tglf_path) + ".gen")
+    if not gen_path.exists():
+        raise RuntimeError(f"tglf_parse produced no output — expected {gen_path}")
+    return gen_path
+
+
+# ---------------------------------------------------------------------------
+# Output writer: outputs dict → out.tglf.gbflux
+# ---------------------------------------------------------------------------
+
+def write_gbflux(outputs: dict, filepath: str | Path) -> None:
+    """
+    Write ``out.tglf.gbflux`` from the output dict returned by
+    :meth:`TGLFInProcess.run` or :meth:`TGLFInProcess.run_from_dict`.
+
+    Format: one ASCII line — ``Ge Gi[0]…Gi[ni-1]  Qe Qi…  Me Mi…  Se Si…``
+    """
+    ni = outputs["ns"] - 1
+    values: list[float] = []
+    values.append(outputs["elec_pflux"])
+    values.extend(outputs["ion_pflux"][:ni])
+    values.append(outputs["elec_eflux"])
+    values.extend(outputs["ion_eflux"][:ni])
+    values.append(outputs["elec_mflux"])
+    values.extend(outputs["ion_mflux"][:ni])
+    values.append(outputs["elec_expwd"])
+    values.extend(outputs["ion_expwd"][:ni])
+    Path(filepath).write_text(" ".join(f"{v:11.4e}" for v in values) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Main in-process runner
+# ---------------------------------------------------------------------------
+
+class TGLFInProcess:
+    """
+    Run TGLF in-process via ctypes — no subprocess fork, no physics file I/O.
+
+    Three usage modes:
+
+    **Standalone / fully in-memory** (preferred)::
+
+        runner = TGLFInProcess()
+        runner.prepare("path/to/input.gacode", rhos=[0.4, 0.6], code_settings="SAT1")
+        results = runner.run_all()   # {rho: output_dict} — zero file I/O
+        out     = runner.run_rho(0.4)
+
+    **Dict-based** (when you already have a flat input dict)::
+
+        tglf_inputs = profiles.to_tglf(r=rhos, code_settings="SAT1")
+        out = runner.run_from_dict(tglf_inputs[0.5])
+
+    **File-based** (legacy, requires GACODE_ROOT)::
+
+        gen = generate_input_gen("/work/run1/input.tglf")
+        out = runner.run(gen)
+
+    Sequential calls are safe; for parallel use ``multiprocessing`` so each
+    worker has its own independent copy of the library globals.
+    """
+
+    def __init__(self) -> None:
+        self._lib      = _load_lib()
+        self._double11 = ctypes.c_double * 11
+        self._inputs: dict = {}  # {float(rho): flat_dict} — populated by prepare()
+
+    # ------------------------------------------------------------------
+    # Standalone in-memory path
+    # ------------------------------------------------------------------
+
+    def prepare(
+        self,
+        profiles,
+        rhos: list = [0.5],
+        code_settings = "SAT1",
+        extraOptions: dict = {},
+        multipliers: dict = {},
+    ) -> None:
+        """
+        Build and cache TGLF input dicts in memory from a PROFILES_GACODE object
+        or an ``input.gacode`` file path.
+
+        Calls ``profiles.to_tglf()`` once, applies *multipliers* and
+        *extraOptions*, and stores the flat dicts in ``self._inputs``.
+        After this call, :meth:`run_all` and :meth:`run_rho` are zero file I/O.
+
+        Parameters
+        ----------
+        profiles:
+            Path to an ``input.gacode`` file (str or Path), **or** a live
+            ``PROFILES_GACODE`` / ``gacode_state`` object already in memory.
+        rhos:
+            Radial locations (rho_tor) to prepare.
+        code_settings:
+            TGLF control-parameter preset passed to ``to_tglf()``
+            (e.g. ``"SAT0"``, ``"SAT1"``, ``"SAT2"``).
+        extraOptions:
+            Additional key/value overrides applied on top.  Keys are
+            case-insensitive TGLF parameter names.
+        multipliers:
+            ``{parameter: factor}`` — each named parameter is scaled by the
+            given factor after ``to_tglf()`` populates it.
+        """
+        if isinstance(profiles, (str, Path)):
+            from mitim_tools.gacode_tools.PROFILEStools import gacode_state
+            profiles = gacode_state(str(profiles))
+
+        raw = profiles.to_tglf(r=list(rhos), code_settings=code_settings)
+
+        self._inputs = {}
+        for rho, d in raw.items():
+            flat = dict(d)
+            for key, factor in multipliers.items():
+                ku = key.upper()
+                if ku in flat:
+                    flat[ku] = flat[ku] * factor
+            flat.update({k.upper(): v for k, v in extraOptions.items()})
+            self._inputs[float(rho)] = flat
+
+    def run_all(self) -> dict:
+        """
+        Run TGLF for every rho prepared by :meth:`prepare`.
+
+        Returns ``{rho: output_dict}`` — same structure as :meth:`run_from_dict`.
+        """
+        if not self._inputs:
+            raise RuntimeError("No inputs prepared — call prepare() first.")
+        return {rho: self.run_from_dict(d) for rho, d in self._inputs.items()}
+
+    def run_rho(self, rho: float) -> dict:
+        """Run TGLF for a single rho prepared by :meth:`prepare`."""
+        if rho not in self._inputs:
+            raise KeyError(
+                f"rho={rho} not in prepared inputs. "
+                f"Available: {sorted(self._inputs)}"
+            )
+        return self.run_from_dict(self._inputs[rho])
+
+    # ------------------------------------------------------------------
+    # File-based path
+    # ------------------------------------------------------------------
+
+    def run(self, gen_file_path: str | Path) -> dict:
+        """
+        Execute TGLF reading inputs from ``input.tglf.gen`` on disk.
+
+        Parameters
+        ----------
+        gen_file_path:
+            Path to ``input.tglf.gen`` produced by :func:`generate_input_gen`.
+        """
+        gen_file_path = Path(gen_file_path).resolve()
+        if not gen_file_path.exists():
+            raise FileNotFoundError(f"input.tglf.gen not found: {gen_file_path}")
+
+        path_str = str(gen_file_path.parent) + "/"
+        self._lib.c_tglf_set_path(path_str.encode("ascii"))
+        self._lib.c_tglf_read_input()
+        self._lib.c_tglf_run()
+        return _collect_outputs(self._lib, self._double11)
+
+    # ------------------------------------------------------------------
+    # In-memory path
+    # ------------------------------------------------------------------
+
+    def run_from_dict(self, input_dict: dict) -> dict:
+        """
+        Execute TGLF setting all inputs directly from *input_dict* — no file I/O.
+
+        *input_dict* is the value for one rho from ``PROFILES_GACODE.to_tglf()``,
+        optionally with ``extra_options`` applied on top::
+
+            tglf_inputs = profiles.to_tglf(r=[0.5], code_settings="SAT1")
+            d = tglf_inputs[0.5]
+            d.update({"XNU_FACTOR": 1.5})   # optional override
+            out = runner.run_from_dict(d)
+
+        Parameters
+        ----------
+        input_dict:
+            Flat dict whose keys follow the TGLF parameter naming convention
+            (e.g. ``"BETAE"``, ``"RMIN_LOC"``, ``"ZS_1"``, ``"SAT_RULE"``).
+            Species arrays use 1-based index suffixes (``"ZS_1"``, ``"ZS_2"``…).
+            Shape harmonics omit ``_LOC`` (``"SHAPE_COS0"`` maps to
+            ``tglf_shape_cos0_loc_in``).
+        """
+        _set_inputs_from_dict(self._lib, input_dict)
+        self._lib.c_tglf_run()
+        return _collect_outputs(self._lib, self._double11)
+
+
+# ------------------------------------------------------------------
+# Module-level worker — must be at module scope to be picklable
+# for ProcessPoolExecutor / multiprocessing.
+# ------------------------------------------------------------------
+
+def _parallel_worker(flat: dict) -> dict:
+    """
+    Run one TGLF case on the calling thread's private library instance.
+
+    Each worker thread in the pool loads its own independent copy of the
+    shared library (via ``_get_thread_lib()``), giving isolated Fortran
+    module-level globals.  Because ``ctypes`` releases the GIL during the
+    Fortran call, multiple threads execute the physics truly in parallel.
+    """
+    lib = _get_thread_lib()
+    double11 = ctypes.c_double * 11
+    _set_inputs_from_dict(lib, flat)
+    lib.c_tglf_run()
+    return _collect_outputs(lib, double11)

--- a/src/mitim_tools/simulation_tools/interfaces/tglf_inprocess.py
+++ b/src/mitim_tools/simulation_tools/interfaces/tglf_inprocess.py
@@ -66,9 +66,35 @@ spawn/fork/forkserver issues, no ``if __name__ == '__main__':`` requirement).
 
 from __future__ import annotations
 
+import os
+
+# ---------------------------------------------------------------------------
+# Pin BLAS / OpenMP to one thread per *worker* BEFORE any ctypes import.
+#
+# libtglf_serial.so links against the conda-forge libblas / liblapack
+# wrappers, which on many clusters resolve to MKL (or openblas).  When the
+# in-process driver fans out N TGLF cases across N Python ThreadPoolExecutor
+# workers (see GACODEinprocess._run_inprocess), MKL/openblas inside each
+# worker has no idea the other workers exist — every thread tries to spin
+# up a full thread pool sized to the whole node.  With e.g. 18 workers on a
+# 64-core node that becomes 18 * 64 ≈ 1152 OS threads competing for 64
+# cores, catastrophic oversubscription and order-of-magnitude slowdowns.
+#
+# TGLF is *not* BLAS-bound on the relevant code paths (measured: a single
+# call takes the same wall time at MKL_NUM_THREADS=1 and =8), so pinning to
+# 1 BLAS thread per worker costs nothing and avoids the meltdown.
+#
+# These vars must be set BEFORE the shared library is dlopen'd, because
+# MKL/openblas read them once at library init time.  setdefault() leaves
+# any value the user has explicitly exported alone.
+# ---------------------------------------------------------------------------
+os.environ.setdefault("MKL_NUM_THREADS",      "1")
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
+os.environ.setdefault("OMP_NUM_THREADS",      "1")
+os.environ.setdefault("MKL_DYNAMIC",          "FALSE")
+
 import atexit
 import ctypes
-import os
 import shutil
 import tempfile
 import threading

--- a/src/mitim_tools/simulation_tools/interfaces/tglf_inprocess.py
+++ b/src/mitim_tools/simulation_tools/interfaces/tglf_inprocess.py
@@ -66,35 +66,9 @@ spawn/fork/forkserver issues, no ``if __name__ == '__main__':`` requirement).
 
 from __future__ import annotations
 
-import os
-
-# ---------------------------------------------------------------------------
-# Pin BLAS / OpenMP to one thread per *worker* BEFORE any ctypes import.
-#
-# libtglf_serial.so links against the conda-forge libblas / liblapack
-# wrappers, which on many clusters resolve to MKL (or openblas).  When the
-# in-process driver fans out N TGLF cases across N Python ThreadPoolExecutor
-# workers (see GACODEinprocess._run_inprocess), MKL/openblas inside each
-# worker has no idea the other workers exist — every thread tries to spin
-# up a full thread pool sized to the whole node.  With e.g. 18 workers on a
-# 64-core node that becomes 18 * 64 ≈ 1152 OS threads competing for 64
-# cores, catastrophic oversubscription and order-of-magnitude slowdowns.
-#
-# TGLF is *not* BLAS-bound on the relevant code paths (measured: a single
-# call takes the same wall time at MKL_NUM_THREADS=1 and =8), so pinning to
-# 1 BLAS thread per worker costs nothing and avoids the meltdown.
-#
-# These vars must be set BEFORE the shared library is dlopen'd, because
-# MKL/openblas read them once at library init time.  setdefault() leaves
-# any value the user has explicitly exported alone.
-# ---------------------------------------------------------------------------
-os.environ.setdefault("MKL_NUM_THREADS",      "1")
-os.environ.setdefault("OPENBLAS_NUM_THREADS", "1")
-os.environ.setdefault("OMP_NUM_THREADS",      "1")
-os.environ.setdefault("MKL_DYNAMIC",          "FALSE")
-
 import atexit
 import ctypes
+import os
 import shutil
 import tempfile
 import threading
@@ -132,6 +106,97 @@ def _cleanup_temp_libs() -> None:
             os.unlink(p)
         except OSError:
             pass
+
+
+# ---------------------------------------------------------------------------
+# OpenBLAS thread pinning
+#
+# WHY:
+# Empirically (measured on a 16-core M-series Mac with conda-forge openblas),
+# TGLF in-process is FASTEST when openblas is pinned to 1 thread:
+#   1 thread :  ~700 ms / call
+#   8 threads: ~1280 ms / call
+# The TGLF eigensolve sub-blocks are too small to amortise openblas's
+# per-call thread sync cost — multi-threaded openblas is pure overhead here.
+# This is exactly why the gacode `tglf` shell wrapper exports
+# OMP_NUM_THREADS=1 before invoking the binary; we mirror that behaviour for
+# the in-process path via the openblas runtime API instead of an env var,
+# so the user's other Python libraries (numpy etc.) are not affected.
+#
+# We do NOT do the same for NEO — its dense linear solves are larger and
+# may legitimately benefit from multi-threaded BLAS.  See neo_inprocess.py
+# if a future measurement says otherwise.
+# ---------------------------------------------------------------------------
+# Cached setter callables — populated by _discover_thread_setters() on first
+# use, then re-applied via _pin_threads() before every c_tglf_run call.
+_THREAD_SETTERS: list[tuple[str, "callable"]] = []
+_THREAD_SETTERS_INIT = False
+
+
+def _discover_thread_setters() -> list[tuple[str, "callable"]]:
+    """
+    Discover every "set num threads" entry point reachable in this process.
+
+    On macOS conda-forge, libopenblas is built with USE_OPENMP=1, which
+    means its actual worker pool is controlled by libomp (LLVM OpenMP),
+    not by openblas's internal thread state.  Calling
+    ``openblas_set_num_threads()`` works *until* the first OpenMP parallel
+    region runs, which silently resets the worker count to libomp's
+    OMP_NUM_THREADS (16 → 12 here).  So we have to pin BOTH openblas AND
+    libomp on every call to be sure.
+
+    We cache the discovered setters so we only dlopen once per process.
+    Best-effort: missing libraries are ignored silently.
+    """
+    global _THREAD_SETTERS_INIT
+    if _THREAD_SETTERS_INIT:
+        return _THREAD_SETTERS
+
+    candidates = [
+        # (display name, libnames to try, symbol to look up)
+        ("openblas", ["libopenblas.0.dylib", "libopenblas.dylib",
+                      "libopenblas.so.0", "libopenblas.so"],
+                     "openblas_set_num_threads"),
+        ("omp",      ["libomp.dylib",
+                      "libomp.so", "libgomp.so.1", "libgomp.so"],
+                     "omp_set_num_threads"),
+    ]
+    for name, libnames, sym in candidates:
+        for ln in libnames:
+            try:
+                lib = ctypes.CDLL(ln)
+            except OSError:
+                continue
+            fn = getattr(lib, sym, None)
+            if fn is None:
+                continue
+            fn.argtypes = [ctypes.c_int]
+            fn.restype  = None
+
+            def _setter(n: int, _fn=fn):
+                _fn(ctypes.c_int(int(n)))
+
+            _THREAD_SETTERS.append((name, _setter))
+            break  # found this candidate; move to next family
+
+    _THREAD_SETTERS_INIT = True
+    return _THREAD_SETTERS
+
+
+def _pin_threads(n: int = 1) -> list[str]:
+    """
+    Cap openblas + libomp at *n* threads.  Returns the names actually pinned
+    (for logging).  Cheap: ~10 µs once setters are cached, so safe to call
+    immediately before every c_tglf_run.
+    """
+    pinned = []
+    for name, setter in _discover_thread_setters():
+        try:
+            setter(int(n))
+            pinned.append(name)
+        except Exception:  # noqa: BLE001 — best-effort, never fail
+            pass
+    return pinned
 
 
 def _setup_lib_signatures(lib: ctypes.CDLL) -> ctypes.CDLL:
@@ -183,6 +248,14 @@ def _load_lib() -> ctypes.CDLL:
             "Check that the library was compiled for the current platform."
         ) from exc
 
+    # Pin openblas + libomp to 1 thread for the TGLF code path. We re-pin
+    # before every c_tglf_run via _set_inputs_from_dict, since the call
+    # itself can reset the count. See _discover_thread_setters() for why.
+    pinned = _pin_threads(1)
+    if pinned:
+        print(f"[tglf_inprocess] pinned {', '.join(pinned)} to 1 thread "
+              f"(TGLF eigensolve is faster single-threaded)")
+
     _lib = _setup_lib_signatures(lib)
     return _lib
 
@@ -214,6 +287,8 @@ def _load_unique_lib() -> ctypes.CDLL:
         lib = ctypes.CDLL(tmp_path)
     except OSError as exc:
         raise RuntimeError(f"Failed to load private lib copy {tmp_path}: {exc}") from exc
+    # Pin openblas + libomp to 1 thread (idempotent across thread libs).
+    _pin_threads(1)
     return _setup_lib_signatures(lib)
 
 
@@ -562,6 +637,7 @@ class TGLFInProcess:
         path_str = str(gen_file_path.parent) + "/"
         self._lib.c_tglf_set_path(path_str.encode("ascii"))
         self._lib.c_tglf_read_input()
+        _pin_threads(1)            # see _discover_thread_setters() — must be re-applied per call
         self._lib.c_tglf_run()
         return _collect_outputs(self._lib, self._double11)
 
@@ -591,6 +667,7 @@ class TGLFInProcess:
             ``tglf_shape_cos0_loc_in``).
         """
         _set_inputs_from_dict(self._lib, input_dict)
+        _pin_threads(1)            # see _discover_thread_setters() — must be re-applied per call
         self._lib.c_tglf_run()
         return _collect_outputs(self._lib, self._double11)
 
@@ -612,5 +689,6 @@ def _parallel_worker(flat: dict) -> dict:
     lib = _get_thread_lib()
     double11 = ctypes.c_double * 11
     _set_inputs_from_dict(lib, flat)
+    _pin_threads(1)            # see _discover_thread_setters() — must be re-applied per call
     lib.c_tglf_run()
     return _collect_outputs(lib, double11)

--- a/src/mitim_tools/simulation_tools/interfaces/vgen_c_api.f90
+++ b/src/mitim_tools/simulation_tools/interfaces/vgen_c_api.f90
@@ -1,0 +1,309 @@
+!---------------------------------------------------------------------------
+! vgen_c_api.f90
+!
+! PURPOSE:
+!   Thin Fortran C-binding wrapper that runs the gacode "vgen" velocity-
+!   generation workflow in-process.  Built into libvgen_serial.so and
+!   loaded from Python via ctypes (vgen_inprocess.py).
+!
+!   The standard `profiles_gen -vgen` driver is the `vgen` Fortran program
+!   in gacode/vgen/src/vgen.f90, which:
+!     1. Calls neo_init_serial → neo_read_input → expro_read('input.gacode')
+!     2. Distributes radial surfaces across MPI ranks
+!     3. Calls vgen_compute_neo on each surface (which sets neo_*_in,
+!        runs neo_run, reads neo_*_out)
+!     4. Computes Er, w0, w0p from the per-surface results
+!     5. Writes a new input.gacode via expro_write
+!
+!   This wrapper does (1)–(5) **without** any MPI: it loops over surfaces
+!   sequentially in a single thread, calls expro_read with comm=0 to disable
+!   MPI inside expro, and skips vgen_reduce entirely (no need with one rank).
+!
+!   For the PORTALS use case (er_method = 2 = NEO weak rotation limit, with
+!   zero toroidal rotation) the only output that matters is EXPRO_w0,
+!   which is written into vgen/input.gacode by expro_write.
+!---------------------------------------------------------------------------
+
+module vgen_c_api
+
+  use iso_c_binding
+  use neo_interface
+  use neo_globals,   only: path, silent_flag, i_proc, n_proc, NEO_COMM_WORLD
+  use vgen_globals,  only: vgen_path => path, &
+                           vgen_i_proc => i_proc, vgen_n_proc => n_proc, &
+                           er_method, vel_method, erspecies_indx, epar_flag, &
+                           nth_min, nth_max, nn_flag, &
+                           dens_norm, temp_norm, mass_norm, vth_norm, jbs_norm, e_norm, &
+                           vtor_measured, &
+                           pflux_sum, &
+                           jbs_neo, jsigma_neo, jtor_neo, &
+                           jbs_sauter, jsigma_sauter, jtor_sauter, &
+                           jbs_sauter_mod, jsigma_sauter_mod, jtor_sauter_mod, &
+                           n_ions, tag, fmt, &
+                           temp_norm_fac, charge_norm_fac
+  use expro
+
+  implicit none
+
+contains
+
+  ! -------------------------------------------------------------------------
+  ! c_vgen_set_path
+  !   Set the working directory for vgen.  expro_read / expro_write open
+  !   files relative to the current working directory, so the Python wrapper
+  !   chdir's into `path` before calling c_vgen_run.  This routine just
+  !   stores the path string into both neo_globals::path and
+  !   vgen_globals::path for any code that consults them.
+  ! -------------------------------------------------------------------------
+  subroutine c_vgen_set_path(path_cstr) bind(C, name="c_vgen_set_path")
+    character(kind=c_char), dimension(*), intent(in) :: path_cstr
+    integer :: i
+
+    path      = ' '
+    vgen_path = ' '
+    do i = 1, len(path)
+      if (path_cstr(i) == c_null_char) exit
+      path(i:i)      = path_cstr(i)
+      vgen_path(i:i) = path_cstr(i)
+    end do
+
+  end subroutine c_vgen_set_path
+
+  ! -------------------------------------------------------------------------
+  ! c_vgen_run
+  !   Run the full vgen workflow on input.gacode in the current directory.
+  !
+  !   Arguments:
+  !     er_method_in     : 1 = force balance (needs vpol/vtor), 2 = NEO weak
+  !                        rotation limit (recommended for zero Vtor),
+  !                        4 = use given omega0
+  !     vel_method_in    : 1 = NEO weak rotation, 2 = NEO strong rotation
+  !     erspecies_indx_in: Index (1-based) of the ion species to match
+  !     nth_min_in,
+  !     nth_max_in       : Min / max poloidal theta resolution
+  !     n_species_in     : Number of NEO species (set in neo_n_species_in)
+  !
+  !   On return, the new input.gacode (with populated EXPRO_w0) has been
+  !   written to <cwd>/vgen/input.gacode.  The Python wrapper is responsible
+  !   for ensuring the cwd already contains an input.gacode file and an
+  !   empty vgen/ subdirectory.
+  ! -------------------------------------------------------------------------
+  subroutine c_vgen_run(er_method_in, vel_method_in, erspecies_indx_in, &
+                        nth_min_in, nth_max_in, n_species_in)            &
+                        bind(C, name="c_vgen_run")
+
+    integer(c_int), intent(in), value :: er_method_in
+    integer(c_int), intent(in), value :: vel_method_in
+    integer(c_int), intent(in), value :: erspecies_indx_in
+    integer(c_int), intent(in), value :: nth_min_in
+    integer(c_int), intent(in), value :: nth_max_in
+    integer(c_int), intent(in), value :: n_species_in
+
+    integer :: i, j, ix, rotation_model, simntheta, iteration_flag
+    real    :: vtor_diff, er0, omega, omega_deriv, ya, yb, grad_p
+    real, dimension(:), allocatable :: er_exp
+
+    ! ---- Stash vgen control inputs into vgen_globals ----
+    er_method      = er_method_in
+    vel_method     = vel_method_in
+    erspecies_indx = erspecies_indx_in
+    nth_min        = nth_min_in
+    nth_max        = nth_max_in
+    epar_flag      = 0       ! conductivity calculation off
+    nn_flag        = 0       ! NEO neural-net path off
+
+    ! ---- Serial init: pretend we're rank 0 of a 1-rank communicator ----
+    i_proc          = 0
+    n_proc          = 1
+    NEO_COMM_WORLD  = -1
+    vgen_i_proc     = 0
+    vgen_n_proc     = 1
+
+    ! Initialise the per-rank file-tag array (vgen_compute_neo writes
+    ! out.vgen.neontheta00 etc.; the main vgen.f90 fills `tag` in its main
+    ! loop, but we are bypassing that, so do it here.)
+    do ix = 1, 100
+       write(tag(ix), fmt) ix - 1
+    end do
+
+    ! ---- Mirror neo_init_serial: set neo_globals state for serial use ----
+    silent_flag = 1
+
+    ! ---- Set NEO interface variables directly to the same values that
+    !      gacode/vgen/templates/input.neo.default specifies, plus the
+    !      ones profiles_gen -vgen appends afterwards (SUBROUTINE_FLAG=1,
+    !      EQUILIBRIUM_MODEL=2, N_SPECIES=...).  We bypass neo_read_input
+    !      entirely so the wrapper has zero file dependencies on input.neo*.
+    neo_n_energy_in         = 6
+    neo_n_xi_in             = 17
+    neo_n_theta_in          = 17
+    neo_sim_model_in        = 2
+    neo_ae_flag_in          = 0
+    neo_equilibrium_model_in = 2
+    neo_subroutine_flag     = 1
+    neo_n_species_in        = n_species_in
+    neo_n_radial_in         = 1
+    neo_profile_model_in    = 1
+    neo_silent_flag_in      = 1
+
+    EXPRO_ctrl_quasineutral_flag = 1
+    EXPRO_ctrl_n_ion             = neo_n_species_in + neo_ae_flag_in - 1
+    n_ions                       = EXPRO_ctrl_n_ion
+
+    ! comm=0 → expro_read sets hasmpi=.false. and skips all MPI broadcasts
+    call expro_read('input.gacode', 0)
+
+    if (EXPRO_error == 1) then
+       print '(a)', 'ERROR: (VGEN) Negative ion density'
+       return
+    endif
+
+    ! Set ion masses and charges from EXPRO
+    do j = 1, EXPRO_ctrl_n_ion
+       neo_z_in(j)    = expro_z(j)
+       neo_mass_in(j) = expro_mass(j) / 2.0
+    end do
+    if (neo_ae_flag_in == 0) then
+       neo_z_in(neo_n_species_in)    = expro_ze
+       neo_mass_in(neo_n_species_in) = expro_masse / 2.0
+    endif
+
+    ! Set sign of btccw and ipccw from sign of B and q from EXPRO
+    neo_btccw_in = -EXPRO_signb
+    neo_ipccw_in = -EXPRO_signb * EXPRO_signq
+
+    ! Working storage that vgen_init normally allocates
+    allocate(vtor_measured  (EXPRO_n_exp))
+    allocate(pflux_sum      (EXPRO_n_exp))
+    allocate(jbs_neo        (EXPRO_n_exp))
+    allocate(jsigma_neo     (EXPRO_n_exp))
+    allocate(jtor_neo       (EXPRO_n_exp))
+    allocate(jbs_sauter     (EXPRO_n_exp))
+    allocate(jsigma_sauter  (EXPRO_n_exp))
+    allocate(jtor_sauter    (EXPRO_n_exp))
+    allocate(jbs_sauter_mod (EXPRO_n_exp))
+    allocate(jsigma_sauter_mod(EXPRO_n_exp))
+    allocate(jtor_sauter_mod  (EXPRO_n_exp))
+
+    pflux_sum         = 0.0
+    jbs_neo           = 0.0
+    jsigma_neo        = 0.0
+    jtor_neo          = 0.0
+    jbs_sauter        = 0.0
+    jsigma_sauter     = 0.0
+    jtor_sauter       = 0.0
+    jbs_sauter_mod    = 0.0
+    jsigma_sauter_mod = 0.0
+    jtor_sauter_mod   = 0.0
+
+    do j = 1, EXPRO_n_ion
+       if (j == erspecies_indx) then
+          vtor_measured(:) = EXPRO_vtor(j, :)
+       endif
+       EXPRO_vpol(j, :) = 0.0
+       EXPRO_vtor(j, :) = 0.0
+    end do
+
+    ! ---- Allocate Er working array ----
+    allocate(er_exp(EXPRO_n_exp))
+    if (er_method /= 4) then
+       er_exp(:)    = 0.0
+       EXPRO_w0(:)  = 0.0
+       EXPRO_w0p(:) = 0.0
+    endif
+
+    ! ====================================================================
+    ! Sequential per-surface loop (replaces the MPI-distributed loop in
+    ! vgen.f90).  Only er_method == 2 is supported here — that is what
+    ! PORTALS uses for the neoclassical ExB shear (zero toroidal rotation,
+    ! NEO weak rotation limit).  Other er_methods would require additional
+    ! logic; add it here if needed.
+    ! ====================================================================
+    if (er_method /= 2) then
+       print '(a,i0)', 'ERROR: (VGEN c_api) only er_method=2 is supported, got ', er_method
+       deallocate(er_exp)
+       return
+    endif
+
+    do i = 2, EXPRO_n_exp - 1
+       rotation_model = 1            ! weak rotation
+       er0            = 0.0
+       omega          = 0.0
+       omega_deriv    = 0.0
+       iteration_flag = 1
+
+       call vgen_compute_neo(i, vtor_diff, rotation_model, er0, &
+                             omega, omega_deriv, simntheta, iteration_flag)
+
+       ! Same Er-from-vtor_diff formula as vgen.f90 case(2)
+       er_exp(i) = (vtor_diff / (vth_norm * EXPRO_rmin(EXPRO_n_exp)))     &
+            / (neo_rmaj_over_a_in + neo_rmin_over_a_in)                   &
+            * neo_rmin_over_a_in / (abs(neo_q_in) * EXPRO_signq)          &
+            / (abs(neo_rho_star_in) * EXPRO_signb)                        &
+            * EXPRO_grad_r0(i)                                            &
+            * (temp_norm * temp_norm_fac / charge_norm_fac                &
+               / EXPRO_rmin(EXPRO_n_exp)) / 1000
+
+       ! Add the Er-driven contribution to vtor for every ion
+       do j = 1, n_ions
+          EXPRO_vtor(j, i) = EXPRO_vtor(j, i) + vtor_diff
+       end do
+    end do
+
+    ! ====================================================================
+    ! Compute EXPRO_w0 / EXPRO_w0p and extrapolate to the boundary points.
+    ! Mirrors the post-loop block of vgen.f90.
+    ! ====================================================================
+    do i = 2, EXPRO_n_exp - 1
+       EXPRO_w0(i) = 2.9979e10 * EXPRO_q(i) * (er_exp(i) / 30.0) /         &
+            ((1e4 * EXPRO_bunit(i)) * (1e2 * EXPRO_rmin(i)) * EXPRO_grad_r0(i))
+    end do
+
+    call bound_extrap(ya, yb, er_exp,    EXPRO_rmin, EXPRO_n_exp)
+    er_exp(1)           = ya
+    er_exp(EXPRO_n_exp) = yb
+
+    call bound_extrap(ya, yb, EXPRO_w0,  EXPRO_rmin, EXPRO_n_exp)
+    EXPRO_w0(1)           = ya
+    EXPRO_w0(EXPRO_n_exp) = yb
+
+    call bound_deriv(EXPRO_w0p(2:EXPRO_n_exp-1), EXPRO_w0(2:EXPRO_n_exp-1), &
+                     EXPRO_rmin, EXPRO_n_exp - 2)
+    call bound_extrap(ya, yb, EXPRO_w0p, EXPRO_rmin, EXPRO_n_exp)
+    EXPRO_w0p(1)           = ya
+    EXPRO_w0p(EXPRO_n_exp) = yb
+
+    do j = 1, n_ions
+       call bound_extrap(ya, yb, EXPRO_vpol(j, :), EXPRO_rmin, EXPRO_n_exp)
+       EXPRO_vpol(j, 1)           = ya
+       EXPRO_vpol(j, EXPRO_n_exp) = yb
+       call bound_extrap(ya, yb, EXPRO_vtor(j, :), EXPRO_rmin, EXPRO_n_exp)
+       EXPRO_vtor(j, 1)           = ya
+       EXPRO_vtor(j, EXPRO_n_exp) = yb
+    end do
+
+    ! ====================================================================
+    ! Write the new input.gacode (vgen/input.gacode), the same way the
+    ! standard vgen driver does.  expro_write opens this path relative to
+    ! the cwd that c_vgen_set_path established.
+    ! ====================================================================
+    expro_head_vgen = '#      vgen : in-process (er=2, weak rotation)'
+    call expro_write('vgen/input.gacode')
+
+    ! ---- Cleanup ----
+    deallocate(er_exp)
+    deallocate(vtor_measured)
+    deallocate(pflux_sum)
+    deallocate(jbs_neo)
+    deallocate(jsigma_neo)
+    deallocate(jtor_neo)
+    deallocate(jbs_sauter)
+    deallocate(jsigma_sauter)
+    deallocate(jtor_sauter)
+    deallocate(jbs_sauter_mod)
+    deallocate(jsigma_sauter_mod)
+    deallocate(jtor_sauter_mod)
+
+  end subroutine c_vgen_run
+
+end module vgen_c_api

--- a/src/mitim_tools/simulation_tools/interfaces/vgen_inprocess.py
+++ b/src/mitim_tools/simulation_tools/interfaces/vgen_inprocess.py
@@ -1,0 +1,190 @@
+"""
+vgen_inprocess.py
+=================
+In-process VGEN execution via a ctypes-loaded shared library
+(``libvgen_serial.so``).
+
+The standard PORTALS path runs ``profiles_gen -vgen`` as a subprocess via
+``mitim_job`` (SLURM submission, tarballing, etc.).  The in-process path
+loads the same Fortran physics directly into the Python process and
+runs every radial surface sequentially in a single thread — no SLURM,
+no tarball/transfer overhead, no shell scripts.
+
+VGEN still needs an ``input.gacode`` file on disk because gacode's
+``expro_read`` reads from a file path; the wrapper does NOT change that.
+What it eliminates is the job-manager wrapping around the call.
+
+API
+---
+::
+
+    from mitim_tools.simulation_tools.interfaces.vgen_inprocess import VGENInProcess
+
+    runner = VGENInProcess()
+    runner.run(
+        folder         = "/path/to/work_dir",   # must contain input.gacode
+        er_method      = 2,
+        vel_method     = 1,
+        erspecies_indx = 1,
+        nth_min        = 17,
+        nth_max        = 39,
+        n_species      = 5,
+    )
+    # ⇒ folder/vgen/input.gacode now exists with NEO-computed w0 populated
+
+Prerequisites
+-------------
+Build the shared library once per machine::
+
+    cd <MITIM-fusion>/src/mitim_tools/simulation_tools/interfaces
+    bash build_vgen_lib.sh
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# All build artefacts live in vgen_build/ (gitignored) inside this directory.
+# ---------------------------------------------------------------------------
+_INTERFACES_DIR = Path(__file__).parent
+_LIB_PATH = _INTERFACES_DIR / "vgen_build" / "libvgen_serial.so"
+
+# ---------------------------------------------------------------------------
+# Lazy singleton: load libvgen_serial.so once per process.
+# VGEN runs sequentially over surfaces and PORTALS calls it once per
+# iteration, so a single shared instance is enough — no thread-private
+# copies like the TGLF / NEO wrappers need.
+# ---------------------------------------------------------------------------
+_lib: Any = None
+
+
+def _setup_lib_signatures(lib: ctypes.CDLL) -> ctypes.CDLL:
+    lib.c_vgen_set_path.restype  = None
+    lib.c_vgen_set_path.argtypes = [ctypes.c_char_p]
+
+    lib.c_vgen_run.restype  = None
+    lib.c_vgen_run.argtypes = [
+        ctypes.c_int,   # er_method
+        ctypes.c_int,   # vel_method
+        ctypes.c_int,   # erspecies_indx
+        ctypes.c_int,   # nth_min
+        ctypes.c_int,   # nth_max
+        ctypes.c_int,   # n_species
+    ]
+    return lib
+
+
+def _load_lib() -> ctypes.CDLL:
+    global _lib
+    if _lib is not None:
+        return _lib
+
+    if not _LIB_PATH.exists():
+        raise RuntimeError(
+            f"libvgen_serial.so not found at {_LIB_PATH}\n"
+            "  Build it once with:\n"
+            f"    cd {_INTERFACES_DIR} && bash build_vgen_lib.sh"
+        )
+
+    try:
+        lib = ctypes.CDLL(str(_LIB_PATH))
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to load {_LIB_PATH}: {exc}\n"
+            "Check that the library was compiled for the current platform."
+        ) from exc
+
+    _lib = _setup_lib_signatures(lib)
+    return _lib
+
+
+# ---------------------------------------------------------------------------
+# Main runner
+# ---------------------------------------------------------------------------
+
+class VGENInProcess:
+    """
+    Run gacode's ``vgen`` (velocity generation) workflow in-process.
+
+    Usage::
+
+        runner = VGENInProcess()
+        runner.run(folder, er_method=2, vel_method=1, erspecies_indx=1,
+                   nth_min=17, nth_max=39, n_species=5)
+        # → <folder>/vgen/input.gacode now exists with NEO-computed w0
+    """
+
+    def __init__(self) -> None:
+        self._lib = _load_lib()
+
+    def run(
+        self,
+        folder,
+        er_method: int      = 2,
+        vel_method: int     = 1,
+        erspecies_indx: int = 1,
+        nth_min: int        = 17,
+        nth_max: int        = 39,
+        n_species: int      = 5,
+    ) -> Path:
+        """
+        Run vgen on ``<folder>/input.gacode`` and write
+        ``<folder>/vgen/input.gacode`` with the populated w0(rad/s).
+
+        Parameters
+        ----------
+        folder:
+            Working directory.  Must already contain ``input.gacode``.
+        er_method:
+            How vgen computes Er.  Currently only ``2`` (NEO weak rotation
+            limit) is wired through; this is the option PORTALS uses.
+        vel_method:
+            Velocity method (1 = NEO weak rotation, 2 = NEO strong rotation).
+        erspecies_indx:
+            1-based index of the ion species to match for Er computation.
+        nth_min, nth_max:
+            Min / max poloidal theta resolution.
+        n_species:
+            Number of NEO species (sets ``neo_n_species_in``).
+
+        Returns
+        -------
+        Path to the generated ``vgen/input.gacode`` file.
+        """
+        folder = Path(folder).resolve()
+        if not (folder / "input.gacode").exists():
+            raise FileNotFoundError(f"input.gacode not found in {folder}")
+
+        # vgen always writes its output into a `vgen/` subdirectory of the
+        # cwd.  Ensure it exists before calling the Fortran routine.
+        (folder / "vgen").mkdir(parents=True, exist_ok=True)
+
+        # The Fortran wrapper opens files relative to cwd (and stores the
+        # path in neo/vgen globals for any code that consults it).  chdir
+        # so expro_read('input.gacode') and expro_write('vgen/input.gacode')
+        # land in the right place.
+        prev_cwd = os.getcwd()
+        try:
+            os.chdir(str(folder))
+            self._lib.c_vgen_set_path(b"./")
+            self._lib.c_vgen_run(
+                ctypes.c_int(int(er_method)),
+                ctypes.c_int(int(vel_method)),
+                ctypes.c_int(int(erspecies_indx)),
+                ctypes.c_int(int(nth_min)),
+                ctypes.c_int(int(nth_max)),
+                ctypes.c_int(int(n_species)),
+            )
+        finally:
+            os.chdir(prev_cwd)
+
+        out = folder / "vgen" / "input.gacode"
+        if not out.exists():
+            raise RuntimeError(
+                f"vgen completed but {out} was not produced — check NEO error output."
+            )
+        return out

--- a/templates/namelist.optimization.yaml
+++ b/templates/namelist.optimization.yaml
@@ -1,97 +1,124 @@
+# -----------------------------------------------------------------
+# Problem definition
+# -----------------------------------------------------------------
+
 problem_options:
-  ofs: ["y0", "y1"]
-  dvs: ["x0", "x1"]
-  dvs_min: [0.8, 0.8]
-  dvs_base: null
-  dvs_max: [1.2, 1.2]
+  ofs: ["y0", "y1"]        # Objective function names (outputs to minimize / match)
+  dvs: ["x0", "x1"]        # Decision variable names (inputs the optimizer varies)
+  dvs_min: [0.8, 0.8]      # Lower bounds for each DV
+  dvs_base: null            # Baseline DV values (null = no baseline point in the initial set)
+  dvs_max: [1.2, 1.2]      # Upper bounds for each DV
+
+# -----------------------------------------------------------------
+# Evaluation options
+# -----------------------------------------------------------------
 
 evaluation_options:
-  parallel_evaluations: 1
-  train_Ystd: null
+  parallel_evaluations: 1   # Number of model evaluations to run concurrently (>1 uses multiprocessing)
+  train_Ystd: null          # Fixed observation noise; null = infer from the model
 
-# Convergence options for the BO optimization process
+# -----------------------------------------------------------------
+# Convergence criteria for the Bayesian Optimization loop
+# -----------------------------------------------------------------
+
 convergence_options:
-  maximum_iterations: 5
+  maximum_iterations: 5     # Hard cap on BO iterations
   stopping_criteria: "import::mitim_tools.opt_tools.STRATEGYtools.stopping_criteria_default"
   stopping_criteria_parameters:
-    maximum_value: -0.001
-    maximum_value_is_rel: false
-    minimum_inputs_variation: [10, 3, 0.01]
+    maximum_value: -0.001           # Stop if the best objective exceeds this threshold
+    maximum_value_is_rel: false     # If true, maximum_value is relative to iteration 0
+    minimum_inputs_variation: [10, 3, 0.01]  # [after_iter, window, tol%]: stop if DVs vary < tol% over the last <window> iterations, checked after <after_iter>
+
+# -----------------------------------------------------------------
+# Initialization: how the first training points are generated
+# -----------------------------------------------------------------
 
 initialization_options:
-  initial_training: 5
-  type_initialization: 3
-  read_initial_training_from_csv: false
-  initialization_fun: null
-  initialization_params: null
-  ensure_within_bounds: false
-  expand_bounds: true
+  initial_training: 5               # Number of initial training points
+  type_initialization: 3            # 1 = LHS, 3 = read from CSV, 4 = read from Execution folders
+  read_initial_training_from_csv: false  # If true, read initial DVs from a CSV file instead of generating them
+  initialization_fun: null          # Custom initialization function (e.g. PORTALS simple-relax); null = use type_initialization
+  initialization_params: null       # Per-trajectory parameter overrides for custom initialization_fun (see namelist.portals.yaml for the full schema)
+  ensure_within_bounds: false       # Remove initial points that fall outside dvs_min / dvs_max
+  expand_bounds: true               # Expand bounds to include any initial point that lies outside them
+
+# -----------------------------------------------------------------
+# Acquisition function: how the next candidate point is chosen
+# -----------------------------------------------------------------
 
 acquisition_options:
-  type: noisy_logei_mc
+  type: noisy_logei_mc      # Acquisition function type (noisy_logei_mc = noisy Log Expected Improvement via MC)
   parameters:
-    mc_samples: 1024
-  optimizers: ["botorch"]
+    mc_samples: 1024        # Monte Carlo samples for the acquisition estimator
+  optimizers: ["botorch"]   # Which optimizer(s) to use for maximizing the acquisition function
   optimizer_options:
     botorch:
-      num_restarts: 64
-      raw_samples: 4096
-      maxiter: 1000
-      sequential_q: true
-      keep_best: 1
+      num_restarts: 64                          # Multi-start restarts for the acquisition optimizer
+      raw_samples: 4096                         # Random samples for initial candidate generation
+      maxiter: 1000                             # Max L-BFGS-B iterations per restart
+      sequential_q: true                        # Optimize q-batch candidates sequentially (greedy)
+      keep_best: 1                              # Return the top-K candidates from all restarts
     root:
       num_restarts: 5
-      solver: lm
+      solver: lm                                # Scipy root solver ('lm' = Levenberg-Marquardt)
       maxiter: 1000
       relative_improvement_for_stopping: 0.0001
       keep_best: 1
     sr:
       num_restarts: 5                           # How many points to initialize with (parallel optimization)
       maxiter: 1000                             # Maximum number of iterations in acquisition optimization
-      relative_improvement_for_stopping: 0.001  # Treshold (relative improvement) to stop the acquisition optimization
-      relax: 0.1                                # Initial relaxation parameter (will be updated during the dynamic adjustments, if relax_dyn: true)
+      relative_improvement_for_stopping: 0.001  # Threshold (relative improvement) to stop the acquisition optimization
+      relax: 0.1                                # Initial relaxation parameter (updated during dynamic adjustments if relax_dyn: true)
       relax_dyn: true                           # Use Dynamic Simple Relaxation
-      keep_best: 1                              # How many best points to keep (#TODO: >1 not fully defined yet)
+      keep_best: 1                              # How many best points to keep
     ga:
       num_restarts: 1
       keep_best: 32
-  relative_improvement_for_stopping: null
-  favor_proximity_type: 0
-  ensure_new_points: true
-  points_per_step: 1
+  relative_improvement_for_stopping: null  # Global fallback; overridden per optimizer above
+  favor_proximity_type: 0                  # 0 = off; >0 penalizes candidates far from the current best
+  ensure_new_points: true                  # Reject a candidate if it is too close to an already-evaluated point
+  points_per_step: 1                       # Number of new points proposed per BO iteration (q-batch size)
+
+# -----------------------------------------------------------------
+# Surrogate (Gaussian Process) model options
+# -----------------------------------------------------------------
 
 surrogate_options:
-  TypeKernel: 0
-  TypeMean: 0
-  surrogate_selection: null
-  
-  additional_constraints: null
+  TypeKernel: 0             # 0 = Matern 5/2 (default); see BOgraphics for other kernels
+  TypeMean: 0               # 0 = constant mean; 1 = linear mean
+  surrogate_selection: null  # null = train one GP per output; or a list of output indices to model
 
-  # Noise treatment options
-  FixedNoise: true
-  ExtraNoise: false
-  ConstrainNoise: -0.001
-  MinimumRelativeNoise: null
+  additional_constraints: null  # Extra constraints on the GP hyperparameters
 
-  # Capability to remove outliers
-  stds_outside: null      # Standard deviations outside the mean to consider a point as an outlier
-  stds_outside_checker: 5 # Check for outliers only if there are at least these many points
+  # Noise treatment
+  FixedNoise: true          # If true, observation noise is fixed to train_Ystd (not learned)
+  ExtraNoise: false         # If true, add a learned homoscedastic noise term on top of FixedNoise
+  ConstrainNoise: -0.001    # Lower bound on the learned noise variance (log scale); negative = very small
+  MinimumRelativeNoise: null # If set, enforce a minimum noise floor relative to the output range
 
-  # Capability to add points to surrogates based on files
-  extrapointsFile: null
-  extrapointsModels: null
-  extrapointsModelsAvoidContent: null
+  # Outlier removal
+  stds_outside: null        # Remove points > this many stds from the GP posterior mean (null = off)
+  stds_outside_checker: 5   # Only check for outliers when the training set has at least this many points
+
+  # External data injection
+  extrapointsFile: null             # Path to a CSV with extra (X, Y) rows to add to the training set
+  extrapointsModels: null           # Path(s) to pre-trained surrogate model(s) to augment the GP
+  extrapointsModelsAvoidContent: null  # Exclude models whose path contains this substring
+
+# -----------------------------------------------------------------
+# Strategy options: bounds management, TURBO, and other BO heuristics
+# -----------------------------------------------------------------
 
 strategy_options:
-  AllowedExcursions: [0.0, 0.0]
-  HitBoundsIncrease: [1.0, 1.0]
-  boundsRefine: null
-  RandomRangeBounds: 0.5
-  ToleranceNiche: 0.001
-  applyCorrections: true
-  SwitchIterationsReduction: [null, null]
+  AllowedExcursions: [0.0, 0.0]     # Fraction of the bound range by which the optimizer may exceed dvs_min / dvs_max
+  HitBoundsIncrease: [1.0, 1.0]     # Multiplicative expansion of bounds when the best point sits at a boundary
+  boundsRefine: null                 # Manual per-DV bound override [min, max] applied after initialization
+  RandomRangeBounds: 0.5            # Fraction of the range used for random perturbation of initial LHS points
+  ToleranceNiche: 0.001             # Minimum distance between candidates to count as distinct (niche radius)
+  applyCorrections: true            # Apply post-processing corrections to the surrogate predictions
+  SwitchIterationsReduction: [null, null]  # [iter_start, iter_end]: reduce acquisition aggressiveness between these iterations
   TURBO_options:
-    apply: false
-    points: 32
-    bounds: [0.75, 1.33]
-    metrics: [3, 3]
+    apply: false            # If true, enable Trust Region Bayesian Optimization (TuRBO)
+    points: 32              # Number of candidate points sampled inside the trust region
+    bounds: [0.75, 1.33]    # Trust region shrink / expand factors
+    metrics: [3, 3]         # [success_tol, failure_tol]: consecutive successes/failures before adjusting the trust region

--- a/templates/namelist.optimization.yaml
+++ b/templates/namelist.optimization.yaml
@@ -23,6 +23,7 @@ initialization_options:
   type_initialization: 3
   read_initial_training_from_csv: false
   initialization_fun: null
+  initialization_params: null
   ensure_within_bounds: false
   expand_bounds: true
 

--- a/templates/namelist.portals.yaml
+++ b/templates/namelist.portals.yaml
@@ -292,11 +292,31 @@ optimization_namelist_location: null # If null, it will grab the default at: __m
 
 optimization_options:
 
-  initialization_options: 
+  initialization_options:
 
     # PORTALS works well with 5 initial training points obtained with simple relaxation
     initial_training: 5
     initialization_fun: "import::mitim_modules.portals.utils.PORTALSoptimization.initialization_simple_relax"
+
+    # Optional list of per-trajectory solver-option overrides for the simple-relax initializer.
+    # Each list entry defines one trajectory; all trajectories run sequentially, each producing
+    # `initial_training / len(initialization_params)` sequential training points. Use this to
+    # seed the initial set with several distinct relax shapes (e.g. cautious + aggressive walks).
+    # Requirements:
+    #   - initial_training must be divisible by the number of entries
+    #   - permitted keys: relax, dx_max, dx_max_abs, dx_min_abs, relax_dyn, relax_dyn_decrease,
+    #     relax_dyn_num, tol, tol_rel, print_each
+    #   - omit or set to null to keep the default single-trajectory behaviour
+    #
+    # Example (uncomment and edit to activate; initial_training above would need to be a multiple
+    # of the number of entries):
+    # initialization_params:
+    #   - relax: 0.2
+    #     dx_max: 0.2
+    #     dx_min_abs: 0.1
+    #   - relax: 0.1
+    #     dx_max: 0.4
+    #     dx_min_abs: 0.05
 
   # Convergence options for the optimization process
   convergence_options:

--- a/templates/namelist.portals.yaml
+++ b/templates/namelist.portals.yaml
@@ -116,6 +116,13 @@ transport:
   # Function to post-process input.gacode only *before* passing to transport codes (i.e. not for targets)
   profiles_postprocessing_fun: null
 
+  # Flatten the gradient at fine-grid neighbors of each coarse control point, creating a small
+  # plateau that ensures any derivative stencil (including TGYRO/GACODE's higher-order Lagrange)
+  # recovers the correct gradient value from the reconstructed profile. Also adds extra fine-grid
+  # points at +-1e-3 around each control point to support the plateau. Set to false to skip both
+  # (more uniform grid, but gradient recomputation by transport codes may see slope-change artifacts).
+  flatten_gradients_at_control_points: true
+
   # Corrections to be applied to each iteration input.gacode file
   applyCorrections:
     Ti_thermals: true       # Keep all *thermal* ion temperatures equal to the main Ti

--- a/templates/namelist.portals.yaml
+++ b/templates/namelist.portals.yaml
@@ -166,13 +166,25 @@ transport:
     # *********************************************************************************************************
     neo:
 
-      run: 
+      run:
         code_settings: "Sonic"
 
       read: {}
 
       # (%) Error (std, in percent) of model evaluation
       percent_error: 10.0
+
+      # Compute the neoclassical E×B shearing rate from NEO (profiles_gen -vgen) and pass it to TGLF as VEXB_SHEAR.
+      # This is appropriate when toroidal rotation is zero or negligible: Er is then determined by the
+      # combination of the ion pressure gradient and the neoclassical poloidal rotation (Waltz-Miller formula).
+      # Set to null (default) or false to disable. Set to true to use default NEO resolution settings, or
+      # provide a dict to override specific options, e.g.:
+      #   vgen_exb_shear:
+      #     er: 2          # Er method: 2 = NEO weak rotation limit (recommended for zero Vtor)
+      #     vel: 1         # Velocity method: 1 = NEO weak rotation limit
+      #     nth: "17,39"   # Min,max poloidal theta resolution
+      #     matched_ion: 1 # Ion species index to match (1-indexed)
+      vgen_exb_shear: null
 
     # *********************************************************************************************************
     # CGYRO

--- a/templates/namelist.portals.yaml
+++ b/templates/namelist.portals.yaml
@@ -298,25 +298,20 @@ optimization_options:
     initial_training: 5
     initialization_fun: "import::mitim_modules.portals.utils.PORTALSoptimization.initialization_simple_relax"
 
-    # Optional list of per-trajectory solver-option overrides for the simple-relax initializer.
-    # Each list entry defines one trajectory; all trajectories run sequentially, each producing
-    # `initial_training / len(initialization_params)` sequential training points. Use this to
-    # seed the initial set with several distinct relax shapes (e.g. cautious + aggressive walks).
+    # Per-trajectory solver-option overrides for the simple-relax initializer.
+    # Each list entry defines one trajectory; all trajectories run in parallel (one batched
+    # flux_match call dispatching N concurrent TGLF+NEO evaluations per step). Each trajectory
+    # contributes `initial_training / len(initialization_params)` training points.
     # Requirements:
     #   - initial_training must be divisible by the number of entries
-    #   - permitted keys: relax, dx_max, dx_max_abs, dx_min_abs, relax_dyn, relax_dyn_decrease,
-    #     relax_dyn_num, tol, tol_rel, print_each
-    #   - omit or set to null to keep the default single-trajectory behaviour
-    #
-    # Example (uncomment and edit to activate; initial_training above would need to be a multiple
-    # of the number of entries):
-    # initialization_params:
-    #   - relax: 0.2
-    #     dx_max: 0.2
-    #     dx_min_abs: 0.1
-    #   - relax: 0.1
-    #     dx_max: 0.4
-    #     dx_min_abs: 0.05
+    #   - permitted keys per trajectory: relax, dx_max, dx_max_abs, dx_min_abs, relax_dyn,
+    #     relax_dyn_decrease, relax_dyn_num, tol, tol_rel, print_each, perturbation_base
+    #   - perturbation_base (default 0) shifts the starting gradients by the given fraction
+    #     (e.g. 0.1 = all a/Lx increased by 10% from the base), creating diversity in the
+    #     initial training set without changing the relax dynamics
+    # Single trajectory with default parameters (equivalent to the historical behaviour):
+    initialization_params:
+      - {}
 
   # Convergence options for the optimization process
   convergence_options:

--- a/templates/namelist.portals.yaml
+++ b/templates/namelist.portals.yaml
@@ -104,6 +104,15 @@ transport:
   # Transport model class
   evaluator: "import::mitim_modules.powertorch.utils.TRANSPORTtools.portals_transport_model"
 
+  # If True, run transport models in-process if they allow that option.
+  #     E.g.,
+  #         TGLF and NEO via ctypes, libtglf_serial.so / libneo_serial.so) instead of forking subprocesses.
+  #         Requires the shared libraries to be built once per machine via:
+  #             cd src/mitim_tools/simulation_tools/interfaces && bash build_tglf_lib.sh
+  #             cd src/mitim_tools/simulation_tools/interfaces && bash build_neo_lib.sh
+  # When True, every PORTALS transport call is executed in-memory with no folder / file I/O.
+  in_process: true
+
   # Select transport models (when instantiating the evaluator, assign these parameters)
   evaluator_instance_attributes:
 
@@ -139,14 +148,6 @@ transport:
     # *********************************************************************************************************
     tglf:
 
-      # If True, run TGLF in-process via ctypes (libtglf_serial.so) instead of
-      # forking a `tglf` subprocess.  Requires the shared library to be built
-      # once per machine via:
-      #   cd src/mitim_tools/simulation_tools/interfaces && bash build_tglf_lib.sh
-      # When True, every PORTALS TGLF call (base run + scan-trick uncertainty
-      # scans) is executed in-memory with no folder / file I/O.
-      in_process: false
-
       # Kwargs to be passed to the run command
       run:
         code_settings: "SAT3"
@@ -180,12 +181,6 @@ transport:
     # NEO
     # *********************************************************************************************************
     neo:
-
-      # If True, run NEO in-process via ctypes (libneo_serial.so) instead of
-      # forking a `neo` subprocess.  Requires the shared library to be built
-      # once per machine via:
-      #   cd src/mitim_tools/simulation_tools/interfaces && bash build_neo_lib.sh
-      in_process: false
 
       run:
         code_settings: "Sonic"

--- a/templates/namelist.portals.yaml
+++ b/templates/namelist.portals.yaml
@@ -111,7 +111,7 @@ transport:
   #             cd src/mitim_tools/simulation_tools/interfaces && bash build_tglf_lib.sh
   #             cd src/mitim_tools/simulation_tools/interfaces && bash build_neo_lib.sh
   # When True, every PORTALS transport call is executed in-memory with no folder / file I/O.
-  in_process: true
+  in_process: false
 
   # Select transport models (when instantiating the evaluator, assign these parameters)
   evaluator_instance_attributes:

--- a/templates/namelist.portals.yaml
+++ b/templates/namelist.portals.yaml
@@ -132,6 +132,14 @@ transport:
     # *********************************************************************************************************
     tglf:
 
+      # If True, run TGLF in-process via ctypes (libtglf_serial.so) instead of
+      # forking a `tglf` subprocess.  Requires the shared library to be built
+      # once per machine via:
+      #   cd src/mitim_tools/simulation_tools/interfaces && bash build_tglf_lib.sh
+      # When True, every PORTALS TGLF call (base run + scan-trick uncertainty
+      # scans) is executed in-memory with no folder / file I/O.
+      in_process: false
+
       # Kwargs to be passed to the run command
       run:
         code_settings: "SAT3"
@@ -165,6 +173,12 @@ transport:
     # NEO
     # *********************************************************************************************************
     neo:
+
+      # If True, run NEO in-process via ctypes (libneo_serial.so) instead of
+      # forking a `neo` subprocess.  Requires the shared library to be built
+      # once per machine via:
+      #   cd src/mitim_tools/simulation_tools/interfaces && bash build_neo_lib.sh
+      in_process: false
 
       run:
         code_settings: "Sonic"

--- a/tests/CGYRO_workflow.py
+++ b/tests/CGYRO_workflow.py
@@ -108,6 +108,45 @@ cgyro.run(
 cgyro.read(label="cgyro2")
 
 # ---------------------------------------------------------------------------
+# Nonlinear with automatic BOX_SIZE / N_RADIAL via preprocess_options
+# (run_type='prep' so no SLURM submission: we only check the input files)
+# ---------------------------------------------------------------------------
+
+cgyro.run(
+    'Nonlinear_preprocessed',
+    code_settings="Nonlinear",
+    extraOptions={
+        'MAX_TIME': 10.0,
+    },
+    preprocess_options={
+        'ky_min': 0.3,
+        'L_x': 90,
+        'N_radial': 256,
+    },
+    slurm_setup={'cores': 16, 'minutes': 10},
+    cold_start=cold_start,
+    forceIfcold_start=True,
+    run_type='prep',
+)
+
+for rho in cgyro.rhos:
+    input_file = cgyro.FolderSimLast / f'input.cgyro_{rho:.4f}'
+    with open(input_file, 'r') as f:
+        txt = f.read()
+    parsed = {}
+    for line in txt.splitlines():
+        if '=' in line and not line.strip().startswith('#'):
+            k, v = line.split('=', 1)
+            parsed[k.strip()] = v.strip().split()[0]
+    box_size = int(parsed['BOX_SIZE'])
+    n_radial = int(parsed['N_RADIAL'])
+    assert n_radial % 2 == 0, f"N_RADIAL={n_radial} must be even"
+    assert n_radial % box_size == 0, (
+        f"N_RADIAL={n_radial} must be divisible by BOX_SIZE={box_size}"
+    )
+    print(f"[preprocess test] rho={rho}: BOX_SIZE={box_size} N_RADIAL={n_radial}")
+
+# ---------------------------------------------------------------------------
 # Plotting
 # ---------------------------------------------------------------------------
 

--- a/tests/CGYROlinear_preprocess_workflow.py
+++ b/tests/CGYROlinear_preprocess_workflow.py
@@ -15,7 +15,7 @@ from mitim_tools import __mitimroot__
 # ---------------------------------------------------------------------------
 
 cold_start = True
-save_figures = True
+save_figures = False
 
 gacode_file = __mitimroot__ / "tests" / "data" / "input.gacode"
 folder = __mitimroot__ / "tests" / "scratch" / "cgyro_linear_preprocess_test"

--- a/tests/CGYROlinear_preprocess_workflow.py
+++ b/tests/CGYROlinear_preprocess_workflow.py
@@ -1,0 +1,101 @@
+import os
+from mitim_tools.gacode_tools import CGYROtools
+from mitim_tools.misc_tools import GUItools
+from mitim_tools import __mitimroot__
+
+# ---------------------------------------------------------------------------
+# Minimal CGYRO linear workflow test using preprocess_options.
+#
+# This test exercises the preprocess_options knob added in commit 848e408a
+# (auto BOX_SIZE / N_RADIAL from local equilibrium quantities). Unlike the
+# preprocess section in CGYRO_workflow.py — which runs with run_type='prep'
+# to only inspect the generated input files — this test invokes a full
+# `run_type='normal'` linear run at one rho so the auto-computed BOX_SIZE,
+# N_RADIAL and KY are exercised end-to-end through the submission pipeline.
+# ---------------------------------------------------------------------------
+
+cold_start = True
+save_figures = True
+
+gacode_file = __mitimroot__ / "tests" / "data" / "input.gacode"
+folder = __mitimroot__ / "tests" / "scratch" / "cgyro_linear_preprocess_test"
+
+if cold_start and folder.exists():
+    os.system(f"rm -r {folder}")
+
+folder.mkdir(parents=True, exist_ok=True)
+
+cgyro = CGYROtools.CGYRO(rhos=[0.5])
+
+cgyro.prep(gacode_file, folder)
+
+# ---------------------------------------------------------------------------
+# One linear run at rho=0.5 in 'normal' mode. BOX_SIZE, N_RADIAL and KY are
+# picked by _apply_cgyro_preprocessing from the local Q / s / r/a at rho and
+# the caller-provided L_x / N_radial / ky_min. A short MAX_TIME keeps the
+# actual CGYRO execution well under a few minutes.
+# ---------------------------------------------------------------------------
+
+cgyro.run(
+    "linear_preprocessed",
+    code_settings="Linear",
+    extraOptions={
+        "MAX_TIME": 10.0,
+    },
+    preprocess_options={
+        "ky_min": 0.3,
+        "L_x": 90.0,
+        "N_radial": 256,
+        "min_box_size": 100,
+    },
+    slurm_setup={
+        "cores": 16,
+        "minutes": 10,
+    },
+    cold_start=cold_start,
+    forceIfcold_start=True,
+    run_type="normal",
+)
+
+# ---------------------------------------------------------------------------
+# Sanity-check the generated input.cgyro file: the preprocess_options must
+# have landed in the submitted input (BOX_SIZE, N_RADIAL, KY), and the
+# standard CGYRO divisibility invariant N_RADIAL % BOX_SIZE == 0 must hold.
+# ---------------------------------------------------------------------------
+
+for rho in cgyro.rhos:
+    input_file = cgyro.FolderSimLast / f"input.cgyro_{rho:.4f}"
+    with open(input_file, "r") as f:
+        txt = f.read()
+    parsed = {}
+    for line in txt.splitlines():
+        if "=" in line and not line.strip().startswith("#"):
+            k, v = line.split("=", 1)
+            parsed[k.strip()] = v.strip().split()[0]
+    box_size = int(parsed["BOX_SIZE"])
+    n_radial = int(parsed["N_RADIAL"])
+    ky = float(parsed["KY"])
+    assert n_radial % 2 == 0, f"N_RADIAL={n_radial} must be even"
+    assert n_radial % box_size == 0, (
+        f"N_RADIAL={n_radial} must be divisible by BOX_SIZE={box_size}"
+    )
+    print(
+        f"[cgyro linear preprocess] rho={rho}: "
+        f"BOX_SIZE={box_size} N_RADIAL={n_radial} KY={ky}"
+    )
+
+# Read results from the completed run.
+cgyro.read(label="linear_preprocessed")
+
+# ---------------------------------------------------------------------------
+# Plot
+# ---------------------------------------------------------------------------
+
+fn = GUItools.FigureNotebook("CGYRO linear preprocess", geometry="1600x1000", show=not save_figures)
+cgyro.plot(labels=["linear_preprocessed"], fn=fn)
+
+if not save_figures:
+    cgyro.fn.show()
+    cgyro.fn.close()
+else:
+    cgyro.fn.save(f"{folder}/figs_cgyro/")

--- a/tests/NEO_workflow.py
+++ b/tests/NEO_workflow.py
@@ -13,7 +13,7 @@ input_gacode = __mitimroot__ / "tests" / "data" / "input.gacode"
 if cold_start and folder.exists():
     os.system(f"rm -r {folder.resolve()}")
 
-neo = NEOtools.NEO(rhos=np.linspace(0.1,0.95,5))
+neo = NEOtools.NEO(rhos=np.linspace(0.8,0.95,10))
 neo.prep(input_gacode, folder)
 
 neo.run('neo1/', cold_start=cold_start)
@@ -25,11 +25,11 @@ neo.read('NEO low res')
 neo.run('neo3/', cold_start=cold_start, extraOptions={'N_ENERGY':5,'N_XI': 11, 'N_THETA': 11}, multipliers={'DLNTDR_1': 1.5})
 neo.read('NEO low res + 50% aLTi1')
 
-neo.plot(labels=['NEO default', 'NEO low res', 'NEO low res + 50% aLTi1'])
+neo.plot(labels=['NEO default', 'NEO low res', 'NEO low res + 50% aLTi1'], fn_color='r')
 
 neo.run_scan('scan1', cold_start=cold_start, variable='DLNTDR_1', varUpDown=np.linspace(0.5, 1.5, 4))
 neo.read_scan(label='scan1',variable = 'DLNTDR_1')
-neo.plot_scan(labels=['scan1'], fn = neo.fn)
+neo.plot_scan(labels=['scan1'], fn = neo.fn, fn_color='b')
 
 neo.fn.show()
 neo.fn.close()

--- a/tests/NEOvgen_workflow.py
+++ b/tests/NEOvgen_workflow.py
@@ -1,0 +1,41 @@
+import os
+from mitim_tools.gacode_tools import NEOtools, PROFILEStools
+from mitim_tools import __mitimroot__
+
+cold_start = True
+
+(__mitimroot__ / "tests" / "scratch").mkdir(parents=True, exist_ok=True)
+
+folder = __mitimroot__ / "tests" / "scratch" / "neovgen_test"
+input_gacode = __mitimroot__ / "tests" / "data" / "input.gacode"
+
+if cold_start and folder.exists():
+    os.system(f"rm -r {folder.resolve()}")
+
+# Load the plasma state
+plasma_state = PROFILEStools.gacode_state(input_gacode)
+
+# --- Set up NEO for VGEN  (rhos=[] because VGEN runs on all flux surfaces)
+neo = NEOtools.NEO(rhos=[])
+neo.prep(input_gacode, folder)
+
+# --- run_vgen: submit profiles_gen -vgen and wait
+neo.run_vgen(
+    subfolder="vgen1",
+    rho_range=[0.8,1.0],
+    vgenOptions={
+        "er": 2,          # NEO weak rotation limit (recommended for zero Vtor)
+        "vel": 1,         # NEO weak rotation limit
+        "nth": "17,39",   # Min/max poloidal theta resolution
+        "matched_ion": 1, # Ion species index to match (1-indexed)
+    },
+    cold_start=cold_start,
+)
+
+# --- read_vgen: parse ercomp, vel, and updated input.gacode
+neo.read_vgen()
+
+# --- plot_vgen: Er decomposition + w0/VEXB before & after
+neo.plot_vgen()
+neo.fn.show()
+neo.fn.close()

--- a/tests/NEOvgen_workflow.py
+++ b/tests/NEOvgen_workflow.py
@@ -29,6 +29,7 @@ neo.run_vgen(
         "nth": "17,39",   # Min/max poloidal theta resolution
         "matched_ion": 1, # Ion species index to match (1-indexed)
     },
+    smooth_profiles=True,
     cold_start=cold_start,
 )
 

--- a/tests/NEOworkflow_inprocess.py
+++ b/tests/NEOworkflow_inprocess.py
@@ -1,0 +1,114 @@
+"""
+NEO in-process workflow — runs NEO via ctypes (no subprocess, no files).
+
+Two differences from a standard NEO workflow:
+  1. `in_process=True` in the constructor.
+  2. `prep()` does not require a folder — pass only the input.gacode.
+
+All methods (`run`, `read`, `run_scan`) produce zero file I/O: no
+directories are created, no input.neo or out.neo.* files are written.
+Scan methods run all cases in parallel across all available CPU cores
+via threads (each thread loads its own private .so copy for independent
+Fortran globals).
+
+Prerequisites — build the shared library once per machine:
+
+    cd src/mitim_tools/simulation_tools/interfaces
+    bash build_neo_lib.sh
+"""
+
+import os
+import numpy as np
+from mitim_tools.gacode_tools import NEOtools
+from mitim_tools import __mitimroot__
+
+cold_start = True
+
+(__mitimroot__ / "tests" / "scratch").mkdir(parents=True, exist_ok=True)
+
+input_gacode = __mitimroot__ / "tests" / "data" / "input.gacode"
+rhos = [0.8, 0.9]
+
+# ── single-point runs (zero file I/O) ───────────────────────────────────────
+
+# in_process=True: no folder needed — prep() works with just the input file
+neo = NEOtools.NEO(rhos=rhos, in_process=True)
+neo.prep(input_gacode)
+
+neo.run("neo1/", code_settings="Sonic", cold_start=cold_start, forceIfcold_start=True)
+neo.read(label="NEO default")
+
+neo.run("neo2/", code_settings="Sonic", cold_start=cold_start, forceIfcold_start=True,
+        extraOptions={"N_ENERGY": 5, "N_XI": 11, "N_THETA": 11})
+neo.read(label="NEO low res")
+
+neo.run("neo3/", code_settings="Sonic", cold_start=cold_start, forceIfcold_start=True,
+        extraOptions={"N_ENERGY": 5, "N_XI": 11, "N_THETA": 11},
+        multipliers={"DLNTDR_1": 1.5})
+neo.read(label="NEO low res + 50% aLTi1")
+
+print(f"\nQe (default):     {[f'{r.Qe:.4e}' for r in neo.results['NEO default']['output']]}")
+print(f"Qe (low res):     {[f'{r.Qe:.4e}' for r in neo.results['NEO low res']['output']]}")
+print(f"Qe (low res +50): {[f'{r.Qe:.4e}' for r in neo.results['NEO low res + 50% aLTi1']['output']]}")
+print(f"Qi (default):     {[f'{r.Qi:.4e}' for r in neo.results['NEO default']['output']]}")
+print(f"Qi (low res):     {[f'{r.Qi:.4e}' for r in neo.results['NEO low res']['output']]}")
+print(f"Qi (low res +50): {[f'{r.Qi:.4e}' for r in neo.results['NEO low res + 50% aLTi1']['output']]}")
+
+# ── run_scan: subprocess vs in-process comparison ──────────────────────────
+
+SCAN_KWARGS = dict(
+    cold_start=cold_start,
+    forceIfcold_start=True,
+    variable="DLNTDR_1",
+    varUpDown=np.linspace(0.5, 1.5, 4).tolist(),
+    code_settings="Sonic",
+    extraOptions={"N_ENERGY": 5, "N_XI": 11, "N_THETA": 11},
+)
+
+# subprocess run
+folder_sub = __mitimroot__ / "tests" / "scratch" / "neo_scan_sub"
+if cold_start and folder_sub.exists():
+    os.system(f"rm -r {folder_sub.resolve()}")
+
+neo_sub = NEOtools.NEO(rhos=rhos, in_process=False)
+neo_sub.prep(input_gacode, folder_sub)
+neo_sub.run_scan(subfolder="scan_dltdr1", **SCAN_KWARGS)
+
+# in-process run (zero file I/O)
+folder_ip = __mitimroot__ / "tests" / "scratch" / "neo_scan_ip"
+if cold_start and folder_ip.exists():
+    os.system(f"rm -r {folder_ip.resolve()}")
+
+neo_ip = NEOtools.NEO(rhos=rhos, in_process=True)
+neo_ip.prep(input_gacode, folder_ip)
+neo_ip.run_scan(subfolder="scan_dltdr1", **SCAN_KWARGS)
+
+# comparison
+shared_labels = sorted(k for k in neo_sub.results if k in neo_ip.results)
+print(f"\n{'=' * 75}")
+print(f"Comparing {len(shared_labels)} scan labels across {len(rhos)} rhos")
+print(f"{'=' * 75}")
+
+# NEO momentum flux is genuinely tiny (≲1e-12 GB) for ITG-style cases, so
+# rtol on Qe/Qi is the meaningful check; momentum is dominated by noise.
+RTOL = 5e-3
+all_ok = True
+for label in shared_labels:
+    out_sub = neo_sub.results[label]["output"]
+    out_ip  = neo_ip.results[label]["output"]
+    for i, rho in enumerate(rhos):
+        Qe_s, Qe_i = out_sub[i].Qe, out_ip[i].Qe
+        Qi_s, Qi_i = out_sub[i].Qi, out_ip[i].Qi
+        ok = np.isclose(Qe_s, Qe_i, rtol=RTOL) and np.isclose(Qi_s, Qi_i, rtol=RTOL)
+        if not ok:
+            all_ok = False
+        status = "PASS" if ok else "FAIL"
+        print(
+            f"  [{status}]  {label:<32s}  rho={rho:.2f}"
+            f"  Qe: {Qe_s:.4e} vs {Qe_i:.4e}"
+            f"  Qi: {Qi_s:.4e} vs {Qi_i:.4e}"
+        )
+
+print(f"\n{'=' * 75}")
+print(f"Overall: {'ALL PASS' if all_ok else 'FAILURES DETECTED'}")
+print(f"{'=' * 75}")

--- a/tests/NEOworkflow_inprocess.py
+++ b/tests/NEOworkflow_inprocess.py
@@ -74,13 +74,9 @@ neo_sub = NEOtools.NEO(rhos=rhos, in_process=False)
 neo_sub.prep(input_gacode, folder_sub)
 neo_sub.run_scan(subfolder="scan_dltdr1", **SCAN_KWARGS)
 
-# in-process run (zero file I/O)
-folder_ip = __mitimroot__ / "tests" / "scratch" / "neo_scan_ip"
-if cold_start and folder_ip.exists():
-    os.system(f"rm -r {folder_ip.resolve()}")
-
+# in-process run (zero file I/O — no folder needed at any step)
 neo_ip = NEOtools.NEO(rhos=rhos, in_process=True)
-neo_ip.prep(input_gacode, folder_ip)
+neo_ip.prep(input_gacode)
 neo_ip.run_scan(subfolder="scan_dltdr1", **SCAN_KWARGS)
 
 # comparison

--- a/tests/PORTALS_workflow.py
+++ b/tests/PORTALS_workflow.py
@@ -10,7 +10,7 @@ cold_start = True
 (__mitimroot__ / "tests" / "scratch").mkdir(parents=True, exist_ok=True)
 
 # Inputs
-inputgacode = __mitimroot__ / "tests" / "data" / "input.gacode"
+inputgacode = "/Users/pablorf/envs/dev-pixi/MFE-IM/private_data/PLASMAS/input.gacode_SPARC_LmodeInvestigation_20230313"
 folderWork = __mitimroot__ / "tests" / "scratch" / "portals_test"
 
 if cold_start and folderWork.exists():
@@ -28,9 +28,10 @@ portals_fun.optimization_options["initialization_options"]["initial_training"] =
 portals_fun.portals_parameters["solution"]['turbulent_exchange_as_surrogate'] = True
 
 portals_fun.portals_parameters["solution"]["predicted_rho"] = [0.25, 0.45, 0.65, 0.85]
-portals_fun.portals_parameters["solution"]["predicted_channels"] = ["te", "ti", "ne", "nZ", "w0"] 
-portals_fun.portals_parameters["solution"]["trace_impurity"] = 'N'
+portals_fun.portals_parameters["solution"]["predicted_channels"] = ["te", "ti", "ne"] #, "nZ", "w0"] 
+# portals_fun.portals_parameters["solution"]["trace_impurity"] = 'N'
 portals_fun.portals_parameters["transport"]["options"]["tglf"]["run"]["code_settings"] = "SAT0"
+portals_fun.portals_parameters["transport"]["options"]["neo"]["vgen_exb_shear"] = True  # Compute neoclassical E×B shear from NEO (zero toroidal rotation)
 
 # Prepare case to run
 plasma_state = PROFILEStools.gacode_state(inputgacode)

--- a/tests/PORTALS_workflow.py
+++ b/tests/PORTALS_workflow.py
@@ -31,7 +31,6 @@ portals_fun.portals_parameters["solution"]["predicted_rho"] = [0.25, 0.45, 0.65,
 portals_fun.portals_parameters["solution"]["predicted_channels"] = ["te", "ti", "ne", "nZ", "w0"] 
 portals_fun.portals_parameters["solution"]["trace_impurity"] = 'N'
 portals_fun.portals_parameters["transport"]["options"]["tglf"]["run"]["code_settings"] = "SAT0"
-portals_fun.portals_parameters["transport"]["options"]["neo"]["vgen_exb_shear"] = True  # Compute neoclassical E×B shear from NEO (zero toroidal rotation)
 
 # Prepare case to run
 plasma_state = PROFILEStools.gacode_state(inputgacode)

--- a/tests/PORTALS_workflow.py
+++ b/tests/PORTALS_workflow.py
@@ -10,7 +10,7 @@ cold_start = True
 (__mitimroot__ / "tests" / "scratch").mkdir(parents=True, exist_ok=True)
 
 # Inputs
-inputgacode = "/Users/pablorf/envs/dev-pixi/MFE-IM/private_data/PLASMAS/input.gacode_SPARC_LmodeInvestigation_20230313"
+inputgacode = __mitimroot__ / "tests" / "data" / "input.gacode"
 folderWork = __mitimroot__ / "tests" / "scratch" / "portals_test"
 
 if cold_start and folderWork.exists():
@@ -28,8 +28,8 @@ portals_fun.optimization_options["initialization_options"]["initial_training"] =
 portals_fun.portals_parameters["solution"]['turbulent_exchange_as_surrogate'] = True
 
 portals_fun.portals_parameters["solution"]["predicted_rho"] = [0.25, 0.45, 0.65, 0.85]
-portals_fun.portals_parameters["solution"]["predicted_channels"] = ["te", "ti", "ne"] #, "nZ", "w0"] 
-# portals_fun.portals_parameters["solution"]["trace_impurity"] = 'N'
+portals_fun.portals_parameters["solution"]["predicted_channels"] = ["te", "ti", "ne", "nZ", "w0"] 
+portals_fun.portals_parameters["solution"]["trace_impurity"] = 'N'
 portals_fun.portals_parameters["transport"]["options"]["tglf"]["run"]["code_settings"] = "SAT0"
 portals_fun.portals_parameters["transport"]["options"]["neo"]["vgen_exb_shear"] = True  # Compute neoclassical E×B shear from NEO (zero toroidal rotation)
 

--- a/tests/PORTALSparallel_SR_workflow.py
+++ b/tests/PORTALSparallel_SR_workflow.py
@@ -46,17 +46,20 @@ portals_fun.optimization_options["initialization_options"]["initial_training"] =
 
 # Two deliberately contrasting trajectories so the initial training set covers
 # a wide range of a/Lx states. Trajectory 0 is cautious (small dx_max, slower
-# relax); trajectory 1 is aggressive (bigger steps, smaller min abs step).
+# relax, starts from the unperturbed base); trajectory 1 is aggressive (bigger
+# steps, smaller min abs step, gradients bumped by 10% via perturbation_base).
 portals_fun.optimization_options["initialization_options"]["initialization_params"] = [
     {
         "relax": 0.15,
         "dx_max": 0.15,
         "dx_min_abs": 0.10,
+        "perturbation_base": 0.0,
     },
     {
         "relax": 0.30,
         "dx_max": 0.30,
         "dx_min_abs": 0.05,
+        "perturbation_base": 0.1,
     },
 ]
 

--- a/tests/PORTALSparallel_SR_workflow.py
+++ b/tests/PORTALSparallel_SR_workflow.py
@@ -83,25 +83,63 @@ mitim_bo = STRATEGYtools.MITIM_BO(portals_fun, cold_start=cold_start, askQuestio
 mitim_bo.run()
 
 # ---------------------------------------------------------------------------
-# Assertions: after initialization the folder layout must reflect the
-# step-major interleaving of the two trajectories:
-#   portals_sr_ev_{s*n_traj + t}  for s in [0..steps_per_traj-1], t in [0..n_traj-1]
-# For this test (initial_training=4, n_traj=2) that means folders 0..3 must
-# all exist, plus Execution/Evaluation.0..3 copied from them.
+# Assertions: after initialization the folder layout must reflect the new
+# batched simple-relax shape:
+#
+#   portals_sr_ev_{s}                            for s in [0..steps_per_traj-1]
+#     └── transport_simulation_folder/
+#          ├── plasma_0/ (per-trajectory flux JSON + input.gacode)
+#          └── plasma_1/
+#
+# and Execution/Evaluation.{s*n_traj+t} is populated from `plasma_{t}` for the
+# step s, each carrying the single-plasma `fluxes_{turb,neoc}.json` pair that
+# the BO-time cache gate in `power_transport.evaluate` will pick up for zero-
+# work reuse.
+#
+# For this test (initial_training=4, n_traj=2) that means:
+#   - portals_sr_ev_{0,1} exist, each with plasma_{0,1} sub-dirs containing
+#     fluxes_turb.json + fluxes_neoc.json
+#   - Evaluation.{0..3}/transport_simulation_folder exist and each contain the
+#     single-plasma JSON pair at their top level.
 # ---------------------------------------------------------------------------
 
+N_TRAJ = 2
+STEPS_PER_TRAJ = 2
+N_POINTS = N_TRAJ * STEPS_PER_TRAJ  # = initial_training (4)
+
 init_dir = folderWork / "Initialization" / "initialization_simple_relax"
-for i in range(4):
-    expected = init_dir / f"portals_sr_ev_{i}"
-    assert expected.exists(), f"Expected {expected} from parallel SR initialization"
+for s in range(STEPS_PER_TRAJ):
+    step_folder = init_dir / f"portals_sr_ev_{s}" / "transport_simulation_folder"
+    assert step_folder.exists(), f"Expected {step_folder} from batched SR step {s}"
+    for t in range(N_TRAJ):
+        plasma_sub = step_folder / f"plasma_{t}"
+        assert plasma_sub.exists(), f"Expected per-plasma sub-folder {plasma_sub}"
+        assert (plasma_sub / "input.gacode").exists(), (
+            f"Expected {plasma_sub/'input.gacode'} written by _evaluate_batched"
+        )
+        assert (plasma_sub / "fluxes_turb.json").exists(), (
+            f"Expected single-plasma {plasma_sub/'fluxes_turb.json'}"
+        )
+        assert (plasma_sub / "fluxes_neoc.json").exists(), (
+            f"Expected single-plasma {plasma_sub/'fluxes_neoc.json'}"
+        )
 
 exec_dir = folderWork / "Execution"
-for i in range(4):
-    expected = exec_dir / f"Evaluation.{i}" / "transport_simulation_folder"
-    assert expected.exists(), f"Expected {expected} from parallel SR initialization"
+for i in range(N_POINTS):
+    exec_tr = exec_dir / f"Evaluation.{i}" / "transport_simulation_folder"
+    assert exec_tr.exists(), f"Expected {exec_tr} from parallel SR initialization"
+    assert (exec_tr / "fluxes_turb.json").exists(), (
+        f"Expected cached turbulence JSON at {exec_tr/'fluxes_turb.json'}"
+    )
+    assert (exec_tr / "fluxes_neoc.json").exists(), (
+        f"Expected cached neoclassical JSON at {exec_tr/'fluxes_neoc.json'}"
+    )
 
-print("\n[PORTALSparallel_SR_workflow] Four portals_sr_ev_* folders and "
-      "matching Evaluation.{0..3} folders found. Step-major layout OK.")
+print(
+    f"\n[PORTALSparallel_SR_workflow] {STEPS_PER_TRAJ} batched portals_sr_ev_* folders "
+    f"each with {N_TRAJ} plasma_* sub-folders, matching {N_POINTS} Evaluation.* "
+    "folders carrying single-plasma JSON pairs. Step-major batched layout OK."
+)
 
 # ---------------------------------------------------------------------------
 # Plot

--- a/tests/PORTALSparallel_SR_workflow.py
+++ b/tests/PORTALSparallel_SR_workflow.py
@@ -38,7 +38,7 @@ if cold_start and folderWork.exists():
 portals_fun = PORTALSmain.portals(folderWork)
 
 # Shorten the BO loop so the test is about the *initialization*, not the BO.
-portals_fun.optimization_options["convergence_options"]["maximum_iterations"] = 1
+portals_fun.optimization_options["convergence_options"]["maximum_iterations"] = 2
 
 # Total deterministic simple-relax points. Must be divisible by the number of
 # trajectories below (2). 4 points = 2 trajectories x 2 steps each.

--- a/tests/PORTALSparallel_SR_workflow.py
+++ b/tests/PORTALSparallel_SR_workflow.py
@@ -1,0 +1,116 @@
+import os
+from mitim_tools.opt_tools import STRATEGYtools
+from mitim_modules.portals import PORTALSmain
+from mitim_modules.portals.utils import PORTALSanalysis
+from mitim_tools.gacode_tools import PROFILEStools
+from mitim_tools import __mitimroot__
+
+# ---------------------------------------------------------------------------
+# PORTALS parallel simple-relax workflow test
+#
+# Exercises the multi-trajectory initialization path added in commit 1e4b4a2d:
+#   optimization_options.initialization_options.initialization_params
+#
+# initial_training is split across N deterministic simple-relax trajectories,
+# each with its own (relax, dx_max, dx_min_abs, ...). The total number of
+# initial training points must be divisible by the number of trajectories.
+# This test uses 4 initial points spread over 2 trajectories (2 steps each)
+# with contrasting relax factors so the two trajectories visibly diverge in
+# the Initialization/initialization_simple_relax/portals_sr_ev_* folder
+# sequence.
+# ---------------------------------------------------------------------------
+
+cold_start = True
+
+(__mitimroot__ / "tests" / "scratch").mkdir(parents=True, exist_ok=True)
+
+inputgacode = __mitimroot__ / "tests" / "data" / "input.gacode"
+folderWork = __mitimroot__ / "tests" / "scratch" / "portals_parallel_SR_test"
+
+if cold_start and folderWork.exists():
+    os.system(f"rm -r {folderWork.resolve()}")
+
+# ---------------------------------------------------------------------------
+# PORTALS optimization class: start from the default namelist and override
+# only the minimum to keep the test fast (few rhos, short BO loop).
+# ---------------------------------------------------------------------------
+
+portals_fun = PORTALSmain.portals(folderWork)
+
+# Shorten the BO loop so the test is about the *initialization*, not the BO.
+portals_fun.optimization_options["convergence_options"]["maximum_iterations"] = 1
+
+# Total deterministic simple-relax points. Must be divisible by the number of
+# trajectories below (2). 4 points = 2 trajectories x 2 steps each.
+portals_fun.optimization_options["initialization_options"]["initial_training"] = 4
+
+# Two deliberately contrasting trajectories so the initial training set covers
+# a wide range of a/Lx states. Trajectory 0 is cautious (small dx_max, slower
+# relax); trajectory 1 is aggressive (bigger steps, smaller min abs step).
+portals_fun.optimization_options["initialization_options"]["initialization_params"] = [
+    {
+        "relax": 0.15,
+        "dx_max": 0.15,
+        "dx_min_abs": 0.10,
+    },
+    {
+        "relax": 0.30,
+        "dx_max": 0.30,
+        "dx_min_abs": 0.05,
+    },
+]
+
+portals_fun.portals_parameters["solution"]["turbulent_exchange_as_surrogate"] = True
+portals_fun.portals_parameters["solution"]["predicted_rho"] = [0.35, 0.65, 0.85]
+portals_fun.portals_parameters["solution"]["predicted_channels"] = ["te", "ti", "ne"]
+portals_fun.portals_parameters["transport"]["options"]["tglf"]["run"]["code_settings"] = "SAT0"
+
+# ---------------------------------------------------------------------------
+# Prepare and run
+# ---------------------------------------------------------------------------
+
+plasma_state = PROFILEStools.gacode_state(inputgacode)
+plasma_state.correct(options={
+    "recalculate_ptot": True,
+    "remove_fast": True,
+    "quasineutrality": True,
+    "enforce_same_aLn": True,
+})
+
+portals_fun.prep(plasma_state)
+
+mitim_bo = STRATEGYtools.MITIM_BO(portals_fun, cold_start=cold_start, askQuestions=False)
+mitim_bo.run()
+
+# ---------------------------------------------------------------------------
+# Assertions: after initialization the folder layout must reflect the
+# step-major interleaving of the two trajectories:
+#   portals_sr_ev_{s*n_traj + t}  for s in [0..steps_per_traj-1], t in [0..n_traj-1]
+# For this test (initial_training=4, n_traj=2) that means folders 0..3 must
+# all exist, plus Execution/Evaluation.0..3 copied from them.
+# ---------------------------------------------------------------------------
+
+init_dir = folderWork / "Initialization" / "initialization_simple_relax"
+for i in range(4):
+    expected = init_dir / f"portals_sr_ev_{i}"
+    assert expected.exists(), f"Expected {expected} from parallel SR initialization"
+
+exec_dir = folderWork / "Execution"
+for i in range(4):
+    expected = exec_dir / f"Evaluation.{i}" / "transport_simulation_folder"
+    assert expected.exists(), f"Expected {expected} from parallel SR initialization"
+
+print("\n[PORTALSparallel_SR_workflow] Four portals_sr_ev_* folders and "
+      "matching Evaluation.{0..3} folders found. Step-major layout OK.")
+
+# ---------------------------------------------------------------------------
+# Plot
+# ---------------------------------------------------------------------------
+
+portals_fun.plot_optimization_results(analysis_level=2)
+
+portals_output = PORTALSanalysis.PORTALSanalyzer.from_folder(folderWork)
+portals_output.plotPORTALS(noshow=True)
+portals_output.fn.save(folderWork / "final_portals_plots")
+
+portals_fun.fn.show()

--- a/tests/TGLF_read_npz.py
+++ b/tests/TGLF_read_npz.py
@@ -1,0 +1,30 @@
+"""
+Read and plot TGLF results previously saved as npz files.
+
+Requires that TGLF_workflow.py and TGLFscan_workflow.py have already been run
+so that the npz files exist under tests/scratch/.
+"""
+from mitim_tools.gacode_tools import TGLFtools
+from mitim_tools import __mitimroot__
+
+scratch = __mitimroot__ / "tests" / "scratch"
+
+# ---------------------------------------------------------------------------
+# 1. Standard TGLF runs  (produced by TGLF_workflow.py)
+# ---------------------------------------------------------------------------
+
+tglf = TGLFtools.TGLF.from_npz(scratch / "tglf_test" / "tglf_results.npz")
+tglf.plot(labels=["ES (SAT1)", "EM (SAT1)", "EM (SAT3)"])
+tglf.fn.show()
+
+# ---------------------------------------------------------------------------
+# 2. Scan results  (produced by TGLFscan_workflow.py)
+# ---------------------------------------------------------------------------
+
+tglf_scan = TGLFtools.TGLF.from_npz(scratch / "tglfscan_test" / "scan_results.npz")
+
+tglf_scan.plot_scan(labels=["scan1"], plotTGLFs=False)
+tglf_scan.fn.show()
+
+tglf_scan.plotScanTurbulenceDrives(label="turb_drives", plotTGLFs=False)
+tglf_scan.fn.show()

--- a/tests/TGLF_workflow.py
+++ b/tests/TGLF_workflow.py
@@ -8,6 +8,7 @@ cold_start = True
 
 folder = __mitimroot__ / "tests" / "scratch" / "tglf_test"
 input_tglf = __mitimroot__ / "tests" / "data" / "input.tglf"
+npz_file   = folder / "tglf_results.npz"
 
 if cold_start and folder.exists():
     os.system(f"rm -r {folder.resolve()}")
@@ -25,7 +26,7 @@ tglf.run(
     slurm_setup={"cores": 4, "minutes": 1},
 )
 
-tglf.read(label="ES (SAT1)")
+tglf.read(label="ES (SAT1)", save_and_cleanup=npz_file)
 
 tglf.run(
     "run2/",
@@ -36,7 +37,7 @@ tglf.run(
     slurm_setup={"cores": 4, "minutes": 1},
 )
 
-tglf.read(label="EM (SAT1)")
+tglf.read(label="EM (SAT1)", save_and_cleanup=npz_file)
 
 tglf.run(
     "run3/",
@@ -47,9 +48,8 @@ tglf.run(
     slurm_setup={"cores": 4, "minutes": 1},
 )
 
-tglf.read(label="EM (SAT3)")
+tglf.read(label="EM (SAT3)", save_and_cleanup=npz_file)
 
-tglf.plot(labels=["EM (SAT1)","ES (SAT1)", "EM (SAT3)"])
-
-# Required if running in non-interactive mode
-tglf.fn.show()
+tglf_loaded = TGLFtools.TGLF.from_npz(npz_file)
+tglf_loaded.plot(labels=["ES (SAT1)", "EM (SAT1)", "EM (SAT3)"])
+tglf_loaded.fn.show()

--- a/tests/TGLFmulti_plasma_workflow.py
+++ b/tests/TGLFmulti_plasma_workflow.py
@@ -1,0 +1,110 @@
+import os
+import numpy as np
+import matplotlib.pyplot as plt
+from mitim_tools.gacode_tools import TGLFtools, PROFILEStools
+from mitim_tools import __mitimroot__
+
+# ---------------------------------------------------------------------------
+# Multi-plasma TGLF workflow test
+#
+# This test mirrors TGLFscan_workflow.py but exercises the new "plasmas"
+# parallelism axis added via mitim_simulation.run_over_plasmas: a single TGLF
+# instance runs two independent plasmas (two input.gacodes) at the same rhos
+# in one parallel submission, then each plasma's results are read back via
+# read_plasma(...) and plotted side-by-side.
+# ---------------------------------------------------------------------------
+
+cold_start = True
+
+(__mitimroot__ / 'tests' / 'scratch').mkdir(parents=True, exist_ok=True)
+
+folder = __mitimroot__ / "tests" / "scratch" / "tglf_multi_plasma_test"
+input_gacode = __mitimroot__ / "tests" / "data" / "input.gacode"
+
+if cold_start and folder.exists():
+    os.system(f"rm -r {folder.resolve()}")
+
+# ---------------------------------------------------------------------------
+# Build two distinct plasma states from the shared test input.gacode:
+#   - plasma 0 = baseline
+#   - plasma 1 = 30% hotter electrons, 10% hotter ions (a deliberate perturbation
+#     that guarantees different TGLF fluxes at the same rhos)
+# ---------------------------------------------------------------------------
+state_a = PROFILEStools.gacode_state(input_gacode)
+
+state_b = PROFILEStools.gacode_state(input_gacode)
+state_b.profiles['te(keV)'] = state_b.profiles['te(keV)'] * 1.3
+state_b.profiles['ti(keV)'] = state_b.profiles['ti(keV)'] * 1.1
+
+list_of_states = [state_a, state_b]
+
+# ---------------------------------------------------------------------------
+# Run TGLF on both plasmas in one parallel submission.
+# run_over_plasmas creates a subfolder per plasma ("base_plasma0", "base_plasma1")
+# and every (plasma, rho) work unit is dispatched through the existing
+# FARMINGtools parallel loop — same path scans already use.
+# ---------------------------------------------------------------------------
+tglf = TGLFtools.TGLF(rhos=[0.5, 0.7])
+tglf.prep(state_a, folder, cold_start=cold_start)
+
+plasma_labels = tglf.run_over_plasmas(
+    list_of_states,
+    base_subfolder='base',
+    cold_start=cold_start,
+)
+
+print("\nrun_over_plasmas returned plasma -> subfolder mapping:", plasma_labels)
+
+# ---------------------------------------------------------------------------
+# Read each plasma's results. read_plasma temporarily restores that plasma's
+# prep-time state (profiles, inputs, normalizations, folder) so the existing
+# TGLF.read() path can reuse its per-plasma normalizations unchanged.
+# ---------------------------------------------------------------------------
+for p in plasma_labels:
+    tglf.read_plasma(p, cold_startWF=False)
+
+# ---------------------------------------------------------------------------
+# Build Qe / Qi arrays (one value per rho per plasma) and plot a side-by-side
+# comparison so the caller can eyeball the two plasmas against each other.
+# ---------------------------------------------------------------------------
+rhos = np.array(tglf.rhos)
+Qe_per_plasma, Qi_per_plasma = {}, {}
+for p, label in plasma_labels.items():
+    outputs = tglf.results[label]['output']
+    Qe_per_plasma[p] = np.array([o.Qe for o in outputs])
+    Qi_per_plasma[p] = np.array([o.Qi for o in outputs])
+
+fig, axs = plt.subplots(1, 2, figsize=(10, 4), sharex=True)
+colors = ['tab:blue', 'tab:red']
+for p in plasma_labels:
+    axs[0].plot(rhos, Qe_per_plasma[p], 'o-', color=colors[p], label=f'plasma {p}')
+    axs[1].plot(rhos, Qi_per_plasma[p], 'o-', color=colors[p], label=f'plasma {p}')
+
+axs[0].set_xlabel(r'$\rho$')
+axs[0].set_ylabel(r'$Q_e$ (TGLF, GB units)')
+axs[0].set_title('Electron energy flux')
+axs[0].legend()
+
+axs[1].set_xlabel(r'$\rho$')
+axs[1].set_ylabel(r'$Q_i$ (TGLF, GB units)')
+axs[1].set_title('Ion energy flux')
+
+fig.suptitle('TGLF multi-plasma workflow: two plasmas, shared rhos, parallel submission')
+fig.tight_layout()
+plt.show()
+plt.close(fig)
+
+# ---------------------------------------------------------------------------
+# Assertion: plasma 0 and plasma 1 must produce distinct fluxes (the 30% / 10%
+# temperature perturbation in state_b should not collapse to the baseline).
+# ---------------------------------------------------------------------------
+for rho_idx, rho in enumerate(rhos):
+    qe_a = float(Qe_per_plasma[0][rho_idx])
+    qe_b = float(Qe_per_plasma[1][rho_idx])
+    if np.isclose(qe_a, qe_b, rtol=1e-6, atol=0):
+        raise AssertionError(
+            f"Expected distinct Qe between the two plasmas at rho={rho:.4f}, "
+            f"got qe_a={qe_a:.6g}, qe_b={qe_b:.6g}"
+        )
+
+print("\nTGLFmulti_plasma_workflow.py: Qe/Qi differ across the two plasmas at every rho. PASS.")

--- a/tests/TGLFscan2D_workflow.py
+++ b/tests/TGLFscan2D_workflow.py
@@ -1,0 +1,37 @@
+import os
+import numpy as np
+from mitim_tools.gacode_tools import TGLFtools
+from mitim_tools import __mitimroot__
+
+cold_start = True
+
+(__mitimroot__ / "tests" / "scratch").mkdir(parents=True, exist_ok=True)
+
+folder      = __mitimroot__ / "tests" / "scratch" / "tglfscan2d_test"
+input_gacode = __mitimroot__ / "tests" / "data" / "input.gacode"
+npz_file    = folder / "scan2d_results.npz"
+
+if cold_start and folder.exists():
+    os.system(f"rm -r {folder.resolve()}")
+
+tglf = TGLFtools.TGLF(rhos=[0.5, 0.7])
+tglf.prep(input_gacode, folder, cold_start=cold_start)
+
+tglf.run_scan2d(
+    subfolder   = "scan2d",
+    variable1   = "RLTS_1",
+    varUpDown1  = np.linspace(0.5, 1.5, 4),
+    variable2   = "RLTS_2",
+    varUpDown2  = np.linspace(0.5, 1.5, 4),
+    code_settings = None,
+    cold_start  = cold_start,
+    save_and_cleanup = npz_file,
+)
+
+# Load from npz and aggregate + plot (raw folders have been cleaned up)
+tglf_loaded = TGLFtools.TGLF.from_npz(npz_file)
+tglf_loaded.read_scan2d(label="scan2d", ky_target=0.3)
+
+tglf_loaded.plot_scan2d(label="scan2d")
+tglf_loaded.fn.show()
+tglf_loaded.fn.close()

--- a/tests/TGLFscan_workflow.py
+++ b/tests/TGLFscan_workflow.py
@@ -9,32 +9,37 @@ cold_start = True
 
 folder = __mitimroot__ / "tests" / "scratch" / "tglfscan_test"
 input_gacode = __mitimroot__ / "tests" / "data" / "input.gacode"
+npz_file = folder / "scan_results.npz"
 
 if cold_start and folder.exists():
     os.system(f"rm -r {folder.resolve()}")
 
 tglf = TGLFtools.TGLF(rhos=[0.5, 0.7])
-tglf.prep(input_gacode,folder, cold_start=cold_start)
+tglf.prep(input_gacode, folder, cold_start=cold_start)
 
-tglf.run_scan(	subfolder = 'scan1',
+tglf.run_scan(  subfolder = 'scan1',
                 code_settings  = None,
-                extraOptions = {"USE_BPER": [False, True]}, # extraOptions can receive a list to provide different values per rho
+                extraOptions = {"USE_BPER": [False, True]},
                 cold_start       = cold_start,
                 runWaveForms  = [0.67, 10.0],
                 variable      = 'RLTS_1',
-                varUpDown 	  = np.linspace(0.5,1.5,4))
-tglf.read_scan(label='scan1',variable = 'RLTS_1')
+                varUpDown     = np.linspace(0.5,1.5,4))
 
-tglf.plot_scan(labels=['scan1'])
-tglf.fn.show()
-tglf.fn.close()
+tglf.read_scan(label='scan1', variable='RLTS_1', save_and_cleanup=npz_file)
 
-tglf.runScanTurbulenceDrives(	
+tglf_loaded = TGLFtools.TGLF.from_npz(npz_file)
+tglf_loaded.plot_scan(labels=['scan1'], plotTGLFs=False)
+tglf_loaded.fn.show()
+tglf_loaded.fn.close()
+
+tglf.runScanTurbulenceDrives(
                 subfolder = 'turb_drives',
                 code_settings  = None,
                 resolutionPoints=3,
-                cold_start       = cold_start)
+                cold_start       = cold_start,
+                save_and_cleanup = npz_file)
 
-tglf.plotScanTurbulenceDrives(label='turb_drives')
-tglf.fn.show()
-tglf.fn.close()
+tglf_loaded2 = TGLFtools.TGLF.from_npz(npz_file)
+tglf_loaded2.plotScanTurbulenceDrives(label='turb_drives', plotTGLFs=False)
+tglf_loaded2.fn.show()
+tglf_loaded2.fn.close()

--- a/tests/TGLFworkflow_inprocess.py
+++ b/tests/TGLFworkflow_inprocess.py
@@ -18,6 +18,7 @@ Prerequisites — build the shared library once per machine:
 """
 
 import os
+import time
 import numpy as np
 from mitim_tools.gacode_tools import TGLFtools
 from mitim_tools import __mitimroot__
@@ -29,18 +30,54 @@ cold_start = True
 input_gacode = __mitimroot__ / "tests" / "data" / "input.gacode"
 rhos = [0.5, 0.7]
 
+# ---------------------------------------------------------------------------
+# Timing helper — collects (label, wall_seconds) into TIMINGS so we can print
+# a summary table at the end.  Use as: with timed("label"): ...
+# ---------------------------------------------------------------------------
+from contextlib import contextmanager
+
+TIMINGS: list[tuple[str, float]] = []
+
+@contextmanager
+def timed(label: str):
+    print(f"\n>>> [{label}] start")
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        dt = time.perf_counter() - t0
+        TIMINGS.append((label, dt))
+        print(f"<<< [{label}] done in {dt:.2f}s")
+
+# Echo the BLAS / OpenMP thread environment so we can correlate timings with
+# whatever thread pinning is in effect (the in_process modules pin to 1 by
+# default; values may have been overridden by the calling shell).
+print(
+    "[env] MKL_NUM_THREADS={}  OPENBLAS_NUM_THREADS={}  OMP_NUM_THREADS={}  "
+    "MKL_DYNAMIC={}  cpu_count={}".format(
+        os.environ.get("MKL_NUM_THREADS"),
+        os.environ.get("OPENBLAS_NUM_THREADS"),
+        os.environ.get("OMP_NUM_THREADS"),
+        os.environ.get("MKL_DYNAMIC"),
+        os.cpu_count(),
+    )
+)
+
 # ── single-point runs (zero file I/O) ───────────────────────────────────────
 
 # in_process=True: no folder needed — prep() works with just the input file
-tglf = TGLFtools.TGLF(rhos=rhos, in_process=True)
-tglf.prep(input_gacode)
+with timed("single: prep"):
+    tglf = TGLFtools.TGLF(rhos=rhos, in_process=True)
+    tglf.prep(input_gacode)
 
-tglf.run("run1/", code_settings="SAT1", cold_start=cold_start, forceIfcold_start=True)
-tglf.read(label="SAT1")
+with timed("single: run SAT1"):
+    tglf.run("run1/", code_settings="SAT1", cold_start=cold_start, forceIfcold_start=True)
+    tglf.read(label="SAT1")
 
-tglf.run("run2/", code_settings="SAT1", cold_start=cold_start, forceIfcold_start=True,
-         extraOptions={"USE_BPER": True, "USE_BPAR": True})
-tglf.read(label="SAT1 EM")
+with timed("single: run SAT1 EM"):
+    tglf.run("run2/", code_settings="SAT1", cold_start=cold_start, forceIfcold_start=True,
+             extraOptions={"USE_BPER": True, "USE_BPAR": True})
+    tglf.read(label="SAT1 EM")
 
 print(f"\nQe (SAT1):    {[f'{r.Qe:.4f}' for r in tglf.results['SAT1']['output']]}")
 print(f"Qe (SAT1 EM): {[f'{r.Qe:.4f}' for r in tglf.results['SAT1 EM']['output']]}")
@@ -60,14 +97,16 @@ folder_sub = __mitimroot__ / "tests" / "scratch" / "tglf_drives_sub"
 if cold_start and folder_sub.exists():
     os.system(f"rm -r {folder_sub.resolve()}")
 
-tglf_sub = TGLFtools.TGLF(rhos=rhos, in_process=False)
-tglf_sub.prep(input_gacode, folder_sub)
-tglf_sub.runScanTurbulenceDrives(subfolder="drives", **DRIVES_KWARGS)
+with timed("scanTurbulenceDrives: subprocess"):
+    tglf_sub = TGLFtools.TGLF(rhos=rhos, in_process=False)
+    tglf_sub.prep(input_gacode, folder_sub)
+    tglf_sub.runScanTurbulenceDrives(subfolder="drives", **DRIVES_KWARGS)
 
 # in-process run (zero file I/O — no folder needed at any step)
-tglf_ip = TGLFtools.TGLF(rhos=rhos, in_process=True)
-tglf_ip.prep(input_gacode)
-tglf_ip.runScanTurbulenceDrives(subfolder="drives", **DRIVES_KWARGS)
+with timed("scanTurbulenceDrives: in-process"):
+    tglf_ip = TGLFtools.TGLF(rhos=rhos, in_process=True)
+    tglf_ip.prep(input_gacode)
+    tglf_ip.runScanTurbulenceDrives(subfolder="drives", **DRIVES_KWARGS)
 
 # comparison
 shared_labels = sorted(k for k in tglf_sub.results if k in tglf_ip.results)
@@ -97,4 +136,16 @@ for label in shared_labels:
 
 print(f"\n{'='*65}")
 print(f"Overall: {'ALL PASS' if all_ok else 'FAILURES DETECTED'}")
+print(f"{'='*65}")
+
+# ── timing summary ──────────────────────────────────────────────────────────
+print(f"\n{'='*65}")
+print("Timing summary")
+print(f"{'='*65}")
+total = 0.0
+for label, dt in TIMINGS:
+    print(f"  {label:<40s}  {dt:8.2f}s")
+    total += dt
+print(f"  {'-'*40}  {'-'*9}")
+print(f"  {'TOTAL':<40s}  {total:8.2f}s")
 print(f"{'='*65}")

--- a/tests/TGLFworkflow_inprocess.py
+++ b/tests/TGLFworkflow_inprocess.py
@@ -1,0 +1,104 @@
+"""
+TGLF in-process workflow — runs TGLF via ctypes (no subprocess, no files).
+
+Two differences from a standard TGLF workflow:
+  1. `in_process=True` in the constructor.
+  2. `prep()` does not require a folder — pass only the input.gacode.
+
+All methods (`run`, `read`, `run_scan`, `runScanTurbulenceDrives`) produce
+zero file I/O: no directories are created, no input.tglf or out.tglf.gbflux
+files are written.  Scan methods run all cases in parallel across all
+available CPU cores via threads (each thread loads its own private .so copy
+for independent Fortran globals).
+
+Prerequisites — build the shared library once per machine:
+
+    cd src/mitim_tools/simulation_tools/interfaces
+    bash build_tglf_lib.sh
+"""
+
+import os
+import numpy as np
+from mitim_tools.gacode_tools import TGLFtools
+from mitim_tools import __mitimroot__
+
+cold_start = True
+
+(__mitimroot__ / "tests" / "scratch").mkdir(parents=True, exist_ok=True)
+
+input_gacode = __mitimroot__ / "tests" / "data" / "input.gacode"
+rhos = [0.5, 0.7]
+
+# ── single-point runs (zero file I/O) ───────────────────────────────────────
+
+# in_process=True: no folder needed — prep() works with just the input file
+tglf = TGLFtools.TGLF(rhos=rhos, in_process=True)
+tglf.prep(input_gacode)
+
+tglf.run("run1/", code_settings="SAT1", cold_start=cold_start, forceIfcold_start=True)
+tglf.read(label="SAT1")
+
+tglf.run("run2/", code_settings="SAT1", cold_start=cold_start, forceIfcold_start=True,
+         extraOptions={"USE_BPER": True, "USE_BPAR": True})
+tglf.read(label="SAT1 EM")
+
+print(f"\nQe (SAT1):    {[f'{r.Qe:.4f}' for r in tglf.results['SAT1']['output']]}")
+print(f"Qe (SAT1 EM): {[f'{r.Qe:.4f}' for r in tglf.results['SAT1 EM']['output']]}")
+
+# ── runScanTurbulenceDrives: subprocess vs in-process comparison ─────────────
+
+DRIVES_KWARGS = dict(
+    code_settings="SAT1",
+    resolutionPoints=3,
+    variablesDrives=["RLTS_1", "RLTS_2", "RLNS_1"],
+    cold_start=cold_start,
+    forceIfcold_start=True,
+)
+
+# subprocess run
+folder_sub = __mitimroot__ / "tests" / "scratch" / "tglf_drives_sub"
+if cold_start and folder_sub.exists():
+    os.system(f"rm -r {folder_sub.resolve()}")
+
+tglf_sub = TGLFtools.TGLF(rhos=rhos, in_process=False)
+tglf_sub.prep(input_gacode, folder_sub)
+tglf_sub.runScanTurbulenceDrives(subfolder="drives", **DRIVES_KWARGS)
+
+# in-process run (zero file I/O)
+folder_ip = __mitimroot__ / "tests" / "scratch" / "tglf_drives_ip"
+if cold_start and folder_ip.exists():
+    os.system(f"rm -r {folder_ip.resolve()}")
+
+tglf_ip = TGLFtools.TGLF(rhos=rhos, in_process=True)
+tglf_ip.prep(input_gacode, folder_ip)
+tglf_ip.runScanTurbulenceDrives(subfolder="drives", **DRIVES_KWARGS)
+
+# comparison
+shared_labels = sorted(k for k in tglf_sub.results if k in tglf_ip.results)
+print(f"\n{'='*65}")
+print(f"Comparing {len(shared_labels)} scan labels across {len(rhos)} rhos")
+print(f"{'='*65}")
+
+all_ok = True
+for label in shared_labels:
+    out_sub = tglf_sub.results[label]["output"]
+    out_ip  = tglf_ip.results[label]["output"]
+    for i, rho in enumerate(rhos):
+        Qe_s, Qe_i = out_sub[i].Qe, out_ip[i].Qe
+        Qi_s, Qi_i = out_sub[i].Qi, out_ip[i].Qi
+        # The subprocess reads fluxes from out.tglf.gbflux (limited file precision
+        # ~4-5 significant figures); in-process retains full double precision.
+        # rtol=1e-3 (0.1 %) is tight enough to catch physics disagreements.
+        ok = np.isclose(Qe_s, Qe_i, rtol=1e-3) and np.isclose(Qi_s, Qi_i, rtol=1e-3)
+        if not ok:
+            all_ok = False
+        status = "PASS" if ok else "FAIL"
+        print(
+            f"  [{status}]  {label:<40s}  rho={rho:.2f}"
+            f"  Qe: {Qe_s:.6f} vs {Qe_i:.6f}"
+            f"  Qi: {Qi_s:.6f} vs {Qi_i:.6f}"
+        )
+
+print(f"\n{'='*65}")
+print(f"Overall: {'ALL PASS' if all_ok else 'FAILURES DETECTED'}")
+print(f"{'='*65}")

--- a/tests/TGLFworkflow_inprocess.py
+++ b/tests/TGLFworkflow_inprocess.py
@@ -64,13 +64,9 @@ tglf_sub = TGLFtools.TGLF(rhos=rhos, in_process=False)
 tglf_sub.prep(input_gacode, folder_sub)
 tglf_sub.runScanTurbulenceDrives(subfolder="drives", **DRIVES_KWARGS)
 
-# in-process run (zero file I/O)
-folder_ip = __mitimroot__ / "tests" / "scratch" / "tglf_drives_ip"
-if cold_start and folder_ip.exists():
-    os.system(f"rm -r {folder_ip.resolve()}")
-
+# in-process run (zero file I/O — no folder needed at any step)
 tglf_ip = TGLFtools.TGLF(rhos=rhos, in_process=True)
-tglf_ip.prep(input_gacode, folder_ip)
+tglf_ip.prep(input_gacode)
 tglf_ip.runScanTurbulenceDrives(subfolder="drives", **DRIVES_KWARGS)
 
 # comparison

--- a/tests/test_derivative_roundtrip.py
+++ b/tests/test_derivative_roundtrip.py
@@ -1,0 +1,608 @@
+"""
+Comprehensive test and visualization of the T -> a/LT -> T roundtrip problem.
+
+Compares the old Lagrange-polynomial derivative (derivation_into_Lx_lagrange)
+with the new central-difference derivative (derivation_into_Lx) that is matched
+to integration_Lx. Performs roundtrips on both fine and coarse grids, with
+varying resolution.
+
+Usage:
+    python tests/test_derivative_roundtrip.py
+"""
+
+import numpy as np
+import torch
+from mitim_tools.gacode_tools import PROFILEStools
+from mitim_tools.misc_tools import GUItools
+from mitim_modules.powertorch.utils import CALCtools
+from mitim_tools import __mitimroot__
+
+# ============================================================================
+# Load data
+# ============================================================================
+
+print("\nLoading input.gacode...")
+profiles = PROFILEStools.gacode_state(__mitimroot__ / "tests" / "data" / "input.gacode")
+
+rho = profiles.profiles["rho(-)"]
+roa = profiles.derived["roa"]  # r/a coordinate
+te = profiles.profiles["te(keV)"]
+ti = profiles.profiles["ti(keV)"][:, 0]  # First thermal ion
+ne = profiles.profiles["ne(10^19/m^3)"]
+
+all_profiles = {
+    r"$T_e$ (keV)": te,
+    r"$T_i$ (keV)": ti,
+    r"$n_e$ ($10^{19}/m^3$)": ne,
+}
+profile_short = ["Te", "Ti", "ne"]
+profile_labels = list(all_profiles.keys())
+profile_arrays = list(all_profiles.values())
+
+# Coarse grid: 5 radial points (typical PORTALS setup)
+rho_coarse = np.array([0.2, 0.4, 0.55, 0.7, 0.85])
+roa_coarse = np.interp(rho_coarse, rho, roa)
+coarse_indices = [np.argmin(np.abs(roa - rc)) for rc in roa_coarse]
+
+# High-resolution grid (like PORTALS improve_resolution_profiles)
+N_hires = 200
+rho_hires = np.linspace(rho[0], rho[-1], N_hires)
+roa_hires = np.interp(rho_hires, rho, roa)
+hires_profiles = [np.interp(rho_hires, rho, p) for p in profile_arrays]
+coarse_indices_hires = [np.argmin(np.abs(roa_hires - rc)) for rc in roa_coarse]
+
+
+# ============================================================================
+# Helper functions
+# ============================================================================
+
+def fine_grid_roundtrip(roa_arr, profile_arr, deriv_func):
+    """T -> a/LT -> T on the fine grid."""
+    r_torch = torch.from_numpy(roa_arr).unsqueeze(0).double()
+    p_torch = torch.from_numpy(profile_arr).unsqueeze(0).double()
+    aLT = deriv_func(r_torch[0], p_torch[0], array=False)
+    aLT_batch = aLT.unsqueeze(0)
+    T_reconstructed = CALCtools.integration_Lx(r_torch, aLT_batch, p_torch[0, -1])
+    return aLT.numpy(), T_reconstructed[0].numpy()
+
+
+def coarse_grid_roundtrip(roa_arr, profile_arr, coarse_idx, deriv_func):
+    """
+    PORTALS-like roundtrip:
+    T -> a/LT (fine) -> sample at coarse -> piecewise-linear interp -> integrate -> T
+
+    The BC is at the last coarse point (e.g. rho=0.85), and the integration
+    only covers [0, roa_last_coarse]. This mirrors PORTALS, which fixes T at
+    the last prediction radius and stitches the original trailing edge beyond.
+    """
+    r_torch = torch.from_numpy(roa_arr).double()
+    p_torch = torch.from_numpy(profile_arr).double()
+    aLT_fine = deriv_func(r_torch, p_torch, array=False).numpy()
+
+    # Control points: zero at axis + values at coarse locations
+    roa_cp = np.concatenate([[0.0], roa_arr[coarse_idx]])
+    aLT_cp = np.concatenate([[0.0], aLT_fine[coarse_idx]])
+
+    # Only work on the domain [0, last coarse point]
+    ir_last = coarse_idx[-1]
+    roa_domain = roa_arr[: ir_last + 1]
+    prof_domain = profile_arr[: ir_last + 1]
+
+    # Piecewise-linear interpolation of gradients within the domain
+    aLT_interp = np.interp(roa_domain, roa_cp, aLT_cp)
+
+    # BC at the last coarse point
+    f_bound = p_torch[ir_last]
+
+    r_batch = torch.from_numpy(roa_domain).unsqueeze(0).double()
+    aLT_batch = torch.from_numpy(aLT_interp).unsqueeze(0).double()
+    T_reconstructed = CALCtools.integration_Lx(r_batch, aLT_batch, f_bound)
+
+    return (aLT_fine, aLT_cp, roa_cp, aLT_interp,
+            T_reconstructed[0].numpy(), roa_domain, prof_domain)
+
+
+def relative_error(original, reconstructed):
+    """Relative error (%), avoiding division by zero."""
+    with np.errstate(divide="ignore", invalid="ignore"):
+        err = np.abs((reconstructed - original) / original) * 100.0
+        err[~np.isfinite(err)] = 0.0
+    return err
+
+
+# ============================================================================
+# Create FigureNotebook
+# ============================================================================
+
+fn = GUItools.FigureNotebook("Derivative Roundtrip Analysis", geometry="1800x950")
+
+# ============================================================================
+# Tab 1: Original profiles overview
+# ============================================================================
+
+fig = fn.add_figure(label="Original Profiles")
+grid = fig.add_gridspec(1, 3)
+for col, (label, prof) in enumerate(all_profiles.items()):
+    ax = fig.add_subplot(grid[0, col])
+    ax.plot(rho, prof, "k-o", lw=2, ms=3)
+    ax.set_xlabel(r"$\rho$")
+    ax.set_ylabel(label)
+    ax.set_xlim(0, 1)
+    ax.grid(True, alpha=0.3)
+    ax.set_title(f"{len(rho)} grid points")
+
+
+# ============================================================================
+# Tab 2: Derivative comparison (Lagrange vs Central Difference)
+# ============================================================================
+
+fig = fn.add_figure(label="Derivative Comparison")
+grid = fig.add_gridspec(3, 3, hspace=0.4, wspace=0.35)
+
+for row in range(3):
+    for icol, (r_arr, p_arr, rh_arr, nlabel) in enumerate([
+        (roa, profile_arrays[row], rho, f"Original ({len(rho)} pts)"),
+        (roa_hires, hires_profiles[row], rho_hires, f"Hi-res ({N_hires} pts)"),
+    ]):
+        r_t = torch.from_numpy(r_arr).double()
+        p_t = torch.from_numpy(p_arr).double()
+        aLT_lagrange = CALCtools.derivation_into_Lx(r_t, p_t, array=False).numpy()
+        aLT_central = CALCtools.derivation_into_Lx_central(r_t, p_t, array=False).numpy()
+
+        ax = fig.add_subplot(grid[row, icol])
+        ax.plot(rh_arr, aLT_lagrange, "b-", lw=1.5, label="Lagrange (old)")
+        ax.plot(rh_arr, aLT_central, "r--", lw=1.5, label="Central diff (new)")
+        ax.axhline(0, color="gray", lw=0.5)
+        ax.set_ylabel(f"a/L for {profile_labels[row]}")
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=8)
+        ax.set_title(nlabel)
+        ax.grid(True, alpha=0.3)
+
+    # Difference column
+    ax = fig.add_subplot(grid[row, 2])
+    r_t = torch.from_numpy(roa).double()
+    p_t = torch.from_numpy(profile_arrays[row]).double()
+    diff_orig = (CALCtools.derivation_into_Lx_central(r_t, p_t, array=False).numpy()
+                 - CALCtools.derivation_into_Lx(r_t, p_t, array=False).numpy())
+    r_t2 = torch.from_numpy(roa_hires).double()
+    p_t2 = torch.from_numpy(hires_profiles[row]).double()
+    diff_hires = (CALCtools.derivation_into_Lx_central(r_t2, p_t2, array=False).numpy()
+                  - CALCtools.derivation_into_Lx(r_t2, p_t2, array=False).numpy())
+    ax.plot(rho, diff_orig, "g-o", lw=1.5, ms=3, label=f"Orig (max={np.max(np.abs(diff_orig)):.3f})")
+    ax.plot(rho_hires, diff_hires, "m-", lw=1, label=f"Hi-res (max={np.max(np.abs(diff_hires)):.4f})")
+    ax.axhline(0, color="gray", lw=0.5)
+    ax.set_ylabel("Central - Lagrange")
+    ax.set_xlabel(r"$\rho$")
+    ax.legend(fontsize=8)
+    ax.set_title("Difference (converges with resolution)")
+    ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Tab 3: Fine-grid roundtrip on both original and hi-res grids
+# ============================================================================
+
+fig = fn.add_figure(label="Fine-Grid Roundtrip")
+grid = fig.add_gridspec(3, 4, hspace=0.45, wspace=0.35)
+
+for row in range(3):
+    for icol, (r_arr, p_arr, rh_arr, nlabel) in enumerate([
+        (roa, profile_arrays[row], rho, f"Original ({len(rho)} pts)"),
+        (roa_hires, hires_profiles[row], rho_hires, f"Hi-res ({N_hires} pts)"),
+    ]):
+        _, T_lag = fine_grid_roundtrip(r_arr, p_arr, CALCtools.derivation_into_Lx)
+        _, T_cen = fine_grid_roundtrip(r_arr, p_arr, CALCtools.derivation_into_Lx_central)
+        err_lag = relative_error(p_arr, T_lag)
+        err_cen = relative_error(p_arr, T_cen)
+
+        ax = fig.add_subplot(grid[row, icol * 2])
+        ax.plot(rh_arr, p_arr, "k-", lw=2, label="Original")
+        ax.plot(rh_arr, T_lag, "b--", lw=1.5, label="Lagrange")
+        ax.plot(rh_arr, T_cen, "r:", lw=2, label="Central diff")
+        ax.set_ylabel(profile_labels[row])
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=7)
+        ax.set_title(nlabel)
+        ax.grid(True, alpha=0.3)
+
+        ax = fig.add_subplot(grid[row, icol * 2 + 1])
+        ax.semilogy(rh_arr[1:], err_lag[1:], "b-", lw=1.5,
+                     label=f"Lagrange (max={np.max(err_lag[1:]):.3f}%)")
+        ax.semilogy(rh_arr[1:], err_cen[1:], "r-", lw=1.5,
+                     label=f"Central (max={np.max(err_cen[1:]):.3f}%)")
+        ax.set_ylabel("Relative error (%)")
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=6)
+        ax.set_title(f"Error - {nlabel}")
+        ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Tab 4: Coarse-grid roundtrip (5 control points) on both grids
+# ============================================================================
+
+fig = fn.add_figure(label="Coarse-Grid Roundtrip (5 pts)")
+fig.suptitle(r"Coarse-Grid Roundtrip, 5 control points at $\rho$ = " + str(list(rho_coarse))
+             + r", BC at last point", fontsize=11)
+grid = fig.add_gridspec(3, 4, hspace=0.45, wspace=0.35)
+
+for row in range(3):
+    for icol, (r_arr, p_arr, rh_arr, c_idx, nlabel) in enumerate([
+        (roa, profile_arrays[row], rho, coarse_indices, f"Orig ({len(rho)} pts)"),
+        (roa_hires, hires_profiles[row], rho_hires, coarse_indices_hires, f"Hi-res ({N_hires} pts)"),
+    ]):
+        aLT_f_lag, aLT_cp_lag, roa_cp, aLT_i_lag, T_c_lag, roa_dom_lag, p_dom_lag = coarse_grid_roundtrip(
+            r_arr, p_arr, c_idx, CALCtools.derivation_into_Lx)
+        aLT_f_cen, aLT_cp_cen, _, aLT_i_cen, T_c_cen, roa_dom_cen, p_dom_cen = coarse_grid_roundtrip(
+            r_arr, p_arr, c_idx, CALCtools.derivation_into_Lx_central)
+        rho_cp = np.interp(roa_cp, r_arr, rh_arr)
+        rho_dom = np.interp(roa_dom_lag, r_arr, rh_arr)
+
+        ax = fig.add_subplot(grid[row, icol * 2])
+        ax.plot(rh_arr, aLT_f_lag, "b-", lw=1, alpha=0.4, label="Fine (Lagrange)")
+        ax.plot(rh_arr, aLT_f_cen, "r-", lw=1, alpha=0.4, label="Fine (Central)")
+        ax.plot(rho_dom, aLT_i_lag, "b--", lw=1.5, alpha=0.8, label="Interp (Lagrange)")
+        ax.plot(rho_dom, aLT_i_cen, "r:", lw=2, alpha=0.8, label="Interp (Central)")
+        ax.plot(rho_cp, aLT_cp_lag, "bs", ms=6, zorder=5)
+        ax.plot(rho_cp, aLT_cp_cen, "r^", ms=6, zorder=5)
+        ax.axvline(rho_dom[-1], color="gray", ls="--", lw=0.8, alpha=0.6, label="BC")
+        ax.set_ylabel(f"a/L for {profile_labels[row]}")
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=5)
+        ax.set_title(f"Gradients - {nlabel}")
+        ax.grid(True, alpha=0.3)
+
+        err_lag = relative_error(p_dom_lag, T_c_lag)
+        err_cen = relative_error(p_dom_cen, T_c_cen)
+        ax = fig.add_subplot(grid[row, icol * 2 + 1])
+        ax.plot(rho_dom, p_dom_lag, "k-", lw=2, label="Original")
+        ax.plot(rho_dom, T_c_lag, "b--", lw=1.5, label=f"Lagrange (err max={np.max(err_lag[1:]):.2f}%)")
+        ax.plot(rho_dom, T_c_cen, "r:", lw=2, label=f"Central (err max={np.max(err_cen[1:]):.2f}%)")
+        ax.axvline(rho_dom[-1], color="gray", ls="--", lw=0.8, alpha=0.6)
+        ax.set_ylabel(profile_labels[row])
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=6)
+        ax.set_title(f"Profiles - {nlabel}")
+        ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Tab 5: Error at control points (bar charts)
+# ============================================================================
+
+fig = fn.add_figure(label="Error at Control Points")
+grid = fig.add_gridspec(2, 3, hspace=0.4, wspace=0.35)
+
+for col in range(3):
+    _, _, _, _, T_c_lag, _, p_dom = coarse_grid_roundtrip(
+        roa_hires, hires_profiles[col], coarse_indices_hires, CALCtools.derivation_into_Lx)
+    _, _, _, _, T_c_cen, _, _ = coarse_grid_roundtrip(
+        roa_hires, hires_profiles[col], coarse_indices_hires, CALCtools.derivation_into_Lx_central)
+
+    # coarse_indices_hires are all <= ir_last, so valid in the truncated arrays
+    orig_at_cp = p_dom[coarse_indices_hires]
+    lag_at_cp = T_c_lag[coarse_indices_hires]
+    cen_at_cp = T_c_cen[coarse_indices_hires]
+    err_lag_cp = np.abs((lag_at_cp - orig_at_cp) / orig_at_cp) * 100.0
+    err_cen_cp = np.abs((cen_at_cp - orig_at_cp) / orig_at_cp) * 100.0
+
+    x_pos = np.arange(len(rho_coarse))
+    width = 0.35
+
+    ax = fig.add_subplot(grid[0, col])
+    ax.bar(x_pos - width / 2, orig_at_cp, width * 0.9, label="Original", color="gray", alpha=0.8)
+    ax.bar(x_pos - width / 2, lag_at_cp, width * 0.9, label="Lagrange", color="blue", alpha=0.3)
+    ax.bar(x_pos + width / 2, cen_at_cp, width * 0.9, label="Central", color="red", alpha=0.3)
+    ax.set_xticks(x_pos)
+    ax.set_xticklabels([f"{r:.2f}" for r in rho_coarse])
+    ax.set_xlabel(r"$\rho$")
+    ax.set_ylabel(profile_labels[col])
+    ax.legend(fontsize=7)
+    ax.set_title(f"{profile_labels[col]} at control points")
+
+    ax = fig.add_subplot(grid[1, col])
+    ax.bar(x_pos - width / 2, err_lag_cp, width,
+           label=f"Lagrange (mean={np.mean(err_lag_cp):.2f}%)", color="blue", alpha=0.7)
+    ax.bar(x_pos + width / 2, err_cen_cp, width,
+           label=f"Central (mean={np.mean(err_cen_cp):.2f}%)", color="red", alpha=0.7)
+    ax.set_xticks(x_pos)
+    ax.set_xticklabels([f"{r:.2f}" for r in rho_coarse])
+    ax.set_xlabel(r"$\rho$")
+    ax.set_ylabel("Relative error (%)")
+    ax.legend(fontsize=7)
+
+
+# ============================================================================
+# Tab 6: Analytic test with exact solution
+# ============================================================================
+
+fig = fn.add_figure(label="Analytic Test")
+fig.suptitle(r"Analytic: $T(r) = T_0 (1 - (r/a)^2)^2$, exact $a/L_T = 4x/(1-x^2)$", fontsize=11)
+grid = fig.add_gridspec(2, 4, hspace=0.4, wspace=0.35)
+
+N_an = 201
+roa_an = np.linspace(1e-4, 0.95, N_an)
+T0 = 5.0
+T_an = T0 * (1.0 - roa_an**2) ** 2
+aLT_exact = 4.0 * roa_an / (1.0 - roa_an**2 + 1e-30)
+
+r_t = torch.from_numpy(roa_an).double()
+p_t = torch.from_numpy(T_an).double()
+aLT_lag_an = CALCtools.derivation_into_Lx(r_t, p_t, array=False).numpy()
+aLT_cen_an = CALCtools.derivation_into_Lx_central(r_t, p_t, array=False).numpy()
+
+_, T_rt_lag = fine_grid_roundtrip(roa_an, T_an, CALCtools.derivation_into_Lx)
+_, T_rt_cen = fine_grid_roundtrip(roa_an, T_an, CALCtools.derivation_into_Lx_central)
+
+roa_coarse_an = np.array([0.15, 0.35, 0.5, 0.65, 0.8])
+ci_an = [np.argmin(np.abs(roa_an - rc)) for rc in roa_coarse_an]
+_, aLT_cp_lag, rcp_lag, aLT_i_lag, T_c_lag, roa_dom_an, p_dom_an = coarse_grid_roundtrip(
+    roa_an, T_an, ci_an, CALCtools.derivation_into_Lx)
+_, aLT_cp_cen, rcp_cen, aLT_i_cen, T_c_cen, _, _ = coarse_grid_roundtrip(
+    roa_an, T_an, ci_an, CALCtools.derivation_into_Lx_central)
+aLT_exact_dom = 4.0 * roa_dom_an / (1.0 - roa_dom_an**2 + 1e-30)
+
+# Row 0: Fine grid
+ax = fig.add_subplot(grid[0, 0])
+ax.plot(roa_an, aLT_exact, "k-", lw=2, label="Exact")
+ax.plot(roa_an, aLT_lag_an, "b--", lw=1.5, label="Lagrange")
+ax.plot(roa_an, aLT_cen_an, "r:", lw=2, label="Central diff")
+ax.set_ylabel("a/LT"); ax.set_xlabel("r/a"); ax.set_ylim(0, 20)
+ax.legend(fontsize=8); ax.set_title("Fine: Derivatives vs Exact"); ax.grid(True, alpha=0.3)
+
+ax = fig.add_subplot(grid[0, 1])
+ax.semilogy(roa_an[1:-1], np.abs(aLT_lag_an[1:-1] - aLT_exact[1:-1]), "b-", lw=1.5, label="Lagrange")
+ax.semilogy(roa_an[1:-1], np.abs(aLT_cen_an[1:-1] - aLT_exact[1:-1]), "r-", lw=1.5, label="Central diff")
+ax.set_ylabel("|Error in a/LT|"); ax.set_xlabel("r/a")
+ax.legend(fontsize=8); ax.set_title("Fine: Derivative Error"); ax.grid(True, alpha=0.3)
+
+ax = fig.add_subplot(grid[0, 2])
+ax.plot(roa_an, T_an, "k-", lw=2, label="Original")
+ax.plot(roa_an, T_rt_lag, "b--", lw=1.5, label="Lagrange")
+ax.plot(roa_an, T_rt_cen, "r:", lw=2, label="Central diff")
+ax.set_ylabel("T (keV)"); ax.set_xlabel("r/a")
+ax.legend(fontsize=8); ax.set_title("Fine: Roundtrip"); ax.grid(True, alpha=0.3)
+
+ax = fig.add_subplot(grid[0, 3])
+err_lag_an = relative_error(T_an, T_rt_lag)
+err_cen_an = relative_error(T_an, T_rt_cen)
+ax.semilogy(roa_an[1:], err_lag_an[1:], "b-", lw=1.5,
+            label=f"Lagrange (max={np.max(err_lag_an[1:]):.4f}%)")
+ax.semilogy(roa_an[1:], err_cen_an[1:], "r-", lw=1.5,
+            label=f"Central (max={np.max(err_cen_an[1:]):.4f}%)")
+ax.set_ylabel("Relative error (%)"); ax.set_xlabel("r/a")
+ax.legend(fontsize=7); ax.set_title("Fine: Roundtrip Error"); ax.grid(True, alpha=0.3)
+
+# Row 1: Coarse grid (domain up to last coarse point only)
+ax = fig.add_subplot(grid[1, 0])
+ax.plot(roa_dom_an, aLT_exact_dom, "k-", lw=1, alpha=0.4, label="Exact")
+ax.plot(roa_dom_an, aLT_i_lag, "b--", lw=1.5, label="Interp (Lagrange)")
+ax.plot(roa_dom_an, aLT_i_cen, "r:", lw=2, label="Interp (Central)")
+ax.plot(rcp_lag, aLT_cp_lag, "bs", ms=7, zorder=5)
+ax.plot(rcp_cen, aLT_cp_cen, "r^", ms=7, zorder=5)
+ax.axvline(roa_dom_an[-1], color="gray", ls="--", lw=0.8, alpha=0.6, label="BC")
+ax.set_ylabel("a/LT"); ax.set_xlabel("r/a"); ax.set_ylim(0, 20)
+ax.legend(fontsize=7); ax.set_title("Coarse: Piecewise-linear"); ax.grid(True, alpha=0.3)
+
+ax = fig.add_subplot(grid[1, 1])
+ax.plot(roa_dom_an, np.abs(aLT_i_lag - aLT_exact_dom), "b-", lw=1.5, label="Lagrange")
+ax.plot(roa_dom_an, np.abs(aLT_i_cen - aLT_exact_dom), "r-", lw=1.5, label="Central diff")
+ax.set_ylabel("|Gradient interp error|"); ax.set_xlabel("r/a")
+ax.legend(fontsize=8); ax.set_title("Coarse: Interp Error"); ax.grid(True, alpha=0.3)
+
+ax = fig.add_subplot(grid[1, 2])
+ax.plot(roa_dom_an, p_dom_an, "k-", lw=2, label="Original")
+ax.plot(roa_dom_an, T_c_lag, "b--", lw=1.5, label="Lagrange")
+ax.plot(roa_dom_an, T_c_cen, "r:", lw=2, label="Central diff")
+ax.axvline(roa_dom_an[-1], color="gray", ls="--", lw=0.8, alpha=0.6)
+ax.set_ylabel("T (keV)"); ax.set_xlabel("r/a")
+ax.legend(fontsize=8); ax.set_title("Coarse: Roundtrip"); ax.grid(True, alpha=0.3)
+
+ax = fig.add_subplot(grid[1, 3])
+err_c_lag = relative_error(p_dom_an, T_c_lag)
+err_c_cen = relative_error(p_dom_an, T_c_cen)
+ax.semilogy(roa_dom_an[1:], err_c_lag[1:], "b-", lw=1.5,
+            label=f"Lagrange (max={np.max(err_c_lag[1:]):.2f}%)")
+ax.semilogy(roa_dom_an[1:], err_c_cen[1:], "r-", lw=1.5,
+            label=f"Central (max={np.max(err_c_cen[1:]):.2f}%)")
+ax.set_ylabel("Relative error (%)"); ax.set_xlabel("r/a")
+ax.legend(fontsize=7); ax.set_title("Coarse: Roundtrip Error"); ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Tab 7: Grid resolution convergence study
+# ============================================================================
+
+fig = fn.add_figure(label="Resolution Convergence")
+grid = fig.add_gridspec(1, 3, wspace=0.3)
+
+resolutions = [21, 41, 81, 101, 151, 201, 301, 501]
+
+for col in range(3):
+    max_err_lag_res, max_err_cen_res = [], []
+    for N in resolutions:
+        roa_test = np.linspace(roa[0], roa[-1], N)
+        p_test = np.interp(roa_test, roa, profile_arrays[col])
+        _, T_lag = fine_grid_roundtrip(roa_test, p_test, CALCtools.derivation_into_Lx)
+        _, T_cen = fine_grid_roundtrip(roa_test, p_test, CALCtools.derivation_into_Lx_central)
+        max_err_lag_res.append(np.max(relative_error(p_test, T_lag)[1:]))
+        max_err_cen_res.append(np.max(relative_error(p_test, T_cen)[1:]))
+
+    ax = fig.add_subplot(grid[0, col])
+    ax.loglog(resolutions, max_err_lag_res, "b-o", lw=2, ms=6, label="Lagrange (old)")
+    ax.loglog(resolutions, max_err_cen_res, "r-s", lw=2, ms=6, label="Central diff (new)")
+    h = np.array(resolutions, dtype=float)
+    ref2 = max_err_lag_res[0] * (h / h[0]) ** (-2)
+    ax.loglog(resolutions, ref2, "k--", lw=0.8, alpha=0.5, label=r"$\propto N^{-2}$")
+    ax.set_xlabel("Number of grid points")
+    ax.set_ylabel("Max relative error (%)")
+    ax.set_title(profile_short[col])
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3, which="both")
+
+
+# ============================================================================
+# Tab 8: Summary bar chart
+# ============================================================================
+
+fig = fn.add_figure(label="Summary")
+grid = fig.add_gridspec(1, 3, wspace=0.3)
+
+categories = [
+    f"Fine\n({len(rho)} pts)",
+    f"Fine\n({N_hires} pts)",
+    f"Coarse 5pts\n({len(rho)} pts)",
+    f"Coarse 5pts\n({N_hires} pts)",
+]
+
+all_errors_lag = [[] for _ in range(4)]
+all_errors_cen = [[] for _ in range(4)]
+
+for i in range(3):
+    _, T = fine_grid_roundtrip(roa, profile_arrays[i], CALCtools.derivation_into_Lx)
+    all_errors_lag[0].append(np.max(relative_error(profile_arrays[i], T)[1:]))
+    _, T = fine_grid_roundtrip(roa, profile_arrays[i], CALCtools.derivation_into_Lx_central)
+    all_errors_cen[0].append(np.max(relative_error(profile_arrays[i], T)[1:]))
+
+    hp = hires_profiles[i]
+    _, T = fine_grid_roundtrip(roa_hires, hp, CALCtools.derivation_into_Lx)
+    all_errors_lag[1].append(np.max(relative_error(hp, T)[1:]))
+    _, T = fine_grid_roundtrip(roa_hires, hp, CALCtools.derivation_into_Lx_central)
+    all_errors_cen[1].append(np.max(relative_error(hp, T)[1:]))
+
+    _, _, _, _, T, _, p_dom = coarse_grid_roundtrip(roa, profile_arrays[i], coarse_indices, CALCtools.derivation_into_Lx)
+    all_errors_lag[2].append(np.max(relative_error(p_dom, T)[1:]))
+    _, _, _, _, T, _, p_dom = coarse_grid_roundtrip(roa, profile_arrays[i], coarse_indices, CALCtools.derivation_into_Lx_central)
+    all_errors_cen[2].append(np.max(relative_error(p_dom, T)[1:]))
+
+    _, _, _, _, T, _, p_dom = coarse_grid_roundtrip(roa_hires, hp, coarse_indices_hires, CALCtools.derivation_into_Lx)
+    all_errors_lag[3].append(np.max(relative_error(p_dom, T)[1:]))
+    _, _, _, _, T, _, p_dom = coarse_grid_roundtrip(roa_hires, hp, coarse_indices_hires, CALCtools.derivation_into_Lx_central)
+    all_errors_cen[3].append(np.max(relative_error(p_dom, T)[1:]))
+
+for col in range(3):
+    ax = fig.add_subplot(grid[0, col])
+    x = np.arange(len(categories))
+    width = 0.35
+    lag_vals = [all_errors_lag[j][col] for j in range(4)]
+    cen_vals = [all_errors_cen[j][col] for j in range(4)]
+    bars1 = ax.bar(x - width / 2, lag_vals, width, label="Lagrange (old)", color="blue", alpha=0.7)
+    bars2 = ax.bar(x + width / 2, cen_vals, width, label="Central diff (new)", color="red", alpha=0.7)
+    ax.set_xticks(x)
+    ax.set_xticklabels(categories, fontsize=8)
+    ax.set_ylabel("Max relative error (%)")
+    ax.set_title(profile_short[col])
+    ax.legend(fontsize=8)
+    ax.bar_label(bars1, fmt="%.2f%%", fontsize=7, padding=2)
+    ax.bar_label(bars2, fmt="%.2f%%", fontsize=7, padding=2)
+    ax.grid(True, alpha=0.3, axis="y")
+
+
+# ============================================================================
+# Tab 9: Multi-pass degradation (original -> 1 pass -> 2 passes -> 3 passes)
+# ============================================================================
+
+def multi_pass_coarse_roundtrip(roa_arr, profile_arr, coarse_idx, deriv_func, n_passes):
+    """
+    Perform n successive T -> a/LT -> T roundtrips through the coarse
+    parameterization. BC is always fixed to the original profile value
+    at the last coarse point (as PORTALS does).
+    """
+    ir_last = coarse_idx[-1]
+    roa_dom = roa_arr[: ir_last + 1]
+    roa_cp = np.concatenate([[0.0], roa_arr[coarse_idx]])
+    bc_value = profile_arr[ir_last]  # fixed BC from original
+
+    current_T = profile_arr[: ir_last + 1].copy()
+    results = []  # (aLT_on_domain, T_result) per pass
+
+    for _ in range(n_passes):
+        r_t = torch.from_numpy(roa_dom).double()
+        p_t = torch.from_numpy(current_T).double()
+        aLT = deriv_func(r_t, p_t, array=False).numpy()
+
+        aLT_cp = np.concatenate([[0.0], aLT[coarse_idx]])
+        aLT_interp = np.interp(roa_dom, roa_cp, aLT_cp)
+
+        r_b = torch.from_numpy(roa_dom).unsqueeze(0).double()
+        z_b = torch.from_numpy(aLT_interp).unsqueeze(0).double()
+        T_new = CALCtools.integration_Lx(r_b, z_b, torch.tensor(bc_value).double())[0].numpy()
+
+        results.append((aLT_interp.copy(), T_new.copy()))
+        current_T = T_new
+
+    return roa_dom, profile_arr[: ir_last + 1], results
+
+
+pass_colors = ["k", "#1f77b4", "#ff7f0e", "#d62728"]
+pass_styles = ["-", "--", "-.", ":"]
+pass_labels = ["Original", "1 pass", "2 passes", "3 passes"]
+
+fig = fn.add_figure(label="Multi-Pass Degradation")
+grid = fig.add_gridspec(6, 2, hspace=0.55, wspace=0.3)
+fig.suptitle("Profile degradation through repeated coarse-grid roundtrips (BC fixed at last control point)", fontsize=11)
+
+for method_row, (deriv_func, method_name) in enumerate([
+    (CALCtools.derivation_into_Lx_central, "Central diff"),
+    (CALCtools.derivation_into_Lx, "Lagrange (GACODE-matched)"),
+]):
+    for prof_idx in range(3):
+        row = method_row * 3 + prof_idx
+
+        roa_dom, p_orig, passes = multi_pass_coarse_roundtrip(
+            roa_hires, hires_profiles[prof_idx], coarse_indices_hires, deriv_func, n_passes=3)
+        rho_dom = np.interp(roa_dom, roa_hires, rho_hires)
+
+        # Also compute the original a/LT on the domain for comparison
+        r_t = torch.from_numpy(roa_dom).double()
+        p_t = torch.from_numpy(p_orig).double()
+        aLT_orig = deriv_func(r_t, p_t, array=False).numpy()
+
+        # -- Left: a/LT --
+        ax = fig.add_subplot(grid[row, 0])
+        ax.plot(rho_dom, aLT_orig, pass_colors[0], ls=pass_styles[0], lw=2, label=pass_labels[0])
+        for ip, (aLT_p, _) in enumerate(passes):
+            ax.plot(rho_dom, aLT_p, pass_colors[ip + 1], ls=pass_styles[ip + 1], lw=1.5,
+                    label=pass_labels[ip + 1])
+        # Mark coarse control points on original
+        rho_cp = rho_hires[coarse_indices_hires]
+        ax.plot(rho_cp, aLT_orig[coarse_indices_hires], "ks", ms=5, zorder=5)
+        ax.set_ylabel(f"a/L {profile_short[prof_idx]}")
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=7, loc="best")
+        ax.set_title(f"{method_name} - a/L{profile_short[prof_idx]}")
+        ax.grid(True, alpha=0.3)
+
+        # -- Right: T --
+        ax = fig.add_subplot(grid[row, 1])
+        ax.plot(rho_dom, p_orig, pass_colors[0], ls=pass_styles[0], lw=2, label=pass_labels[0])
+        for ip, (_, T_p) in enumerate(passes):
+            err_max = np.max(relative_error(p_orig, T_p)[1:])
+            ax.plot(rho_dom, T_p, pass_colors[ip + 1], ls=pass_styles[ip + 1], lw=1.5,
+                    label=f"{pass_labels[ip + 1]} (err={err_max:.2f}%)")
+        ax.plot(rho_cp, p_orig[coarse_indices_hires], "ks", ms=5, zorder=5)
+        ax.axvline(rho_dom[-1], color="gray", ls="--", lw=0.8, alpha=0.5)
+        ax.set_ylabel(profile_labels[prof_idx])
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=7, loc="best")
+        ax.set_title(f"{method_name} - {profile_short[prof_idx]}")
+        ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Print summary and show
+# ============================================================================
+
+print("\n" + "=" * 90)
+print("ROUNDTRIP ERROR SUMMARY (Max Relative Error %)")
+print("=" * 90)
+print(f"{'Profile':<8} {'Fine Lag':>10} {'Fine Cen':>10} {'Fine200 Lag':>12} {'Fine200 Cen':>12} {'Coarse Lag':>12} {'Coarse Cen':>12}")
+print("-" * 90)
+for i, name in enumerate(profile_short):
+    print(f"{name:<8} {all_errors_lag[0][i]:>9.4f}% {all_errors_cen[0][i]:>9.4f}% "
+          f"{all_errors_lag[1][i]:>11.4f}% {all_errors_cen[1][i]:>11.4f}% "
+          f"{all_errors_lag[2][i]:>11.4f}% {all_errors_cen[2][i]:>11.4f}%")
+print("=" * 90)
+
+fn.show()

--- a/tests/test_neo_inprocess.py
+++ b/tests/test_neo_inprocess.py
@@ -1,0 +1,344 @@
+"""
+test_neo_inprocess.py
+=====================
+Benchmark and correctness test for the NEO in-process (ctypes) execution path
+vs. the standard subprocess path.
+
+Usage
+-----
+    # From the MITIM-fusion root, with GACODE_ROOT set:
+    pixi run -- python tests/test_neo_inprocess.py
+
+    # Optional: build the extension first (once per machine):
+    cd src/mitim_tools/simulation_tools/interfaces && bash build_neo_lib.sh
+
+What the script does
+--------------------
+1. Generates ``input.neo.gen`` from a NEO regression ``input.neo`` via
+   neo_parse.py.
+2. Runs the standard subprocess path (``neo -e .``) N times and records
+   wall time.
+3. Runs the in-process path (``c_neo_run()`` via ctypes) N times and records
+   wall time.
+4. Prints a side-by-side table of flux values and their relative differences.
+5. Prints the mean call time for each path and the speedup factor.
+6. Exits non-zero if any flux value differs by more than ``RTOL=1e-4``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+N_CALLS = 3            # NEO is much heavier than TGLF — keep this small
+RTOL    = 1e-4         # relative tolerance for correctness check
+ATOL    = 1e-10        # absolute floor: values below this are treated as zero
+                       # (NEO momentum flux can drop to ~1e-13 where the file's
+                       # 5-digit printf is dominated by numerical noise)
+# ---------------------------------------------------------------------------
+
+# Locate test data — use a NEO regression input from the gacode tree.
+_MITIMROOT = Path(__file__).parent.parent
+GACODE_ROOT = os.environ.get("GACODE_ROOT")
+if not GACODE_ROOT:
+    sys.exit("ERROR: GACODE_ROOT is not set. Source your gacode_setup script.")
+
+# Pick a small / fast NEO regression case.
+INPUT_NEO = Path(GACODE_ROOT) / "neo" / "tools" / "input" / "reg02" / "input.neo"
+SCRATCH    = _MITIMROOT / "tests" / "scratch" / "neo_inprocess_test"
+
+if not INPUT_NEO.exists():
+    sys.exit(f"ERROR: test input file not found: {INPUT_NEO}")
+
+
+# ---------------------------------------------------------------------------
+# Helper: read out.neo.transport_flux into a flat array (ordered)
+# ---------------------------------------------------------------------------
+def _parse_transport_flux(filepath: Path) -> dict:
+    """
+    Return a dict with 'dke', 'gv', 'tgyro' each → list of (Z, G, Q, M) rows
+    in the order they appear in the file.
+    """
+    if not filepath.exists():
+        raise FileNotFoundError(f"NEO output not found: {filepath}")
+
+    sections: dict[str, list[list[float]]] = {}
+    current = None
+    with open(filepath) as f:
+        for raw in f:
+            s = raw.strip()
+            if s.startswith("#"):
+                if "pflux_dke"     in s: current = "dke";   sections[current] = []
+                elif "pflux_gv"    in s: current = "gv";    sections[current] = []
+                elif "pflux_tgyro" in s: current = "tgyro"; sections[current] = []
+                # Other comment lines (units, headers) leave `current` alone.
+            elif current is not None and s and not s.startswith("("):
+                vals = s.split()
+                if len(vals) == 4:
+                    sections[current].append([float(v) for v in vals])
+    return sections
+
+
+def _flatten(sections: dict) -> tuple[list[str], np.ndarray]:
+    """Flatten parsed sections into labelled arrays for side-by-side comparison."""
+    labels: list[str] = []
+    values: list[float] = []
+    for sec_name in ("dke", "gv", "tgyro"):
+        rows = sections.get(sec_name, [])
+        for i, (Z, G, Q, M) in enumerate(rows):
+            labels.append(f"{sec_name}.G[{int(Z):+d}]")
+            values.append(G)
+            labels.append(f"{sec_name}.Q[{int(Z):+d}]")
+            values.append(Q)
+            labels.append(f"{sec_name}.M[{int(Z):+d}]")
+            values.append(M)
+    return labels, np.array(values)
+
+
+# ---------------------------------------------------------------------------
+# Helper: run the standard subprocess path once, return parsed sections
+# ---------------------------------------------------------------------------
+def _run_subprocess(work_dir: Path) -> dict:
+    """Run ``neo -e .`` in work_dir, return parsed transport_flux sections."""
+    result = subprocess.run(
+        ["neo", "-e", "."],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print("  STDERR:", result.stderr[-500:] if result.stderr else "(none)")
+        raise RuntimeError(f"neo subprocess failed (rc={result.returncode})")
+
+    return _parse_transport_flux(work_dir / "out.neo.transport_flux")
+
+
+# ---------------------------------------------------------------------------
+# Helper: run the in-process path once, return a "sections-like" dict from
+# the in-memory output dict so we can compare apples-to-apples.
+# ---------------------------------------------------------------------------
+def _outputs_to_sections(out: dict, Z_per_species: list[float], gb: tuple) -> dict:
+    """
+    Convert NEOInProcess.run() output → same shape as the file parser,
+    applying the GB normalization (pgb, egb, mgb) used by NEO when writing
+    out.neo.transport_flux.  The interface variables themselves are in
+    "norm" units (Gamma/Gamma_norm etc.), so we divide by the gb factors
+    to match the file output exactly.
+    """
+    ns = out["ns"]
+    Z = list(Z_per_species)[:ns]
+    pgb, egb, mgb = gb
+    sections = {"dke": [], "gv": [], "tgyro": []}
+    for k in range(ns):
+        sections["dke"].append([
+            Z[k],
+            out["pflux_dke"][k]    / pgb,
+            out["efluxtot_dke"][k] / egb,
+            out["mflux_dke"][k]    / mgb,
+        ])
+        sections["gv"].append([
+            Z[k],
+            out["pflux_gv"][k]    / pgb,
+            out["efluxtot_gv"][k] / egb,
+            out["mflux_gv"][k]    / mgb,
+        ])
+        sections["tgyro"].append([
+            Z[k],
+            (out["pflux_dke"][k]    + out["pflux_gv"][k])    / pgb,
+            (out["efluxtot_dke"][k] + out["efluxtot_gv"][k]) / egb,
+            (out["mflux_dke"][k]    + out["mflux_gv"][k])    / mgb,
+        ])
+    return sections
+
+
+def _read_gb_from_gen(gen_file: Path) -> tuple:
+    """
+    Compute (pgb, egb, mgb) the same way NEO does when writing
+    transport_flux: pgb = n_e * rho^2 * T_e^1.5, etc.  When AE_FLAG=1 the
+    electron density/temperature come from DENS_AE/TEMP_AE.
+    """
+    params: dict[str, float] = {}
+    with open(gen_file) as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) >= 2:
+                try:
+                    params[parts[1]] = float(parts[0])
+                except ValueError:
+                    pass  # non-numeric (e.g. RBF_DIR=d3d_4)
+
+    rho     = params.get("RHO_STAR", 1e-3)
+    ae_flag = int(params.get("AE_FLAG", 0))
+    if ae_flag == 1:
+        dens_e = params.get("DENS_AE", 1.0)
+        temp_e = params.get("TEMP_AE", 1.0)
+    else:
+        # find the species with Z = -1 (electrons)
+        ns = int(params.get("N_SPECIES", 1))
+        dens_e, temp_e = 1.0, 1.0
+        for i in range(1, ns + 1):
+            if int(params.get(f"Z_{i}", 0)) == -1:
+                dens_e = params.get(f"DENS_{i}", 1.0)
+                temp_e = params.get(f"TEMP_{i}", 1.0)
+                break
+
+    pgb = dens_e * rho**2 * temp_e**1.5
+    egb = dens_e * rho**2 * temp_e**2.5
+    mgb = dens_e * rho**2 * temp_e**2.0
+    return (pgb, egb, mgb)
+
+
+def _read_Z_from_gen(gen_file: Path, ns: int) -> list[float]:
+    """
+    The .gen file from neo_parse stores 'value KEY' per line. Walk it and
+    pull Z_1..Z_ns so the in-process output can be labelled with the same
+    species charges as the subprocess output for comparison.
+    """
+    z = {}
+    with open(gen_file) as f:
+        for line in f:
+            parts = line.split()
+            if len(parts) >= 2 and parts[1].startswith("Z_") and parts[1][2:].isdigit():
+                z[int(parts[1][2:])] = float(parts[0])
+    return [z[i + 1] for i in range(ns) if (i + 1) in z]
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    print("=" * 70)
+    print("NEO in-process vs subprocess benchmark")
+    print("=" * 70)
+    print(f"  Test input: {INPUT_NEO}")
+
+    # ------------------------------------------------------------------
+    # Setup working directories
+    # ------------------------------------------------------------------
+    SCRATCH.mkdir(parents=True, exist_ok=True)
+    work_dir_sub = SCRATCH / "subprocess"
+    work_dir_inp = SCRATCH / "inprocess"
+    for d in [work_dir_sub, work_dir_inp]:
+        if d.exists():
+            shutil.rmtree(d)
+        d.mkdir()
+
+    shutil.copy(INPUT_NEO, work_dir_sub / "input.neo")
+    shutil.copy(INPUT_NEO, work_dir_inp / "input.neo")
+
+    # ------------------------------------------------------------------
+    # Generate input.neo.gen for the in-process path
+    # ------------------------------------------------------------------
+    print("\n[1/4] Generating input.neo.gen ...")
+    from mitim_tools.simulation_tools.interfaces.neo_inprocess import (
+        NEOInProcess,
+        generate_input_gen,
+    )
+    gen_file = generate_input_gen(work_dir_inp / "input.neo")
+    print(f"      -> {gen_file}")
+
+    # ------------------------------------------------------------------
+    # Load the in-process runner (loads the .so once)
+    # ------------------------------------------------------------------
+    print("\n[2/4] Loading neo_lib extension ...")
+    try:
+        runner = NEOInProcess()
+        print("      -> OK")
+    except RuntimeError as exc:
+        print(f"\nERROR: {exc}")
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # Correctness: run both paths once and compare
+    # ------------------------------------------------------------------
+    print("\n[3/4] Correctness check ...")
+
+    sections_sub = _run_subprocess(work_dir_sub)
+    out_inp      = runner.run(gen_file)
+
+    if out_inp["error_status"] != 0:
+        print(f"  WARNING: in-process error_status = {out_inp['error_status']}")
+
+    Z_per_species = _read_Z_from_gen(gen_file, out_inp["ns"])
+    gb_factors    = _read_gb_from_gen(gen_file)
+    sections_inp  = _outputs_to_sections(out_inp, Z_per_species, gb_factors)
+
+    labels_sub, vals_sub = _flatten(sections_sub)
+    labels_inp, vals_inp = _flatten(sections_inp)
+
+    # Align labels (the file parser picks up species in file order, in-process
+    # uses the input dict order — both should match because they come from
+    # the same .gen file).
+    n = min(len(vals_sub), len(vals_inp))
+    vals_sub = vals_sub[:n]
+    vals_inp = vals_inp[:n]
+    labels   = labels_sub[:n]
+
+    max_rdiff = 0.0
+    header = f"{'Quantity':16s}  {'Subprocess':>14s}  {'In-process':>14s}  {'|rel diff|':>12s}"
+    print(f"\n{header}")
+    print("-" * len(header))
+    for lbl, vs, vi in zip(labels, vals_sub, vals_inp):
+        denom = max(abs(vs), abs(vi), 1e-20)
+        rdiff = abs(vs - vi) / denom
+        # Skip values that are below the absolute floor — they are physically
+        # zero and any difference is dominated by ASCII round-trip noise.
+        if max(abs(vs), abs(vi)) < ATOL:
+            flag = " (≈0, skipped)"
+        elif rdiff > RTOL:
+            flag = " <-- MISMATCH"
+            max_rdiff = max(max_rdiff, rdiff)
+        else:
+            flag = ""
+            max_rdiff = max(max_rdiff, rdiff)
+        print(f"  {lbl:14s}  {vs:14.6e}  {vi:14.6e}  {rdiff:12.2e}{flag}")
+
+    print()
+    if max_rdiff > RTOL:
+        print(f"FAIL: maximum relative difference {max_rdiff:.2e} exceeds tolerance {RTOL:.2e}")
+        sys.exit(1)
+    else:
+        print(f"PASS: maximum relative difference {max_rdiff:.2e}  (tolerance {RTOL:.2e})")
+
+    # ------------------------------------------------------------------
+    # Speed benchmark
+    # ------------------------------------------------------------------
+    print(f"\n[4/4] Speed benchmark ({N_CALLS} calls each) ...")
+
+    # --- subprocess ---
+    t0 = time.perf_counter()
+    for _ in range(N_CALLS):
+        _run_subprocess(work_dir_sub)
+    t_sub = (time.perf_counter() - t0) / N_CALLS
+
+    # --- in-process ---
+    t0 = time.perf_counter()
+    for _ in range(N_CALLS):
+        runner.run(gen_file)
+    t_inp = (time.perf_counter() - t0) / N_CALLS
+
+    speedup = t_sub / t_inp if t_inp > 0 else float("inf")
+
+    print()
+    print(f"  Subprocess mean call time : {t_sub*1000:.1f} ms")
+    print(f"  In-process mean call time : {t_inp*1000:.1f} ms")
+    print(f"  Speedup (subprocess/inprocess): {speedup:.1f}x")
+    print()
+
+    print("=" * 70)
+    print("ALL TESTS PASSED")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tglf_inprocess.py
+++ b/tests/test_tglf_inprocess.py
@@ -36,7 +36,7 @@ import numpy as np
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-N_CALLS = 20          # number of repeated calls for timing
+N_CALLS = 5          # number of repeated calls for timing
 RTOL = 1e-4           # relative tolerance for correctness check
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tglf_inprocess.py
+++ b/tests/test_tglf_inprocess.py
@@ -1,0 +1,214 @@
+"""
+test_tglf_inprocess.py
+======================
+Benchmark and correctness test for the TGLF in-process (f2py) execution path
+vs. the standard subprocess path.
+
+Usage
+-----
+    # From the MITIM-fusion root, with GACODE_ROOT set:
+    python tests/test_tglf_inprocess.py
+
+    # Optional: build the extension first (once per machine):
+    cd src/mitim_tools/simulation_tools/interfaces && bash build_tglf_lib.sh
+
+What the script does
+--------------------
+1. Generates ``input.tglf.gen`` from the test ``input.tglf`` via tglf_parse.py.
+2. Runs the standard subprocess path (``tglf -e .``) N times and records wall time.
+3. Runs the in-process path (``tglf_run()`` via f2py) N times and records wall time.
+4. Prints a side-by-side table of flux values and their relative differences.
+5. Prints the mean call time for each path and the speedup factor.
+6. Exits non-zero if any flux value differs by more than ``RTOL=1e-5``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+N_CALLS = 20          # number of repeated calls for timing
+RTOL = 1e-4           # relative tolerance for correctness check
+# ---------------------------------------------------------------------------
+
+# Locate test data
+_MITIMROOT = Path(__file__).parent.parent
+INPUT_TGLF = _MITIMROOT / "tests" / "data" / "input.tglf"
+SCRATCH     = _MITIMROOT / "tests" / "scratch" / "tglf_inprocess_test"
+
+if not INPUT_TGLF.exists():
+    sys.exit(f"ERROR: test input file not found: {INPUT_TGLF}")
+
+
+# ---------------------------------------------------------------------------
+# Helper: run the standard subprocess path once, return gbflux array
+# ---------------------------------------------------------------------------
+def _run_subprocess(work_dir: Path) -> np.ndarray:
+    """Run ``tglf -e .`` in work_dir, return parsed out.tglf.gbflux values."""
+    result = subprocess.run(
+        ["tglf", "-e", "."],
+        cwd=work_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print("  STDERR:", result.stderr[-500:] if result.stderr else "(none)")
+        raise RuntimeError(f"tglf subprocess failed (rc={result.returncode})")
+
+    gbflux_file = work_dir / "out.tglf.gbflux"
+    if not gbflux_file.exists():
+        raise RuntimeError(f"out.tglf.gbflux not found in {work_dir}")
+
+    values = [float(v) for v in gbflux_file.read_text().split()]
+    return np.array(values)
+
+
+# ---------------------------------------------------------------------------
+# Helper: run the in-process path once, return gbflux array
+# ---------------------------------------------------------------------------
+def _run_inprocess(gen_file: Path, runner) -> np.ndarray:
+    """Call tglf_run() in-process, return values matching gbflux format."""
+    outputs = runner.run(gen_file)
+
+    # Reconstruct the flat array in the same order as out.tglf.gbflux
+    ni = outputs["ns"] - 1
+    values: list[float] = []
+    values.append(outputs["elec_pflux"])
+    values.extend(outputs["ion_pflux"][:ni])
+    values.append(outputs["elec_eflux"])
+    values.extend(outputs["ion_eflux"][:ni])
+    values.append(outputs["elec_mflux"])
+    values.extend(outputs["ion_mflux"][:ni])
+    values.append(outputs["elec_expwd"])
+    values.extend(outputs["ion_expwd"][:ni])
+    return np.array(values)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    print("=" * 70)
+    print("TGLF in-process vs subprocess benchmark")
+    print("=" * 70)
+
+    # ------------------------------------------------------------------
+    # Setup working directories
+    # ------------------------------------------------------------------
+    SCRATCH.mkdir(parents=True, exist_ok=True)
+    work_dir_sub = SCRATCH / "subprocess"
+    work_dir_inp = SCRATCH / "inprocess"
+    for d in [work_dir_sub, work_dir_inp]:
+        if d.exists():
+            shutil.rmtree(d)
+        d.mkdir()
+
+    # Copy input.tglf to both dirs
+    shutil.copy(INPUT_TGLF, work_dir_sub / "input.tglf")
+    shutil.copy(INPUT_TGLF, work_dir_inp / "input.tglf")
+
+    # ------------------------------------------------------------------
+    # Generate input.tglf.gen for the in-process path
+    # ------------------------------------------------------------------
+    print("\n[1/4] Generating input.tglf.gen ...")
+    from mitim_tools.simulation_tools.interfaces.tglf_inprocess import (
+        TGLFInProcess,
+        generate_input_gen,
+    )
+    gen_file = generate_input_gen(work_dir_inp / "input.tglf")
+    print(f"      -> {gen_file}")
+
+    # ------------------------------------------------------------------
+    # Load the in-process runner (loads the .so once)
+    # ------------------------------------------------------------------
+    print("\n[2/4] Loading tglf_lib extension ...")
+    try:
+        runner = TGLFInProcess()
+        print("      -> OK")
+    except RuntimeError as exc:
+        print(f"\nERROR: {exc}")
+        sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # Correctness: run both paths once and compare
+    # ------------------------------------------------------------------
+    print("\n[3/4] Correctness check ...")
+
+    # For subprocess, we need input.tglf (tglf -e . will call tglf_parse.py)
+    vals_sub  = _run_subprocess(work_dir_sub)
+    vals_inp  = _run_inprocess(gen_file, runner)
+
+    # Align lengths (should match, but guard against different ns)
+    n = min(len(vals_sub), len(vals_inp))
+    vals_sub  = vals_sub[:n]
+    vals_inp  = vals_inp[:n]
+
+    # Labels for the table: ni = num ions = (total values / 4) - 1
+    # (4 flux types, each has 1 electron + ni ion values)
+    ni = len(vals_inp) // 4 - 1
+    labels: list[str] = []
+    for qty in ("Ge", "Qe", "Me", "Se"):
+        species = [qty.replace("e", f"e")] + [qty.replace("e", f"i{i+1}") for i in range(ni)]
+        labels.extend(species)
+    labels = labels[:n]
+
+    max_rdiff = 0.0
+    header = f"{'Quantity':12s}  {'Subprocess':>14s}  {'In-process':>14s}  {'|rel diff|':>12s}"
+    print(f"\n{header}")
+    print("-" * len(header))
+    for lbl, vs, vi in zip(labels, vals_sub, vals_inp):
+        denom = max(abs(vs), abs(vi), 1e-20)
+        rdiff = abs(vs - vi) / denom
+        max_rdiff = max(max_rdiff, rdiff)
+        flag = " <-- MISMATCH" if rdiff > RTOL else ""
+        print(f"  {lbl:10s}  {vs:14.6e}  {vi:14.6e}  {rdiff:12.2e}{flag}")
+
+    print()
+    if max_rdiff > RTOL:
+        print(f"FAIL: maximum relative difference {max_rdiff:.2e} exceeds tolerance {RTOL:.2e}")
+        sys.exit(1)
+    else:
+        print(f"PASS: maximum relative difference {max_rdiff:.2e}  (tolerance {RTOL:.2e})")
+
+    # ------------------------------------------------------------------
+    # Speed benchmark
+    # ------------------------------------------------------------------
+    print(f"\n[4/4] Speed benchmark ({N_CALLS} calls each) ...")
+
+    # --- subprocess ---
+    t0 = time.perf_counter()
+    for _ in range(N_CALLS):
+        _run_subprocess(work_dir_sub)
+    t_sub = (time.perf_counter() - t0) / N_CALLS
+
+    # --- in-process ---
+    t0 = time.perf_counter()
+    for _ in range(N_CALLS):
+        _run_inprocess(gen_file, runner)
+    t_inp = (time.perf_counter() - t0) / N_CALLS
+
+    speedup = t_sub / t_inp if t_inp > 0 else float("inf")
+
+    print()
+    print(f"  Subprocess mean call time : {t_sub*1000:.1f} ms")
+    print(f"  In-process mean call time : {t_inp*1000:.1f} ms")
+    print(f"  Speedup (subprocess/inprocess): {speedup:.1f}x")
+    print()
+
+    print("=" * 70)
+    print("ALL TESTS PASSED")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trailing_edge.py
+++ b/tests/test_trailing_edge.py
@@ -1,0 +1,344 @@
+"""
+Visualization of the trailing edge blending in profile_constructors_fine.
+
+Compares the old hard-concatenation approach (if still present) with the
+new Hermite blending, focusing on the junction between the reconstructed
+profile and the original trailing edge.
+
+Usage:
+    python tests/test_trailing_edge.py
+"""
+
+import numpy as np
+import torch
+import copy
+from mitim_tools.gacode_tools import PROFILEStools
+from mitim_tools.misc_tools import GUItools
+from mitim_modules.powertorch.utils import CALCtools, TRANSFORMtools
+from mitim_modules.powertorch.physics_models import parameterizers
+from mitim_modules.powertorch import STATEtools
+from mitim_tools import __mitimroot__
+
+
+# ============================================================================
+# Load data and create powerstate
+# ============================================================================
+
+print("\nLoading input.gacode...")
+profiles = PROFILEStools.gacode_state(__mitimroot__ / "tests" / "data" / "input.gacode")
+
+rho_coarse = torch.from_numpy(np.array([0.25, 0.45, 0.65, 0.85])).to(dtype=torch.double)
+
+print("Creating powerstate...")
+s = STATEtools.powerstate(
+    copy.deepcopy(profiles),
+    evolution_options={
+        "ProfilePredicted": ["te", "ti", "ne"],
+        "rhoPredicted": rho_coarse,
+    },
+)
+
+# ============================================================================
+# Extract the data we need for visualization
+# ============================================================================
+
+roa_fine = s.profiles.derived["roa"]
+rho_fine = s.profiles.profiles["rho(-)"]
+
+# The profile_constructors_fine were created during powerstate init
+# Let's use them to reconstruct profiles and visualize
+
+fn = GUItools.FigureNotebook("Trailing Edge Blending", geometry="1800x950")
+
+
+# ============================================================================
+# Tab 1: Full profile reconstruction for each channel
+# ============================================================================
+
+channels = ["te", "ti", "ne"]
+channel_labels = [r"$T_e$ (keV)", r"$T_i$ (keV)", r"$n_e$ ($10^{19}/m^3$)"]
+channel_gacode = ["te(keV)", "ti(keV)", "ne(10^19/m^3)"]
+channel_ions = [None, 0, None]
+
+fig = fn.add_figure(label="Profile Reconstruction")
+grid = fig.add_gridspec(3, 3, hspace=0.45, wspace=0.35)
+fig.suptitle("Profile reconstruction via profile_constructors_fine (Hermite trailing edge)", fontsize=11)
+
+for row, (ch, ch_label, ch_gacode, ion_idx) in enumerate(zip(channels, channel_labels, channel_gacode, channel_ions)):
+
+    # Original profile on the fine grid
+    orig = s.profiles.profiles[ch_gacode] if ion_idx is None else s.profiles.profiles[ch_gacode][:, ion_idx]
+
+    # Reconstruct via profile_constructors_fine with current gradients
+    roa_ps = s.plasma["roa"][0, :]
+    aLT = s.plasma[f"aL{ch}"][0, :]
+
+    x_rec, y_rec = s.profile_constructors_fine[ch](roa_ps, aLT)
+    x_rec = x_rec.numpy()
+    y_rec = y_rec[0].numpy()
+
+    # Map to rho for plotting
+    rho_rec = np.interp(x_rec, roa_fine, rho_fine)
+
+    # Coarse profile from profile_constructors_coarse
+    _, y_coarse = s.profile_constructors_coarse[ch](roa_ps.unsqueeze(0), aLT.unsqueeze(0))
+    rho_coarse_pts = np.interp(roa_ps.numpy(), roa_fine, rho_fine)
+
+    # Also compute gradients of the reconstructed profile to check for kinks
+    r_rec_t = torch.from_numpy(x_rec).double()
+    y_rec_t = torch.from_numpy(y_rec).double()
+    aLT_rec = CALCtools.derivation_into_Lx(r_rec_t, y_rec_t, array=False).numpy()
+
+    aLT_orig = CALCtools.derivation_into_Lx(
+        torch.from_numpy(roa_fine).double(),
+        torch.from_numpy(orig).double(),
+        array=False
+    ).numpy()
+
+    # Left: Full profiles
+    ax = fig.add_subplot(grid[row, 0])
+    ax.plot(rho_fine, orig, "k-", lw=2, label="Original")
+    ax.plot(rho_rec, y_rec, "r--", lw=1.5, label="Reconstructed")
+    ax.plot(rho_coarse_pts, y_coarse[0].numpy(), "go", ms=6, zorder=5, label="Coarse pts")
+    last_cp_rho = rho_coarse_pts[-1]
+    ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.6, label="Last CP")
+    ax.set_ylabel(ch_label)
+    ax.set_xlabel(r"$\rho$")
+    ax.legend(fontsize=7)
+    ax.set_title(f"{ch_label} - Full view")
+    ax.grid(True, alpha=0.3)
+
+    # Middle: Zoom on trailing edge
+    ax = fig.add_subplot(grid[row, 1])
+    ax.plot(rho_fine, orig, "k-", lw=2, label="Original")
+    ax.plot(rho_rec, y_rec, "r--", lw=1.5, label="Reconstructed")
+    ax.plot(rho_coarse_pts, y_coarse[0].numpy(), "go", ms=6, zorder=5)
+    ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.6)
+    ax.set_xlim(last_cp_rho - 0.05, min(rho_fine[-1], last_cp_rho + 0.15))
+    ax.set_ylabel(ch_label)
+    ax.set_xlabel(r"$\rho$")
+    ax.legend(fontsize=7)
+    ax.set_title(f"Zoom: trailing edge")
+    ax.grid(True, alpha=0.3)
+
+    # Right: Gradients (check for kinks)
+    ax = fig.add_subplot(grid[row, 2])
+    ax.plot(rho_fine, aLT_orig, "k-", lw=2, label="Original a/LT")
+    ax.plot(rho_rec, aLT_rec, "r--", lw=1.5, label="Reconstructed a/LT")
+    ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.6, label="Last CP")
+    ax.set_xlim(last_cp_rho - 0.1, min(rho_fine[-1], last_cp_rho + 0.15))
+    ax.set_ylabel(f"a/L for {ch_label}")
+    ax.set_xlabel(r"$\rho$")
+    ax.legend(fontsize=7)
+    ax.set_title(f"Gradient near trailing edge")
+    ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Tab 2: Grid spacing and blend region detail
+# ============================================================================
+
+fig = fn.add_figure(label="Grid & Blend Detail")
+grid_spec = fig.add_gridspec(2, 3, hspace=0.45, wspace=0.35)
+fig.suptitle("Grid spacing and Hermite blend weight near trailing edge", fontsize=11)
+
+for col, (ch, ch_label, ch_gacode, ion_idx) in enumerate(zip(channels, channel_labels, channel_gacode, channel_ions)):
+
+    orig = s.profiles.profiles[ch_gacode] if ion_idx is None else s.profiles.profiles[ch_gacode][:, ion_idx]
+
+    roa_ps = s.plasma["roa"][0, :]
+    aLT = s.plasma[f"aL{ch}"][0, :]
+    x_rec, y_rec = s.profile_constructors_fine[ch](roa_ps, aLT)
+    x_rec = x_rec.numpy()
+    y_rec = y_rec[0].numpy()
+    rho_rec = np.interp(x_rec, roa_fine, rho_fine)
+    last_cp_rho = np.interp(roa_ps[-1].item(), roa_fine, rho_fine)
+
+    # Grid spacing
+    ax = fig.add_subplot(grid_spec[0, col])
+    dr = np.diff(x_rec)
+    rho_mid = 0.5 * (rho_rec[:-1] + rho_rec[1:])
+    ax.semilogy(rho_mid, dr, "b.-", ms=3, lw=1)
+    ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.6, label="Last CP")
+    ax.set_ylabel("dr (r/a spacing)")
+    ax.set_xlabel(r"$\rho$")
+    ax.set_title(f"{ch} - Grid spacing")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    # Relative error between original and reconstructed
+    ax = fig.add_subplot(grid_spec[1, col])
+    orig_interp = np.interp(x_rec, roa_fine, orig)
+    rel_err = np.abs((y_rec - orig_interp) / (orig_interp + 1e-30)) * 100
+    ax.semilogy(rho_rec[1:], rel_err[1:], "r-", lw=1.5)
+    ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.6, label="Last CP")
+    ax.set_ylabel("Relative error (%)")
+    ax.set_xlabel(r"$\rho$")
+    ax.set_title(f"{ch} - Reconstruction error")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Tab 3: Multi-pass stability with the new trailing edge
+# ============================================================================
+
+fig = fn.add_figure(label="Multi-Pass Stability")
+grid_spec = fig.add_gridspec(3, 2, hspace=0.5, wspace=0.3)
+fig.suptitle("Multi-pass stability: does the profile change after re-parameterization?", fontsize=11)
+
+pass_colors = ["k", "#1f77b4", "#ff7f0e", "#d62728"]
+pass_styles = ["-", "--", "-.", ":"]
+pass_labels = ["Original", "1 pass", "2 passes", "3 passes"]
+
+for row, (ch, ch_label, ch_gacode, ion_idx) in enumerate(zip(channels, channel_labels, channel_gacode, channel_ions)):
+
+    orig_full = s.profiles.profiles[ch_gacode] if ion_idx is None else s.profiles.profiles[ch_gacode][:, ion_idx]
+
+    roa_ps = s.plasma["roa"][0, :]
+    aLT_current = s.plasma[f"aL{ch}"][0, :].clone()
+
+    # Pass 0: reconstruct from current gradients
+    x_rec, y_rec = s.profile_constructors_fine[ch](roa_ps, aLT_current)
+    x_rec_np = x_rec.numpy()
+    rho_rec = np.interp(x_rec_np, roa_fine, rho_fine)
+    last_cp_rho = np.interp(roa_ps[-1].item(), roa_fine, rho_fine)
+
+    profiles_passes = [y_rec[0].numpy()]
+    gradients_passes = [CALCtools.derivation_into_Lx(
+        torch.from_numpy(x_rec_np).double(),
+        y_rec[0].double(), array=False).numpy()]
+
+    # Subsequent passes: re-derive gradients from reconstructed profile, sample at coarse, reconstruct again
+    current_profile = y_rec[0].numpy()
+    for p in range(3):
+        r_t = torch.from_numpy(x_rec_np).double()
+        p_t = torch.from_numpy(current_profile).double()
+        aLT_full = CALCtools.derivation_into_Lx(r_t, p_t, array=False).numpy()
+
+        # Find coarse point indices on the reconstructed grid
+        coarse_roa = roa_ps[1:].numpy()  # skip the axis zero
+        coarse_idx = [np.argmin(np.abs(x_rec_np - cr)) for cr in coarse_roa]
+
+        # Sample and re-inject
+        aLT_new = torch.zeros_like(aLT_current)
+        aLT_new[0] = 0.0  # axis
+        for ci, idx in enumerate(coarse_idx):
+            aLT_new[ci + 1] = aLT_full[idx]
+
+        x_new, y_new = s.profile_constructors_fine[ch](roa_ps, aLT_new)
+        current_profile = y_new[0].numpy()
+        profiles_passes.append(current_profile)
+        gradients_passes.append(CALCtools.derivation_into_Lx(
+            torch.from_numpy(x_rec_np).double(),
+            torch.from_numpy(current_profile).double(), array=False).numpy())
+
+    # Left: Profiles
+    ax = fig.add_subplot(grid_spec[row, 0])
+    ax.plot(rho_fine, orig_full, "k-", lw=2, alpha=0.3, label="Original gacode")
+    for ip, (yp, lab, col_p, sty) in enumerate(zip(profiles_passes, pass_labels, pass_colors, pass_styles)):
+        if ip == 0:
+            lab_full = f"Pass 0 (first reconstruction)"
+        else:
+            err = np.max(np.abs((yp - profiles_passes[0]) / (profiles_passes[0] + 1e-30))) * 100
+            lab_full = f"Pass {ip} (max diff={err:.3f}%)"
+        ax.plot(rho_rec, yp, color=col_p, ls=sty, lw=1.5, label=lab_full)
+    ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.5)
+    ax.set_ylabel(ch_label)
+    ax.set_xlabel(r"$\rho$")
+    ax.legend(fontsize=6, loc="best")
+    ax.set_title(f"{ch} profiles")
+    ax.grid(True, alpha=0.3)
+
+    # Right: Gradients near trailing edge
+    ax = fig.add_subplot(grid_spec[row, 1])
+    ax.plot(rho_fine, CALCtools.derivation_into_Lx(
+        torch.from_numpy(roa_fine).double(),
+        torch.from_numpy(orig_full).double(), array=False).numpy(),
+        "k-", lw=2, alpha=0.3, label="Original gacode")
+    for ip, (gp, lab, col_p, sty) in enumerate(zip(gradients_passes, pass_labels, pass_colors, pass_styles)):
+        ax.plot(rho_rec, gp, color=col_p, ls=sty, lw=1.5, label=pass_labels[ip])
+    ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.5)
+    ax.set_xlim(last_cp_rho - 0.15, min(rho_fine[-1], last_cp_rho + 0.15))
+    ax.set_ylabel(f"a/L {ch}")
+    ax.set_xlabel(r"$\rho$")
+    ax.legend(fontsize=6, loc="best")
+    ax.set_title(f"{ch} gradients near trailing edge")
+    ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Tab 4: Comparison with the SPARC case (if available)
+# ============================================================================
+
+from pathlib import Path
+sparc_path = Path("/Users/pablorf/PROJECTS/project_2026_Development/development_portals/roundtrip/sparc_3.7")
+if (sparc_path / "Execution/Evaluation.0/transport_simulation_folder/input.gacode").exists():
+
+    fig = fn.add_figure(label="SPARC Case")
+    grid_spec = fig.add_gridspec(2, 3, hspace=0.45, wspace=0.35)
+    fig.suptitle("SPARC case: profile reconstruction with Hermite trailing edge", fontsize=11)
+
+    p_sparc = PROFILEStools.gacode_state(sparc_path / "Execution/Evaluation.0/transport_simulation_folder/input.gacode")
+
+    rho_sparc = torch.from_numpy(np.array([0.302734, 0.478464, 0.668839, 0.808734, 0.840279])).to(dtype=torch.double)
+
+    s_sparc = STATEtools.powerstate(
+        copy.deepcopy(p_sparc),
+        evolution_options={
+            "ProfilePredicted": ["te", "ti", "ne"],
+            "rhoPredicted": rho_sparc,
+        },
+        increase_profile_resol=False,  # already at enhanced resolution
+    )
+
+    roa_sparc = s_sparc.profiles.derived["roa"]
+    rho_sparc_fine = s_sparc.profiles.profiles["rho(-)"]
+
+    for col, (ch, ch_label, ch_gacode, ion_idx) in enumerate(zip(channels, channel_labels, channel_gacode, channel_ions)):
+
+        orig = p_sparc.profiles[ch_gacode] if ion_idx is None else p_sparc.profiles[ch_gacode][:, ion_idx]
+        roa_ps = s_sparc.plasma["roa"][0, :]
+        aLT = s_sparc.plasma[f"aL{ch}"][0, :]
+        x_rec, y_rec = s_sparc.profile_constructors_fine[ch](roa_ps, aLT)
+        x_rec_np = x_rec.numpy()
+        y_rec_np = y_rec[0].numpy()
+        rho_rec = np.interp(x_rec_np, roa_sparc, rho_sparc_fine)
+        last_cp_rho = np.interp(roa_ps[-1].item(), roa_sparc, rho_sparc_fine)
+
+        # Profile
+        ax = fig.add_subplot(grid_spec[0, col])
+        ax.plot(rho_sparc_fine, orig, "k-", lw=2, label="Original")
+        ax.plot(rho_rec, y_rec_np, "r--", lw=1.5, label="Reconstructed")
+        ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.6)
+        ax.set_xlim(last_cp_rho - 0.05, min(rho_sparc_fine[-1], last_cp_rho + 0.15))
+        ax.set_ylabel(ch_label)
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=8)
+        ax.set_title(f"SPARC {ch} trailing edge")
+        ax.grid(True, alpha=0.3)
+
+        # Gradient
+        ax = fig.add_subplot(grid_spec[1, col])
+        aLT_orig = CALCtools.derivation_into_Lx(
+            torch.from_numpy(roa_sparc).double(),
+            torch.from_numpy(orig).double(), array=False).numpy()
+        aLT_rec = CALCtools.derivation_into_Lx(
+            torch.from_numpy(x_rec_np).double(),
+            torch.from_numpy(y_rec_np).double(), array=False).numpy()
+        ax.plot(rho_sparc_fine, aLT_orig, "k-", lw=2, label="Original a/LT")
+        ax.plot(rho_rec, aLT_rec, "r--", lw=1.5, label="Reconstructed a/LT")
+        ax.axvline(last_cp_rho, color="gray", ls="--", lw=0.8, alpha=0.6)
+        ax.set_xlim(last_cp_rho - 0.1, min(rho_sparc_fine[-1], last_cp_rho + 0.15))
+        ax.set_ylabel(f"a/L {ch}")
+        ax.set_xlabel(r"$\rho$")
+        ax.legend(fontsize=8)
+        ax.set_title(f"SPARC {ch} gradient")
+        ax.grid(True, alpha=0.3)
+
+
+# ============================================================================
+# Show
+# ============================================================================
+
+fn.show()


### PR DESCRIPTION
  ## Summary

  This branch bundles four largely independent capabilities developed
  on top of `development`:

  ### 1. Neoclassical Er capability (NEO VGEN → PORTALS / TGLF)

  - **`NEOtools.run_vgen` / `read_vgen`** — full Python wrapper around
    `profiles_gen -vgen` that submits VGEN, retrieves the output, and
    exposes the resulting `w0(rad/s)`, Er components, bootstrap current,
    flows, and per-species velocities on the NEO class.
  - **PORTALS / TGLF integration** — new namelist option
    `transport.options.neo.vgen_exb_shear` that, when set, runs NEO VGEN
    in the weak-rotation limit (zero toroidal rotation) at every PORTALS
    iteration to compute the neoclassical radial electric field, then
    injects the resulting w0 into `profiles_transport` so TGLF picks it
    up as `VEXB_SHEAR`. The NEO Er components and bootstrap current are
    also retained for downstream analysis.
  - **`MITIMstate.smooth_profiles()`** — cubic-spline smoother applied to
    Te / Ti / ne / ni before VGEN so piecewise-linear kinks in the gacode
    gradients do not pollute the computed Er. The original profiles are
    never mutated; smoothing happens on a deep copy.
  - **Expanded NEO output parser + plot tabs** — `NEOoutput` now reads
    every `out.neo.*` file (transport_flux, transport, transport_gv,
    equil, theory, rotation, diagnostic_geo, prec) and exposes the
    full DKE / GV / theory / NCLASS / rotation / bootstrap surfaces. New
    plot tabs in `NEOtools.plot()` cover per-species fluxes, theory
    comparison, bootstrap current, geometry, and rotation.

  ### 2. TGLF 2D plotting

  - **`TGLF.run_scan2d`** — drive a TGLF 2D scan over any pair of input
    variables (e.g. `(RLTS_1, RLTS_2)`) at fixed radii, with the existing
    scan-trick infrastructure handling the parallel submission.
  - **`TGLF.plot_scan2d`** — heat-map / contour plotting of `Qe_gb`,
    `Qi_gb`, `Ge_gb`, `Gi_gb`, growth rates, and any other scan output
    on the 2D grid, with experimental fluxes overlaid where available.
  - General TGLF plotting improvements (axes labels, legends, color
    schemes) carried alongside.

  ### 3. In-process TGLF / NEO / VGEN via ctypes

  - **TGLF in-process** (`libtglf_serial.so` + `tglf_inprocess.py`) —
    Fortran C-binding wrapper on top of the prebuilt non-MPI TGLF
    objects; thread-private `.so` copies for true parallelism inside
    one Python process.
  - **NEO in-process** (`libneo_serial.so` + `neo_inprocess.py`) —
    same pattern, linked through `mpifort` because a few NEO objects
    `use mpi` for type imports. Verified against the standalone
    subprocess path on `reg02`: max relative diff 2.3e-5, ~32× speedup.
  - **VGEN in-process** (`libvgen_serial.so` + `vgen_inprocess.py`) —
    sequential per-surface loop replacing `vgen.f90`'s MPI-distributed
    loop; calls `expro_read('input.gacode', 0)` to disable MPI inside
    expro; only `er_method=2` (NEO weak rotation, the option PORTALS
    uses) is wired through. Verified against `profiles_gen -vgen` on
    `iter01`: max relative diff in `EXPRO_w0` is 3.5e-7 across all 51
    radii.
  - **`gacode_tools/utils/GACODEinprocess.py`** — pure in-process mixin
    (`_GACODEInProcessMixin`, `TGLFInProcess`, `NEOInProcess`). The
    mixin does NOT inherit from `mitim_simulation`. `TGLFtools.TGLF`
    and `NEOtools.NEO` use multiple inheritance + four tiny dispatchers
    (`prep`, `_run_prepare`, `_run`, `read`) that pick the engine based
    on `self.in_process`, eliminating ~510 lines of duplicated dispatch
    logic between TGLFtools and NEOtools.
  - **PORTALS namelist toggle** — `transport.options.tglf.in_process`
    and `transport.options.neo.in_process` (default `false`) in
    `templates/namelist.portals.yaml`. The NEO toggle also controls
    VGEN, so a single setting drives all three NEO touchpoints.
  - Bug fix: TGLF in-process mixin now respects `ApplyCorrections=False`
    (PORTALS' `transport_tglf` passes this), matching
    `SIMtools.change_and_write_code`. Without it the in-process path
    silently stripped low-density / fast species the subprocess path
    keeps.

  ### 4. TGLF NPZ serialization

  - **`TGLF.save_npz` / `TGLF.from_npz`** — complete round-trip
    save/load of a TGLF results object as a single compressed `.npz`
    archive. Stores only base spectra + scalar metadata (derived slices
    are recomputed by `_compute_derived` on load), keeping archives
    small. Heavy Python objects (TGYRO, matplotlib functions, profile
    classes) are intentionally excluded.

  ## Verification done in the branch

  | Test | Result |
  |---|---|
  | `tests/test_tglf_inprocess.py` (subprocess vs in-process on `input.tglf`) | PASS, large speedup |
  | `tests/test_neo_inprocess.py` (subprocess vs in-process on `reg02`) | PASS, max rdiff 2.3e-5, ~32× speedup |
  | `tests/NEOworkflow_inprocess.py` (NEOtools class API + `run_scan` vs subprocess) | 10/10 PASS within rtol=5e-3 |
  | `tests/TGLFworkflow_inprocess.py` (TGLF class API + `runScanTurbulenceDrives` vs subprocess) | ALL PASS |
  | `profiles_gen -vgen` vs `VGENInProcess` on `iter01` | max rdiff in `EXPRO_w0` = 3.5e-7 across 51 radii |
  | Powertorch transport-module imports after the namelist + dispatch wiring | OK |

  ## Build prerequisites

  ```bash
  cd src/mitim_tools/simulation_tools/interfaces
  bash build_tglf_lib.sh
  bash build_neo_lib.sh
  bash build_vgen_lib.sh
```
  The three _build/ directories are gitignored.

  Test plan (for review)

  - pixi run -- python tests/test_tglf_inprocess.py
  - pixi run -- python tests/test_neo_inprocess.py
  - pixi run -- python tests/NEOworkflow_inprocess.py
  - pixi run -- python tests/TGLFworkflow_inprocess.py
  - Smoke-import the powertorch transport modules:
  pixi run -- python -c 'from mitim_modules.powertorch.physics_models.transport_tglf import tglf_model; from
  mitim_modules.powertorch.physics_models.transport_neo import neo_model'
  - Optional: kick off a small PORTALS run with transport.options.tglf.in_process: true,
  transport.options.neo.in_process: true, and transport.options.neo.vgen_exb_shear: true
  in the namelist and confirm fluxes match a subprocess baseline within rtol=5e-3.

  🤖 Generated with Claude Code