### PR TITLE
Adding fusio option for plasma state description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   # "extended-lengyel @ git+https://github.com/cfs-energy/extended-lengyel.git",
   # "quends @ git+https://github.com/sandialabs/quends.git"
   #"onnx2pytorch",   # Stricly not for MITIM, but good to use ONNX models
-  "fusio",
+  "fusio>=0.4.3",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   # "extended-lengyel @ git+https://github.com/cfs-energy/extended-lengyel.git",
   # "quends @ git+https://github.com/sandialabs/quends.git"
   #"onnx2pytorch",   # Stricly not for MITIM, but good to use ONNX models
+  "fusio",
 ]
 
 [project.optional-dependencies]

--- a/src/mitim_modules/portals/PORTALSmain.py
+++ b/src/mitim_modules/portals/PORTALSmain.py
@@ -432,10 +432,25 @@ class portals(STRATEGYtools.opt_evaluator):
         portals = PORTALSanalysis.PORTALSanalyzer.from_folder(self.folder)
         powerstate = portals.powerstates[portals.ibest]
         
-        powerstate.profiles.write_state(self.folder / "Outputs" / f"input.gacode_final_{suffix}")
+        # Prefer plasma_io-native output -- the fusio plasma_io object stored on
+        # powerstate.profiles.plasma_io (see plasma_io_migration_plan.md), updated with this
+        # evaluation's predicted profiles via powerstate_to_plasma_io()/to_plasma_io() -- over
+        # the GACODE ASCII text format. Only falls back to input.gacode when this run was not
+        # plasma_io-backed (profiles.plasma_io is None), so a final output is always produced.
+        #
+        # Note: powerstate.profiles_transport (the transport-evaluated, as opposed to
+        # flux-matched, snapshot) has no plasma_io-native equivalent yet -- to_plasma_io() is a
+        # powerstate method, and profiles_transport is a standalone gacode_state, not a
+        # powerstate -- so it is still written as GACODE ASCII regardless.
+        if getattr(powerstate, "to_plasma_io", None) is not None:
+            powerstate.to_plasma_io(write_plasma_io=self.folder / "Outputs" / f"plasma_final_{suffix}.nc")
+            print(f"\n- Final plasma_io state (iteration {portals.ibest}) written to Outputs/plasma_final_{suffix}.nc", typeMsg="i")
+        else:
+            powerstate.profiles.write_state(self.folder / "Outputs" / f"input.gacode_final_{suffix}")
+            print(f"\n- Final profiles (iteration {portals.ibest}) written to Outputs/input.gacode_final_{suffix}", typeMsg="i")
+
         powerstate.profiles_transport.write_state(self.folder / "Outputs" / f"input.gacode_transport_final_{suffix}")
-        
-        print(f"\n- Final profiles (iteration {portals.ibest}) written to Outputs/input.gacode_final_{suffix} and Outputs/input.gacode_transport_final_{suffix}", typeMsg="i")
+        print(f"- Final transport-evaluated profiles (iteration {portals.ibest}) written to Outputs/input.gacode_transport_final_{suffix}", typeMsg="i")
 
 def runModelEvaluator(
     self,
@@ -490,6 +505,13 @@ def runModelEvaluator(
 
     # Evaluate X (DVs) through powerstate.calculate(). This will populate .plasma with the results
     powerstate.calculate(X, nameRun=name, folder=folder_model, evaluation_number=numPORTALS)
+
+    # This single call to calculate() is the completed evaluation for this candidate point --
+    # the "iteration complete" boundary that to_gacode() deliberately never syncs plasma_io
+    # from inside calculate()'s own internal transport-evaluation call (see
+    # TRANSFORMtools.to_gacode()'s docstring / plasma_io_migration_plan.md).
+    if getattr(powerstate, "sync_plasma_io", None) is not None:
+        powerstate.sync_plasma_io()
 
     # ---------------------------------------------------------------------------------------------------
     # Produce dictOFs

--- a/src/mitim_modules/portals/utils/PORTALSanalysis.py
+++ b/src/mitim_modules/portals/utils/PORTALSanalysis.py
@@ -216,19 +216,27 @@ class PORTALSanalyzer:
         # Profiles and tgyro results
         print("\t- Reading profiles and tgyros for each evaluation")
 
+        # PORTALSmain._dropped_derived strips 'derived' off lean-stored gacode_state instances at
+        # save time; downstream code here reads via get_derived() instead of the raw .derived dict,
+        # which recomputes lazily on demand regardless of what was stripped -- so no eager rebuild
+        # is needed. (.profiles/.derived aren't stored attributes at all for plasma_io-backed
+        # states -- see get_profiles()/get_derived() on mitim_state -- so an eager
+        # derive_quantities() call here would fail outright for those anyway.)
         self.powerstates = []
         for i in range(self.ilast + 1):
-            power = self.mitim_runs[i]["powerstate"]
-            # Lean-stored powerstates have 'derived' dropped at save (PORTALSmain._dropped_derived);
-            # rebuild it here so all downstream plots/metrics find it.
-            prof = getattr(power, "profiles", None)
-            if prof is not None and not getattr(prof, "derived", None):
-                prof.derive_quantities()
-            self.powerstates.append(power)
+            self.powerstates.append(self.mitim_runs[i]["powerstate"])
 
-        # The string-keyed standalone states ('profiles_original'/'profiles_modified') are also
-        # reached and stripped by PORTALSmain._dropped_derived, but sit outside the integer loop
-        # above -- rebuild them too so plotSummary's plot_gradients(useRoa=True) finds derived['roa'].
+        # The string-keyed standalone states ('profiles_original'/'profiles_modified',
+        # PORTALSmain.py's dictStore["profiles_original"] = PROFILEStools.gacode_state(path))
+        # are a genuinely different case from the numbered powerstates above: they're built via
+        # gacode_state's plain constructor (reading a written input.gacode_original/_modified
+        # ASCII file directly), which always leaves .plasma_io = None -- regardless of whether
+        # this run itself is plasma_io-backed. get_derived() only recomputes lazily for
+        # plasma_io-backed instances (self.plasma_io is not None); for these two it just returns
+        # .derived directly, which _dropped_derived() stripped to {} at save time and nothing
+        # else ever rebuilds after unpickling. Needed by PORTALSplot.py's
+        # PORTALSanalyzer_plotSummary() (profile_original_unCorrected/profile_original_0 ->
+        # plot_gradients()'s useRoa branch, get_derived()["roa"]).
         for ikey in ("profiles_original", "profiles_modified"):
             prof = self.mitim_runs.get(ikey, None)
             if prof is not None and not getattr(prof, "derived", None):
@@ -291,13 +299,15 @@ class PORTALSanalyzer:
         for i, power in enumerate(self.powerstates):
             print(f"\t\t- Processing evaluation {i}/{len(self.powerstates)-1}")
 
-            if 'Q' not in power.profiles.derived:
-                power.profiles.derive_quantities()
+            # get_derived() recomputes lazily on demand (cached per-instance) and works
+            # uniformly for both plasma_io-backed and legacy dict-backed states -- see
+            # mitim_state.get_derived().
+            derived = power.profiles.get_derived()
 
             self.evaluations.append(i)
-            self.FusionGain.append(power.profiles.derived["Q"])
-            self.FusionPower.append(power.profiles.derived["Pfus"])
-            self.tauE.append(power.profiles.derived["tauE"])
+            self.FusionGain.append(derived["Q"])
+            self.FusionPower.append(derived["Pfus"])
+            self.tauE.append(derived["tauE"])
 
             # ------------------------------------------------
             # Residual definitions
@@ -1258,14 +1268,15 @@ class PORTALSinitializer:
                 batch_size = getattr(p, "batch_size", 0) or 1
                 if batch_size > 1:
                     self.n_trajectories = batch_size
+                # No eager derive_quantities() call needed -- downstream code reads derived
+                # quantities via get_derived(), which recomputes lazily on demand for both
+                # plasma_io-backed and legacy dict-backed states (see mitim_state.get_derived()).
                 if batch_size <= 1:
-                    p.profiles.derive_quantities()
                     self.powerstates.append(p)
                 else:
                     for b in range(batch_size):
                         p_b = copy.deepcopy(p)
                         p_b._repeat_tensors(batch_size=1, positionToUnrepeat=b)
-                        p_b.profiles.derive_quantities()
                         self.powerstates.append(p_b)
 
         self.fn = None

--- a/src/mitim_modules/portals/utils/PORTALSanalysis.py
+++ b/src/mitim_modules/portals/utils/PORTALSanalysis.py
@@ -230,9 +230,9 @@ class PORTALSanalyzer:
         # PORTALSmain.py's dictStore["profiles_original"] = PROFILEStools.gacode_state(path))
         # are a genuinely different case from the numbered powerstates above: they're built via
         # gacode_state's plain constructor (reading a written input.gacode_original/_modified
-        # ASCII file directly), which always leaves .plasma_io = None -- regardless of whether
+        # ASCII file directly), which always leaves has_output False -- regardless of whether
         # this run itself is plasma_io-backed. get_derived() only recomputes lazily for
-        # plasma_io-backed instances (self.plasma_io is not None); for these two it just returns
+        # plasma_io-backed instances (self.has_output); for these two it just returns
         # .derived directly, which _dropped_derived() stripped to {} at save time and nothing
         # else ever rebuilds after unpickling. Needed by PORTALSplot.py's
         # PORTALSanalyzer_plotSummary() (profile_original_unCorrected/profile_original_0 ->

--- a/src/mitim_modules/portals/utils/PORTALSinit.py
+++ b/src/mitim_modules/portals/utils/PORTALSinit.py
@@ -18,6 +18,46 @@ from fusio.classes.plasma import plasma_io
 from IPython import embed
 
 
+def _ensure_plasma_io_deepcopy(obj):
+    """
+    Establishes fusio's .input side as MITIM/PORTALS' canonical, untouched starting-state
+    snapshot and .output as an independent deep-copied working copy -- the rest of PORTALS
+    then reads from and overwrites only .output as BO iterations progress
+    (get_profiles()/get_derived() default to side="output" throughout, see MITIMstate.py).
+    io.py's input/output getters and setters already deep-copy on both read and write, so
+    `obj.output = obj.input` below is a true independent copy, not an alias.
+
+    Idempotent/safe to call more than once on the same object -- once both sides are
+    populated, this is a no-op. This matters because initializeProblem() calls it at
+    several points that can all see the same object (the raw-path auto-conversion branch,
+    then again later when it falls through to the generic isinstance(fileStart, io)
+    branches) -- an unconditional `obj.output = obj.input` would silently clobber
+    .output's already-preprocessed state (post remove_fast_ions()/
+    compute_derived_quantities(), which run on .output right after the first call) with
+    the stale, unprocessed .input snapshot on the second call. Must still run exactly
+    once as the very first *effective* operation on any plasma_io/gacode_io object MITIM
+    receives -- NOT inside mitim_state.scratch(), which is called repeatedly throughout a
+    run (every transport evaluation) and, unlike this idempotent guard, has no way to
+    distinguish "fresh object" from "object with real accumulated BO progress on .output".
+
+    If the object arrives with only .output populated (e.g. a caller-constructed object
+    that ran its own preprocessing directly on .output -- every existing .nc-branch
+    PORTALS_workflow_nc*.py script does this today), .input is backfilled from it first so
+    a reference snapshot still exists. This is deliberately a backfill, not a hard
+    requirement that callers populate .input themselves, so existing scripts' own
+    loading/preprocessing conventions don't need to change.
+    """
+    if not obj.has_input:
+        if not obj.has_output:
+            raise ValueError(
+                f"{type(obj).__name__} object has neither .input nor .output populated -- "
+                "cannot establish a starting state for MITIM/PORTALS."
+            )
+        obj.input = obj.output
+    if not obj.has_output:
+        obj.output = obj.input
+
+
 def initializeProblem(
     portals_fun,
     folderWork,
@@ -70,16 +110,18 @@ def initializeProblem(
         if fileStart_path.suffix == ".gacode":
             fileStart = gacode_io.from_file(fileStart_path).to("plasma")
             # .to("plasma") always writes to the *input* side of the new plasma_io object
-            # (io.py's convention for all from_*()/.to() conversions) -- move to .output,
-            # matching every other plasma_io construction path in this codebase (scratch()'s
-            # implicit .to("gacode") read expects data on .output).
-            fileStart.output = fileStart.input
+            # (io.py's convention for all from_*()/.to() conversions) -- see
+            # _ensure_plasma_io_deepcopy()'s docstring for why this is the first operation.
+            _ensure_plasma_io_deepcopy(fileStart)
             # use_main_ion=True: matches MITIM's own gacode_state.correct(quasineutrality=True)
             # convention (adjusts D/T ion density to match ne).
             fileStart.remove_fast_ions(enforce_quasineutrality=True, use_main_ion=True, side='output')
             fileStart.compute_derived_quantities(side='output')
         elif fileStart_path.suffix == ".nc":
-            fileStart = plasma_io.from_file(fileStart_path)
+            # input=... (not the bare/path= default, which lands on .output) so the raw file
+            # lands on .input -- see _ensure_plasma_io_deepcopy()'s docstring.
+            fileStart = plasma_io.from_file(input=fileStart_path)
+            _ensure_plasma_io_deepcopy(fileStart)
             fileStart.remove_fast_ions(enforce_quasineutrality=True, side='output')
             fileStart.compute_derived_quantities(side='output')
         # else: unrecognized suffix -- leave fileStart as the original path, falls through to the
@@ -93,8 +135,12 @@ def initializeProblem(
     if isinstance(fileStart, MITIMstate.mitim_state):
         fileStart.write_state(file=FolderInitialization / "input.gacode")
     elif isinstance(fileStart, io):
-        if not fileStart.has_output and fileStart.has_input:
-            fileStart.swap()
+        # Establishes .input as the canonical snapshot and .output as an independent
+        # working copy (backfilling .input from .output first if only .output was
+        # populated by the caller) -- see _ensure_plasma_io_deepcopy()'s docstring.
+        # Replaces the old swap()-based logic, which emptied out whichever side had
+        # data instead of preserving it as a pristine reference.
+        _ensure_plasma_io_deepcopy(fileStart)
         fileStart.to("gacode").write(FolderInitialization / "input.gacode", side="input")
     else:
         shutil.copy2(fileStart, FolderInitialization / "input.gacode")
@@ -111,8 +157,12 @@ def initializeProblem(
     if isinstance(fileStart, MITIMstate.mitim_state):
         profiles = copy.deepcopy(fileStart)
     elif isinstance(fileStart, io):
-        if not fileStart.has_output and fileStart.has_input:
-            fileStart.swap()
+        # Establishes .input as the canonical snapshot and .output as an independent
+        # working copy (backfilling .input from .output first if only .output was
+        # populated by the caller) -- see _ensure_plasma_io_deepcopy()'s docstring.
+        # Replaces the old swap()-based logic, which emptied out whichever side had
+        # data instead of preserving it as a pristine reference.
+        _ensure_plasma_io_deepcopy(fileStart)
         #profiles = PROFILEStools.gacode_state.scratch(fileStart.to("gacode").to_dict(side="input"))
         profiles = PROFILEStools.gacode_state.scratch(fileStart)
     # If it is a file, then assume it is a gacode one (#TODO: check type?)

--- a/src/mitim_modules/portals/utils/PORTALSinit.py
+++ b/src/mitim_modules/portals/utils/PORTALSinit.py
@@ -83,7 +83,8 @@ def initializeProblem(
     elif isinstance(fileStart, io):
         if not fileStart.has_output and fileStart.has_input:
             fileStart.swap()
-        profiles = PROFILEStools.gacode_state.scratch(fileStart.to("gacode").to_dict(side="input"))
+        #profiles = PROFILEStools.gacode_state.scratch(fileStart.to("gacode").to_dict(side="input"))
+        profiles = PROFILEStools.gacode_state.scratch(fileStart)
     # If it is a file, then assume it is a gacode one (#TODO: check type?)
     else:
         profiles = PROFILEStools.gacode_state(initialization_file)

--- a/src/mitim_modules/portals/utils/PORTALSinit.py
+++ b/src/mitim_modules/portals/utils/PORTALSinit.py
@@ -8,54 +8,13 @@ from collections import OrderedDict
 from mitim_tools.misc_tools import IOtools
 from mitim_tools.gacode_tools import PROFILEStools
 from mitim_tools.plasmastate_tools import MITIMstate
+from mitim_tools.plasmastate_tools.MITIMstate import _ensure_plasma_io_deepcopy
 from mitim_modules.powertorch import STATEtools
 from mitim_modules.portals import PORTALStools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools import __mitimroot__
 from fusio.classes.io import io
-from fusio.classes.gacode import gacode_io
-from fusio.classes.plasma import plasma_io
 from IPython import embed
-
-
-def _ensure_plasma_io_deepcopy(obj):
-    """
-    Establishes fusio's .input side as MITIM/PORTALS' canonical, untouched starting-state
-    snapshot and .output as an independent deep-copied working copy -- the rest of PORTALS
-    then reads from and overwrites only .output as BO iterations progress
-    (get_profiles()/get_derived() default to side="output" throughout, see MITIMstate.py).
-    io.py's input/output getters and setters already deep-copy on both read and write, so
-    `obj.output = obj.input` below is a true independent copy, not an alias.
-
-    Idempotent/safe to call more than once on the same object -- once both sides are
-    populated, this is a no-op. This matters because initializeProblem() calls it at
-    several points that can all see the same object (the raw-path auto-conversion branch,
-    then again later when it falls through to the generic isinstance(fileStart, io)
-    branches) -- an unconditional `obj.output = obj.input` would silently clobber
-    .output's already-preprocessed state (post remove_fast_ions()/
-    compute_derived_quantities(), which run on .output right after the first call) with
-    the stale, unprocessed .input snapshot on the second call. Must still run exactly
-    once as the very first *effective* operation on any plasma_io/gacode_io object MITIM
-    receives -- NOT inside mitim_state.scratch(), which is called repeatedly throughout a
-    run (every transport evaluation) and, unlike this idempotent guard, has no way to
-    distinguish "fresh object" from "object with real accumulated BO progress on .output".
-
-    If the object arrives with only .output populated (e.g. a caller-constructed object
-    that ran its own preprocessing directly on .output -- every existing .nc-branch
-    PORTALS_workflow_nc*.py script does this today), .input is backfilled from it first so
-    a reference snapshot still exists. This is deliberately a backfill, not a hard
-    requirement that callers populate .input themselves, so existing scripts' own
-    loading/preprocessing conventions don't need to change.
-    """
-    if not obj.has_input:
-        if not obj.has_output:
-            raise ValueError(
-                f"{type(obj).__name__} object has neither .input nor .output populated -- "
-                "cannot establish a starting state for MITIM/PORTALS."
-            )
-        obj.input = obj.output
-    if not obj.has_output:
-        obj.output = obj.input
 
 
 def initializeProblem(
@@ -102,28 +61,24 @@ def initializeProblem(
     # ---- If given a raw file path (not a MITIMstate/fusio object already), route it through
     # fusio's plasma_io conversion instead of the legacy hand-rolled input.gacode parser -- reuses
     # the exact sequence already validated end-to-end in test/fusio_integration/PORTALS_workflow.py's
-    # .gacode branch (Ricci/residual numbers documented in plasma_io_migration_plan.md). Once
-    # converted, fileStart becomes a fusio `io` instance and falls through to the branches below
-    # unchanged. Old (hand-rolled-parser) behavior kept available via use_plasma_io=False.
+    # .gacode branch (Ricci/residual numbers documented in plasma_io_migration_plan.md), now moved
+    # into mitim_state.scratch() itself (see MITIMstate.py's raw-filename branch) rather than being
+    # orchestrated here. .gacode loads still become a gacode_state (the source really was a GACODE
+    # ASCII file, and downstream code needs its hand-rolled-parser/write_state() capability); .nc
+    # loads become a bare mitim_state instead -- a .nc file was never actually GACODE-format, so
+    # tagging it gacode_state would misrepresent its provenance and drag in write_state()'s
+    # dependency on gacode_state-only bookkeeping (self.titles_single/self.files) that a .nc-sourced
+    # object never has. The checkpoints below dispatch on gacode_state specifically (not the
+    # broader mitim_state) so a .nc-sourced bare mitim_state instead falls through the same
+    # isinstance(fileStart, io) branches used for any other raw fusio object, upgrading to a real
+    # gacode_state only where the pipeline actually needs one (checkpoint 2's `profiles`). Old
+    # (hand-rolled-parser) behavior kept available via use_plasma_io=False.
     if use_plasma_io and not isinstance(fileStart, (MITIMstate.mitim_state, io)):
         fileStart_path = Path(fileStart)
         if fileStart_path.suffix == ".gacode":
-            fileStart = gacode_io.from_file(fileStart_path).to("plasma")
-            # .to("plasma") always writes to the *input* side of the new plasma_io object
-            # (io.py's convention for all from_*()/.to() conversions) -- see
-            # _ensure_plasma_io_deepcopy()'s docstring for why this is the first operation.
-            _ensure_plasma_io_deepcopy(fileStart)
-            # use_main_ion=True: matches MITIM's own gacode_state.correct(quasineutrality=True)
-            # convention (adjusts D/T ion density to match ne).
-            fileStart.remove_fast_ions(enforce_quasineutrality=True, use_main_ion=True, side='output')
-            fileStart.compute_derived_quantities(side='output')
+            fileStart = PROFILEStools.gacode_state.scratch(fileStart_path)
         elif fileStart_path.suffix == ".nc":
-            # input=... (not the bare/path= default, which lands on .output) so the raw file
-            # lands on .input -- see _ensure_plasma_io_deepcopy()'s docstring.
-            fileStart = plasma_io.from_file(input=fileStart_path)
-            _ensure_plasma_io_deepcopy(fileStart)
-            fileStart.remove_fast_ions(enforce_quasineutrality=True, side='output')
-            fileStart.compute_derived_quantities(side='output')
+            fileStart = MITIMstate.mitim_state.scratch(fileStart_path)
         # else: unrecognized suffix -- leave fileStart as the original path, falls through to the
         # legacy shutil.copy2/hand-rolled-parser branches below.
 
@@ -132,14 +87,15 @@ def initializeProblem(
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
     # ---- Copy the file of interest to initialization folder
-    if isinstance(fileStart, MITIMstate.mitim_state):
+    if isinstance(fileStart, PROFILEStools.gacode_state):
         fileStart.write_state(file=FolderInitialization / "input.gacode")
     elif isinstance(fileStart, io):
         # Establishes .input as the canonical snapshot and .output as an independent
         # working copy (backfilling .input from .output first if only .output was
-        # populated by the caller) -- see _ensure_plasma_io_deepcopy()'s docstring.
-        # Replaces the old swap()-based logic, which emptied out whichever side had
-        # data instead of preserving it as a pristine reference.
+        # populated by the caller) -- see _ensure_plasma_io_deepcopy()'s docstring. Also
+        # catches a bare (non-gacode_state) mitim_state, e.g. from the .nc branch above --
+        # write_state() would fail on it (no titles_single/files), so it goes through
+        # fusio's own gacode-text writer instead, same as any other raw fusio object.
         _ensure_plasma_io_deepcopy(fileStart)
         fileStart.to("gacode").write(FolderInitialization / "input.gacode", side="input")
     else:
@@ -152,9 +108,9 @@ def initializeProblem(
     # ---- Initialize file to modify and increase resolution
 
     initialization_file = FolderInitialization / "input.gacode"
-    
+
     # If it is a profiles class, use it directly
-    if isinstance(fileStart, MITIMstate.mitim_state):
+    if isinstance(fileStart, PROFILEStools.gacode_state):
         profiles = copy.deepcopy(fileStart)
     elif isinstance(fileStart, io):
         # Establishes .input as the canonical snapshot and .output as an independent

--- a/src/mitim_modules/portals/utils/PORTALSinit.py
+++ b/src/mitim_modules/portals/utils/PORTALSinit.py
@@ -63,6 +63,8 @@ def initializeProblem(
     if isinstance(fileStart, MITIMstate.mitim_state):
         fileStart.write_state(file=FolderInitialization / "input.gacode")
     elif isinstance(fileStart, io):
+        if not fileStart.has_output and fileStart.has_input:
+            fileStart.swap()
         fileStart.to("gacode").write(FolderInitialization / "input.gacode", side="input")
     else:
         shutil.copy2(fileStart, FolderInitialization / "input.gacode")
@@ -79,6 +81,8 @@ def initializeProblem(
     if isinstance(fileStart, MITIMstate.mitim_state):
         profiles = copy.deepcopy(fileStart)
     elif isinstance(fileStart, io):
+        if not fileStart.has_output and fileStart.has_input:
+            fileStart.swap()
         profiles = PROFILEStools.gacode_state.scratch(fileStart.to("gacode").to_dict(side="input"))
     # If it is a file, then assume it is a gacode one (#TODO: check type?)
     else:

--- a/src/mitim_modules/portals/utils/PORTALSinit.py
+++ b/src/mitim_modules/portals/utils/PORTALSinit.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 import torch
 import copy
 import numpy as np
@@ -12,6 +13,8 @@ from mitim_modules.portals import PORTALStools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools import __mitimroot__
 from fusio.classes.io import io
+from fusio.classes.gacode import gacode_io
+from fusio.classes.plasma import plasma_io
 from IPython import embed
 
 
@@ -35,6 +38,7 @@ def initializeProblem(
     },
     add_fidelity_level_variable=False,
     n_fidelities=1,
+    use_plasma_io=True,
     ):
     """
     Notes:
@@ -54,6 +58,32 @@ def initializeProblem(
         IOtools.askNewFolder(folderWork, force=cold_start)
 
     FolderInitialization.mkdir(parents=True, exist_ok=True)
+
+    # ---- If given a raw file path (not a MITIMstate/fusio object already), route it through
+    # fusio's plasma_io conversion instead of the legacy hand-rolled input.gacode parser -- reuses
+    # the exact sequence already validated end-to-end in test/fusio_integration/PORTALS_workflow.py's
+    # .gacode branch (Ricci/residual numbers documented in plasma_io_migration_plan.md). Once
+    # converted, fileStart becomes a fusio `io` instance and falls through to the branches below
+    # unchanged. Old (hand-rolled-parser) behavior kept available via use_plasma_io=False.
+    if use_plasma_io and not isinstance(fileStart, (MITIMstate.mitim_state, io)):
+        fileStart_path = Path(fileStart)
+        if fileStart_path.suffix == ".gacode":
+            fileStart = gacode_io.from_file(fileStart_path).to("plasma")
+            # .to("plasma") always writes to the *input* side of the new plasma_io object
+            # (io.py's convention for all from_*()/.to() conversions) -- move to .output,
+            # matching every other plasma_io construction path in this codebase (scratch()'s
+            # implicit .to("gacode") read expects data on .output).
+            fileStart.output = fileStart.input
+            # use_main_ion=True: matches MITIM's own gacode_state.correct(quasineutrality=True)
+            # convention (adjusts D/T ion density to match ne).
+            fileStart.remove_fast_ions(enforce_quasineutrality=True, use_main_ion=True, side='output')
+            fileStart.compute_derived_quantities(side='output')
+        elif fileStart_path.suffix == ".nc":
+            fileStart = plasma_io.from_file(fileStart_path)
+            fileStart.remove_fast_ions(enforce_quasineutrality=True, side='output')
+            fileStart.compute_derived_quantities(side='output')
+        # else: unrecognized suffix -- leave fileStart as the original path, falls through to the
+        # legacy shutil.copy2/hand-rolled-parser branches below.
 
     # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # Initialize file input.gacode
@@ -92,7 +122,7 @@ def initializeProblem(
     # About radial locations
     if portals_fun.portals_parameters["solution"]["predicted_roa"] is not None:
         roa = portals_fun.portals_parameters["solution"]["predicted_roa"]
-        rho = np.interp(roa, profiles.derived["roa"], profiles.profiles["rho(-)"])
+        rho = np.interp(roa, profiles.get_derived()["roa"], profiles.get_profiles()["rho(-)"])
         print("\t * r/a provided, transforming to rho:")
         print(f"\t\t r/a = {roa}")
         print(f"\t\t rho = {rho}")
@@ -107,7 +137,7 @@ def initializeProblem(
         position_of_impurity = 0
 
     if portals_fun.portals_parameters["solution"]["fZ0_as_weight"] is not None and portals_fun.portals_parameters["solution"]["trace_impurity"] is not None:
-        f0 = profiles.Species[position_of_impurity]["n0"] / profiles.profiles['ne(10^19/m^3)'][0]
+        f0 = profiles.Species[position_of_impurity]["n0"] / profiles.get_profiles()['ne(10^19/m^3)'][0]
         portals_fun.portals_parameters["solution"]["fImp_orig"] = f0/portals_fun.portals_parameters["solution"]["fZ0_as_weight"]
         print(f'\t- Ion {portals_fun.portals_parameters["solution"]["trace_impurity"]} has original central concentration of {f0:.2e}, using its inverse multiplied by {portals_fun.portals_parameters["solution"]["fZ0_as_weight"]} as scaling factor of GZ -> {portals_fun.portals_parameters["solution"]["fImp_orig"]:.2e}',typeMsg="i")
     else:

--- a/src/mitim_modules/portals/utils/PORTALSinit.py
+++ b/src/mitim_modules/portals/utils/PORTALSinit.py
@@ -11,6 +11,7 @@ from mitim_modules.powertorch import STATEtools
 from mitim_modules.portals import PORTALStools
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools import __mitimroot__
+from fusio.classes.io import io
 from IPython import embed
 
 
@@ -61,6 +62,8 @@ def initializeProblem(
     # ---- Copy the file of interest to initialization folder
     if isinstance(fileStart, MITIMstate.mitim_state):
         fileStart.write_state(file=FolderInitialization / "input.gacode")
+    elif isinstance(fileStart, io):
+        fileStart.to("gacode").write(FolderInitialization / "input.gacode", side="input")
     else:
         shutil.copy2(fileStart, FolderInitialization / "input.gacode")
 
@@ -75,6 +78,8 @@ def initializeProblem(
     # If it is a profiles class, use it directly
     if isinstance(fileStart, MITIMstate.mitim_state):
         profiles = copy.deepcopy(fileStart)
+    elif isinstance(fileStart, io):
+        profiles = PROFILEStools.gacode_state.scratch(fileStart.to("gacode").to_dict(side="input"))
     # If it is a file, then assume it is a gacode one (#TODO: check type?)
     else:
         profiles = PROFILEStools.gacode_state(initialization_file)

--- a/src/mitim_modules/portals/utils/PORTALSplot.py
+++ b/src/mitim_modules/portals/utils/PORTALSplot.py
@@ -129,52 +129,52 @@ def PORTALSanalyzer_plotMetrics(
             rho = power.plasma['rho'][0].cpu().numpy()
 
             ix = np.argmin(
-                np.abs(p.profiles["rho(-)"] - rho[-1].item())
+                np.abs(p.get_profiles()["rho(-)"] - rho[-1].item())
             )
             if axTe is not None:
                 axTe.plot(
-                    p.profiles["rho(-)"],
-                    p.profiles["te(keV)"],
+                    p.get_profiles()["rho(-)"],
+                    p.get_profiles()["te(keV)"],
                     lw=lw,
                     color=col,
                     label=lab,
                     alpha=alph,
                 )
                 axTe_g.plot(
-                    p.profiles["rho(-)"][:ix],
-                    p.derived["aLTe"][:ix],
+                    p.get_profiles()["rho(-)"][:ix],
+                    p.get_derived()["aLTe"][:ix],
                     lw=lw,
                     color=col,
                     alpha=alph,
                 )
             if axTi is not None:
                 axTi.plot(
-                    p.profiles["rho(-)"],
-                    p.profiles["ti(keV)"][:, 0],
+                    p.get_profiles()["rho(-)"],
+                    p.get_profiles()["ti(keV)"][:, 0],
                     lw=lw,
                     color=col,
                     label=lab,
                     alpha=alph,
                 )
                 axTi_g.plot(
-                    p.profiles["rho(-)"][:ix],
-                    p.derived["aLTi"][:ix, 0],
+                    p.get_profiles()["rho(-)"][:ix],
+                    p.get_derived()["aLTi"][:ix, 0],
                     lw=lw,
                     color=col,
                     alpha=alph,
                 )
             if axne is not None:
                 axne.plot(
-                    p.profiles["rho(-)"],
-                    p.profiles["ne(10^19/m^3)"] * 1e-1,
+                    p.get_profiles()["rho(-)"],
+                    p.get_profiles()["ne(10^19/m^3)"] * 1e-1,
                     lw=lw,
                     color=col,
                     label=lab,
                     alpha=alph,
                 )
                 axne_g.plot(
-                    p.profiles["rho(-)"][:ix],
-                    p.derived["aLne"][:ix],
+                    p.get_profiles()["rho(-)"][:ix],
+                    p.get_derived()["aLne"][:ix],
                     lw=lw,
                     color=col,
                     alpha=alph,
@@ -182,16 +182,16 @@ def PORTALSanalyzer_plotMetrics(
 
             if axnZ is not None:
                 axnZ.plot(
-                    p.profiles["rho(-)"],
-                    p.profiles["ni(10^19/m^3)"][:, self.runWithImpurity] * 1e-1,
+                    p.get_profiles()["rho(-)"],
+                    p.get_profiles()["ni(10^19/m^3)"][:, self.runWithImpurity] * 1e-1,
                     lw=lw,
                     color=col,
                     label=lab,
                     alpha=alph,
                 )
                 axnZ_g.plot(
-                    p.profiles["rho(-)"][:ix],
-                    p.derived["aLni"][:ix, self.runWithImpurity],
+                    p.get_profiles()["rho(-)"][:ix],
+                    p.get_derived()["aLni"][:ix, self.runWithImpurity],
                     lw=lw,
                     color=col,
                     alpha=alph,
@@ -199,16 +199,16 @@ def PORTALSanalyzer_plotMetrics(
 
             if axw0 is not None:
                 axw0.plot(
-                    p.profiles["rho(-)"],
-                    p.profiles["w0(rad/s)"] * 1e-3,
+                    p.get_profiles()["rho(-)"],
+                    p.get_profiles()["w0(rad/s)"] * 1e-3,
                     lw=lw,
                     color=col,
                     label=lab,
                     alpha=alph,
                 )
                 axw0_g.plot(
-                    p.profiles["rho(-)"][:ix],
-                    p.derived["dw0dr"][:ix] * factor_dw0dr,
+                    p.get_profiles()["rho(-)"][:ix],
+                    p.get_derived()["dw0dr"][:ix] * factor_dw0dr,
                     lw=lw,
                     color=col,
                     alpha=alph,
@@ -289,15 +289,15 @@ def PORTALSanalyzer_plotMetrics(
         power = self.powerstates[indexUse]
         p = power.profiles
         
-        ix = np.argmin(np.abs(p.profiles["rho(-)"] - rho[-1]))
+        ix = np.argmin(np.abs(p.get_profiles()["rho(-)"] - rho[-1]))
 
         if axTe_g is not None:
             axTe.plot(
-                p.profiles["rho(-)"], p.profiles["te(keV)"], lw=2, color=col, label=lab
+                p.get_profiles()["rho(-)"], p.get_profiles()["te(keV)"], lw=2, color=col, label=lab
             )
             axTe_g.plot(
-                p.profiles["rho(-)"][:ix],
-                p.derived["aLTe"][:ix],
+                p.get_profiles()["rho(-)"][:ix],
+                p.get_derived()["aLTe"][:ix],
                 "-",
                 markersize=msFlux,
                 lw=2,
@@ -305,15 +305,15 @@ def PORTALSanalyzer_plotMetrics(
             )
         if axTi_g is not None:
             axTi.plot(
-                p.profiles["rho(-)"],
-                p.profiles["ti(keV)"][:, 0],
+                p.get_profiles()["rho(-)"],
+                p.get_profiles()["ti(keV)"][:, 0],
                 lw=2,
                 color=col,
                 label=lab,
             )
             axTi_g.plot(
-                p.profiles["rho(-)"][:ix],
-                p.derived["aLTi"][:ix, 0],
+                p.get_profiles()["rho(-)"][:ix],
+                p.get_derived()["aLTi"][:ix, 0],
                 "-",
                 markersize=msFlux,
                 lw=2,
@@ -321,15 +321,15 @@ def PORTALSanalyzer_plotMetrics(
             )
         if axne is not None:
             axne.plot(
-                p.profiles["rho(-)"],
-                p.profiles["ne(10^19/m^3)"] * 1e-1,
+                p.get_profiles()["rho(-)"],
+                p.get_profiles()["ne(10^19/m^3)"] * 1e-1,
                 lw=2,
                 color=col,
                 label=lab,
             )
             axne_g.plot(
-                p.profiles["rho(-)"][:ix],
-                p.derived["aLne"][:ix],
+                p.get_profiles()["rho(-)"][:ix],
+                p.get_derived()["aLne"][:ix],
                 "-",
                 markersize=msFlux,
                 lw=2,
@@ -338,15 +338,15 @@ def PORTALSanalyzer_plotMetrics(
 
         if axnZ is not None:
             axnZ.plot(
-                p.profiles["rho(-)"],
-                p.profiles["ni(10^19/m^3)"][:, self.runWithImpurity] * 1e-1,
+                p.get_profiles()["rho(-)"],
+                p.get_profiles()["ni(10^19/m^3)"][:, self.runWithImpurity] * 1e-1,
                 lw=2,
                 color=col,
                 label=lab,
             )
             axnZ_g.plot(
-                p.profiles["rho(-)"][:ix],
-                p.derived["aLni"][:ix, self.runWithImpurity],
+                p.get_profiles()["rho(-)"][:ix],
+                p.get_derived()["aLni"][:ix, self.runWithImpurity],
                 markersize=msFlux,
                 lw=2,
                 color=col,
@@ -354,15 +354,15 @@ def PORTALSanalyzer_plotMetrics(
 
         if axw0 is not None:
             axw0.plot(
-                p.profiles["rho(-)"],
-                p.profiles["w0(rad/s)"] * 1e-3,
+                p.get_profiles()["rho(-)"],
+                p.get_profiles()["w0(rad/s)"] * 1e-3,
                 lw=2,
                 color=col,
                 label=lab,
             )
             axw0_g.plot(
-                p.profiles["rho(-)"][:ix],
-                p.derived["dw0dr"][:ix] * factor_dw0dr,
+                p.get_profiles()["rho(-)"][:ix],
+                p.get_derived()["dw0dr"][:ix] * factor_dw0dr,
                 "-",
                 markersize=msFlux,
                 lw=2,
@@ -1201,8 +1201,8 @@ def PORTALSanalyzer_plotExpected(
 
     p = self.powerstates[0].profiles
 
-    rho = p.profiles["rho(-)"]
-    roa = p.derived["roa"]
+    rho = p.get_profiles()["rho(-)"]
+    roa = p.get_derived()["roa"]
     rhoVals = self.portals_parameters["solution"]["predicted_rho"]
     roaVals = np.interp(rhoVals, rho, roa)
     lastX = roaVals[-1]
@@ -1214,15 +1214,15 @@ def PORTALSanalyzer_plotExpected(
 
         p = self.powerstates[i].profiles
 
-        ix = np.argmin(np.abs(p.derived["roa"] - lastX)) + 1
+        ix = np.argmin(np.abs(p.get_derived()["roa"] - lastX)) + 1
 
         lw = 1.0 if cont > 0 else 1.5
 
         if axTe is not None:
             ax = axTe
             ax.plot(
-                p.derived["roa"],
-                p.profiles["te(keV)"],
+                p.get_derived()["roa"],
+                p.get_profiles()["te(keV)"],
                 "-",
                 c=colors[cont],
                 label=labelAssigned[cont],
@@ -1231,13 +1231,13 @@ def PORTALSanalyzer_plotExpected(
         if axTi is not None:
             ax = axTi
             ax.plot(
-                p.derived["roa"], p.profiles["ti(keV)"][:, 0], "-", c=colors[cont], lw=lw
+                p.get_derived()["roa"], p.get_profiles()["ti(keV)"][:, 0], "-", c=colors[cont], lw=lw
             )
         if axne is not None:
             ax = axne
             ax.plot(
-                p.derived["roa"],
-                p.profiles["ne(10^19/m^3)"] * 1e-1,
+                p.get_derived()["roa"],
+                p.get_profiles()["ne(10^19/m^3)"] * 1e-1,
                 "-",
                 c=colors[cont],
                 lw=lw,
@@ -1245,8 +1245,8 @@ def PORTALSanalyzer_plotExpected(
         if axnZ is not None:
             ax = axnZ
             ax.plot(
-                p.derived["roa"],
-                p.profiles["ni(10^19/m^3)"][:, self.runWithImpurity] * 1e-1,
+                p.get_derived()["roa"],
+                p.get_profiles()["ni(10^19/m^3)"][:, self.runWithImpurity] * 1e-1,
                 "-",
                 c=colors[cont],
                 lw=lw,
@@ -1254,8 +1254,8 @@ def PORTALSanalyzer_plotExpected(
         if axw0 is not None:
             ax = axw0
             ax.plot(
-                p.derived["roa"],
-                p.profiles["w0(rad/s)"] * 1e-3,
+                p.get_derived()["roa"],
+                p.get_profiles()["w0(rad/s)"] * 1e-3,
                 "-",
                 c=colors[cont],
                 lw=lw,
@@ -1264,8 +1264,8 @@ def PORTALSanalyzer_plotExpected(
         if axTe_g is not None:
             ax = axTe_g
             ax.plot(
-                p.derived["roa"][:ix],
-                p.derived["aLTe"][:ix],
+                p.get_derived()["roa"][:ix],
+                p.get_derived()["aLTe"][:ix],
                 "-o",
                 c=colors[cont],
                 markersize=0,
@@ -1274,8 +1274,8 @@ def PORTALSanalyzer_plotExpected(
         if axTi_g is not None:
             ax = axTi_g
             ax.plot(
-                p.derived["roa"][:ix],
-                p.derived["aLTi"][:ix, 0],
+                p.get_derived()["roa"][:ix],
+                p.get_derived()["aLTi"][:ix, 0],
                 "-o",
                 c=colors[cont],
                 markersize=0,
@@ -1284,8 +1284,8 @@ def PORTALSanalyzer_plotExpected(
         if axne_g is not None:
             ax = axne_g
             ax.plot(
-                p.derived["roa"][:ix],
-                p.derived["aLne"][:ix],
+                p.get_derived()["roa"][:ix],
+                p.get_derived()["aLne"][:ix],
                 "-o",
                 c=colors[cont],
                 markersize=0,
@@ -1295,8 +1295,8 @@ def PORTALSanalyzer_plotExpected(
         if axnZ_g is not None:
             ax = axnZ_g
             ax.plot(
-                p.derived["roa"][:ix],
-                p.derived["aLni"][:ix, self.runWithImpurity],
+                p.get_derived()["roa"][:ix],
+                p.get_derived()["aLni"][:ix, self.runWithImpurity],
                 "-o",
                 c=colors[cont],
                 markersize=0,
@@ -1305,8 +1305,8 @@ def PORTALSanalyzer_plotExpected(
         if axw0_g is not None:
             ax = axw0_g
             ax.plot(
-                p.derived["roa"][:ix],
-                p.derived["dw0dr"][:ix] * factor_dw0dr,
+                p.get_derived()["roa"][:ix],
+                p.get_derived()["dw0dr"][:ix] * factor_dw0dr,
                 "-o",
                 c=colors[cont],
                 markersize=0,
@@ -1319,8 +1319,8 @@ def PORTALSanalyzer_plotExpected(
 
     if self.profiles_next is not None:
         p = self.profiles_next
-        roa = self.profiles_next_new.derived["roa"]
-        dw0dr = self.profiles_next_new.derived["dw0dr"]
+        roa = self.profiles_next_new.get_derived()["roa"]
+        dw0dr = self.profiles_next_new.get_derived()["dw0dr"]
 
         ix = np.argmin(np.abs(roa - lastX)) + 1
 
@@ -1330,7 +1330,7 @@ def PORTALSanalyzer_plotExpected(
             ax = axTe
             ax.plot(
                 roa,
-                p.profiles["te(keV)"],
+                p.get_profiles()["te(keV)"],
                 "-",
                 c="k",
                 label=f"#{x_train_num} (next)",
@@ -1338,40 +1338,40 @@ def PORTALSanalyzer_plotExpected(
             )
         if axTi is not None:
             ax = axTi
-            ax.plot(roa, p.profiles["ti(keV)"][:, 0], "-", c="k", lw=lw)
+            ax.plot(roa, p.get_profiles()["ti(keV)"][:, 0], "-", c="k", lw=lw)
         if axne is not None:
             ax = axne
-            ax.plot(roa, p.profiles["ne(10^19/m^3)"] * 1e-1, "-", c="k", lw=lw)
+            ax.plot(roa, p.get_profiles()["ne(10^19/m^3)"] * 1e-1, "-", c="k", lw=lw)
 
         if axnZ is not None:
             ax = axnZ
             ax.plot(
                 roa,
-                p.profiles["ni(10^19/m^3)"][:, self.runWithImpurity] * 1e-1,
+                p.get_profiles()["ni(10^19/m^3)"][:, self.runWithImpurity] * 1e-1,
                 "-",
                 c="k",
                 lw=lw,
             )
         if axw0 is not None:
             ax = axw0
-            ax.plot(roa, p.profiles["w0(rad/s)"] * 1e-3, "-", c="k", lw=lw)
+            ax.plot(roa, p.get_profiles()["w0(rad/s)"] * 1e-3, "-", c="k", lw=lw)
 
         if axTe_g is not None:
             ax = axTe_g
-            ax.plot(roa[:ix], p.derived["aLTe"][:ix], "o-", c="k", markersize=0, lw=lw)
+            ax.plot(roa[:ix], p.get_derived()["aLTe"][:ix], "o-", c="k", markersize=0, lw=lw)
         if axTi_g is not None:
             ax = axTi_g
-            ax.plot(roa[:ix], p.derived["aLTi"][:ix, 0], "o-", c="k", markersize=0, lw=lw)
+            ax.plot(roa[:ix], p.get_derived()["aLTi"][:ix, 0], "o-", c="k", markersize=0, lw=lw)
 
         if axne_g is not None:
             ax = axne_g
-            ax.plot(roa[:ix], p.derived["aLne"][:ix], "o-", c="k", markersize=0, lw=lw)
+            ax.plot(roa[:ix], p.get_derived()["aLne"][:ix], "o-", c="k", markersize=0, lw=lw)
 
         if axnZ_g is not None:
             ax = axnZ_g
             ax.plot(
                 roa[:ix],
-                p.derived["aLni"][:ix, self.runWithImpurity],
+                p.get_derived()["aLni"][:ix, self.runWithImpurity],
                 "-o",
                 c="k",
                 markersize=0,
@@ -1390,13 +1390,13 @@ def PORTALSanalyzer_plotExpected(
 
             
 
-            rho = self.profiles_next_new.profiles["rho(-)"]
+            rho = self.profiles_next_new.get_profiles()["rho(-)"]
             rhoVals = self.portals_parameters["solution"]["predicted_rho"]
             roaVals = np.interp(rhoVals, rho, roa)
 
             p0 = self.powerstates[plotPoints[0]].profiles
             zVals = []
-            z = ((p.derived["aLTe"] - p0.derived["aLTe"]) / p0.derived["aLTe"]) * 100.0
+            z = ((p.get_derived()["aLTe"] - p0.get_derived()["aLTe"]) / p0.get_derived()["aLTe"]) * 100.0
             for roai in roaVals:
                 zVals.append(np.interp(roai, roa, z))
             axTe_g_twin.plot(roaVals, zVals, "--s", c=colors[0], lw=0.5, markersize=4)
@@ -1404,7 +1404,7 @@ def PORTALSanalyzer_plotExpected(
             if len(labelAssigned) > 1 and "last" in labelAssigned[1]:
                 p0 = self.powerstates[plotPoints[1]].profiles
                 zVals = []
-                z = ((p.derived["aLTe"] - p0.derived["aLTe"]) / p0.derived["aLTe"]) * 100.0
+                z = ((p.get_derived()["aLTe"] - p0.get_derived()["aLTe"]) / p0.get_derived()["aLTe"]) * 100.0
                 for roai in roaVals:
                     zVals.append(np.interp(roai, roa, z))
                 axTe_g_twin.plot(roaVals, zVals, "--s", c=colors[1], lw=0.5, markersize=4)
@@ -1418,8 +1418,8 @@ def PORTALSanalyzer_plotExpected(
             p0 = self.powerstates[plotPoints[0]].profiles
             zVals = []
             z = (
-                (p.derived["aLTi"][:, 0] - p0.derived["aLTi"][:, 0])
-                / p0.derived["aLTi"][:, 0]
+                (p.get_derived()["aLTi"][:, 0] - p0.get_derived()["aLTi"][:, 0])
+                / p0.get_derived()["aLTi"][:, 0]
             ) * 100.0
             for roai in roaVals:
                 zVals.append(np.interp(roai, roa, z))
@@ -1429,8 +1429,8 @@ def PORTALSanalyzer_plotExpected(
                 p0 = self.powerstates[plotPoints[1]].profiles
                 zVals = []
                 z = (
-                    (p.derived["aLTi"][:, 0] - p0.derived["aLTi"][:, 0])
-                    / p0.derived["aLTi"][:, 0]
+                    (p.get_derived()["aLTi"][:, 0] - p0.get_derived()["aLTi"][:, 0])
+                    / p0.get_derived()["aLTi"][:, 0]
                 ) * 100.0
                 for roai in roaVals:
                     zVals.append(np.interp(roai, roa, z))
@@ -1447,7 +1447,7 @@ def PORTALSanalyzer_plotExpected(
 
             p0 = self.powerstates[plotPoints[0]].profiles
             zVals = []
-            z = ((p.derived["aLne"] - p0.derived["aLne"]) / p0.derived["aLne"]) * 100.0
+            z = ((p.get_derived()["aLne"] - p0.get_derived()["aLne"]) / p0.get_derived()["aLne"]) * 100.0
             for roai in roaVals:
                 zVals.append(np.interp(roai, roa, z))
             axne_g_twin.plot(roaVals, zVals, "--s", c=colors[0], lw=0.5, markersize=4)
@@ -1456,7 +1456,7 @@ def PORTALSanalyzer_plotExpected(
                 p0 = self.powerstates[plotPoints[1]].profiles
                 zVals = []
                 z = (
-                    (p.derived["aLne"] - p0.derived["aLne"]) / p0.derived["aLne"]
+                    (p.get_derived()["aLne"] - p0.get_derived()["aLne"]) / p0.get_derived()["aLne"]
                 ) * 100.0
                 for roai in roaVals:
                     zVals.append(np.interp(roai, roa, z))
@@ -1476,10 +1476,10 @@ def PORTALSanalyzer_plotExpected(
             zVals = []
             z = (
                 (
-                    p.derived["aLni"][:, self.runWithImpurity]
-                    - p0.derived["aLni"][:, self.runWithImpurity]
+                    p.get_derived()["aLni"][:, self.runWithImpurity]
+                    - p0.get_derived()["aLni"][:, self.runWithImpurity]
                 )
-                / p0.derived["aLni"][:, self.runWithImpurity]
+                / p0.get_derived()["aLni"][:, self.runWithImpurity]
             ) * 100.0
             for roai in roaVals:
                 zVals.append(np.interp(roai, roa, z))
@@ -1490,10 +1490,10 @@ def PORTALSanalyzer_plotExpected(
                 zVals = []
                 z = (
                     (
-                        p.derived["aLni"][:, self.runWithImpurity]
-                        - p0.derived["aLni"][:, self.runWithImpurity]
+                        p.get_derived()["aLni"][:, self.runWithImpurity]
+                        - p0.get_derived()["aLni"][:, self.runWithImpurity]
                     )
-                    / p0.derived["aLni"][:, self.runWithImpurity]
+                    / p0.get_derived()["aLni"][:, self.runWithImpurity]
                 ) * 100.0
                 for roai in roaVals:
                     zVals.append(np.interp(roai, roa, z))
@@ -1511,7 +1511,7 @@ def PORTALSanalyzer_plotExpected(
 
             p0 = self.powerstates[plotPoints[0]].profiles
             zVals = []
-            z = ((dw0dr - p0.derived["dw0dr"]) / p0.derived["dw0dr"]) * 100.0
+            z = ((dw0dr - p0.get_derived()["dw0dr"]) / p0.get_derived()["dw0dr"]) * 100.0
             for roai in roaVals:
                 zVals.append(np.interp(roai, roa, z))
             axw0_g_twin.plot(roaVals, zVals, "--s", c=colors[0], lw=0.5, markersize=4)
@@ -1519,7 +1519,7 @@ def PORTALSanalyzer_plotExpected(
             if len(labelAssigned) > 1 and "last" in labelAssigned[1]:
                 p0 = self.powerstates[plotPoints[1]].profiles
                 zVals = []
-                z = ((dw0dr - p0.derived["dw0dr"]) / p0.derived["dw0dr"]) * 100.0
+                z = ((dw0dr - p0.get_derived()["dw0dr"]) / p0.get_derived()["dw0dr"]) * 100.0
                 for roai in roaVals:
                     zVals.append(np.interp(roai, roa, z))
                 axw0_g_twin.plot(
@@ -2035,33 +2035,33 @@ def PORTALSanalyzer_plotDebug(self, fig=None):
             power = self.powerstates[i]
             p = power.profiles
             
-            axs['Te'].plot(p.derived['roa'], p.profiles["te(keV)"], label=f"#{i}", c=colors[j], lw=lw)
+            axs['Te'].plot(p.get_derived()['roa'], p.get_profiles()["te(keV)"], label=f"#{i}", c=colors[j], lw=lw)
             axs['Te'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['te'][0,1:].cpu().numpy(), mm, c=colors[j], markersize=3)
             
-            axs['Ti'].plot(p.derived['roa'], p.profiles["ti(keV)"][:,0], c=colors[j], lw=lw)
+            axs['Ti'].plot(p.get_derived()['roa'], p.get_profiles()["ti(keV)"][:,0], c=colors[j], lw=lw)
             axs['Ti'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['ti'][0,1:].cpu().numpy(), mm, c=colors[j], markersize=3)
             
-            axs['ne'].plot(p.derived['roa'], p.profiles["ne(10^19/m^3)"] * 1e-1, c=colors[j], lw=lw)
+            axs['ne'].plot(p.get_derived()['roa'], p.get_profiles()["ne(10^19/m^3)"] * 1e-1, c=colors[j], lw=lw)
             axs['ne'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['ne'][0,1:].cpu().numpy() * 1e-1, mm, c=colors[j], markersize=3)
             
-            axs['aLTe'].plot(p.derived['roa'], p.derived["aLTe"], c=colors[j], lw=lw)
+            axs['aLTe'].plot(p.get_derived()['roa'], p.get_derived()["aLTe"], c=colors[j], lw=lw)
             axs['aLTe'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['aLte'][0,1:].cpu().numpy(), mm, c=colors[j], markersize=3)
             
-            axs['aLTi'].plot(p.derived['roa'], p.derived["aLTi"][:,0], c=colors[j], lw=lw)
+            axs['aLTi'].plot(p.get_derived()['roa'], p.get_derived()["aLTi"][:,0], c=colors[j], lw=lw)
             axs['aLTi'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['aLti'][0,1:].cpu().numpy(), mm, c=colors[j], markersize=3)
             
-            axs['aLne'].plot(p.derived['roa'], p.derived["aLne"], c=colors[j], lw=lw)
+            axs['aLne'].plot(p.get_derived()['roa'], p.get_derived()["aLne"], c=colors[j], lw=lw)
             axs['aLne'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['aLne'][0,1:].cpu().numpy(), mm, c=colors[j], markersize=3)
             
-            axs['Qe'].plot(p.derived['roa'], p.derived["qe_MWm2"], c=colors[j], lw=lw/2, label=f"HR target")
+            axs['Qe'].plot(p.get_derived()['roa'], p.get_derived()["qe_MWm2"], c=colors[j], lw=lw/2, label=f"HR target")
             axs['Qe'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['QeMWm2'][0,1:].cpu().numpy(), mm2, c=colors[j], markersize=3, label=f"target")
             axs['Qe'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['QeMWm2_tr'][0,1:].cpu().numpy(), mm, c=colors[j], markersize=3, label=f"transport")
             
-            axs['Qi'].plot(p.derived['roa'], p.derived["qi_MWm2"], c=colors[j], lw=lw/2)
+            axs['Qi'].plot(p.get_derived()['roa'], p.get_derived()["qi_MWm2"], c=colors[j], lw=lw/2)
             axs['Qi'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['QiMWm2'][0,1:].cpu().numpy(), mm2, c=colors[j], markersize=3)
             axs['Qi'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['QiMWm2_tr'][0,1:].cpu().numpy(), mm, c=colors[j], markersize=3)
 
-            axs['Ge'].plot(p.derived['roa'], p.derived["ge_10E20m2"], c=colors[j], lw=lw/2)
+            axs['Ge'].plot(p.get_derived()['roa'], p.get_derived()["ge_10E20m2"], c=colors[j], lw=lw/2)
             axs['Ge'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['Ge1E20m2'][0,1:].cpu().numpy(), mm2, c=colors[j], markersize=3)
             axs['Ge'].plot(power.plasma['roa'][0,1:].cpu().numpy(), power.plasma['Ge1E20m2_tr'][0,1:].cpu().numpy(), mm, c=colors[j], markersize=3)
             
@@ -3698,15 +3698,15 @@ def plotFluxComparison(
         ):
             if ax is not None:
                 if var is None:
-                    y = tBest.profiles["rho(-)"] * 0.0
+                    y = tBest.get_profiles()["rho(-)"] * 0.0
                 else:
-                    y = tBest.derived[var] * mult
+                    y = tBest.get_derived()[var] * mult
 
                 if var == "ge_10E20m2":
                     y *= 1 - int(force_zero_particle_flux)
 
                 ax.plot(
-                    (tBest.profiles["rho(-)"] if not useRoa else tBest.derived["roa"]),
+                    (tBest.get_profiles()["rho(-)"] if not useRoa else tBest.get_derived()["roa"]),
                     y,
                     ":",
                     lw=1.0,
@@ -3745,8 +3745,8 @@ def plotFluxComparison(
 
         if addFlowLegend:
             (l4,) = axTe_f.plot(
-                tBest.profiles["rho(-)"] if not useRoa else tBest.derived["roa"],
-                tBest.derived["qe_MWm2"],
+                tBest.get_profiles()["rho(-)"] if not useRoa else tBest.get_derived()["roa"],
+                tBest.get_derived()["qe_MWm2"],
                 ":",
                 c="k",
                 lw=1.0,

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -152,7 +152,18 @@ class powerstate:
         # -------------------------------------------------------------------------------------
 
         if isinstance(profiles_object, MITIMstate.mitim_state):
-            self.to_powerstate = TRANSFORMtools.gacode_to_powerstate
+            # If this state was built from a fusio plasma_io object (via scratch()), source
+            # powerstate's construction from plasma_io's own SI-native fields instead of the
+            # GACODE-unit profiles/derived dict -- see plasma_io_to_powerstate()'s docstring for
+            # the current scope/caveats of this path.
+            if getattr(profiles_object, "plasma_io", None) is not None:
+                self.to_powerstate = TRANSFORMtools.plasma_io_to_powerstate
+                self.to_plasma_io = MethodType(TRANSFORMtools.to_plasma_io, self)
+                self.sync_plasma_io = MethodType(TRANSFORMtools.sync_plasma_io, self)
+            else:
+                self.to_powerstate = TRANSFORMtools.gacode_to_powerstate
+                self.to_plasma_io = None
+                self.sync_plasma_io = None
             self.from_powerstate = MethodType(TRANSFORMtools.to_gacode, self)
 
             # Use a copy because I'm deriving, it may be expensive and I don't want to carry that out outside of this class

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -156,7 +156,7 @@ class powerstate:
             # powerstate's construction from plasma_io's own SI-native fields instead of the
             # GACODE-unit profiles/derived dict -- see plasma_io_to_powerstate()'s docstring for
             # the current scope/caveats of this path.
-            if getattr(profiles_object, "plasma_io", None) is not None:
+            if getattr(profiles_object, "has_output", False):
                 self.to_powerstate = TRANSFORMtools.plasma_io_to_powerstate
                 self.to_plasma_io = MethodType(TRANSFORMtools.to_plasma_io, self)
                 self.sync_plasma_io = MethodType(TRANSFORMtools.sync_plasma_io, self)
@@ -173,7 +173,7 @@ class powerstate:
             # sourced lazily on first get_derived() call instead, so this eager call is both
             # unnecessary and would fail (gacode_state.derive_quantities() touches the dict
             # attribute directly).
-            if getattr(self.profiles, "plasma_io", None) is None and "derived" not in self.profiles.__dict__:
+            if not getattr(self.profiles, "has_output", False) and "derived" not in self.profiles.__dict__:
                 self.profiles.derive_quantities()
 
         else:
@@ -197,7 +197,7 @@ class powerstate:
         # from plasma_io's own native grid and never consumes this resampled dict -- see its
         # docstring / plasma_io_migration_plan.md's "Performance" note. Also, .profiles is no
         # longer a stored attribute for such states -- see get_profiles()/get_derived().)
-        if increase_profile_resol and getattr(self.profiles, "plasma_io", None) is None:
+        if increase_profile_resol and not getattr(self.profiles, "has_output", False):
             smooth_around_coarsing = self.transport_options.get("flatten_gradients_at_control_points", True)
             TRANSFORMtools.improve_resolution_profiles(self.profiles, rho_vec, smooth_around_coarsing=smooth_around_coarsing)
 

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -8,11 +8,13 @@ import dill as pickle
 from mitim_tools.misc_tools import PLASMAtools, IOtools
 from mitim_tools.plasmastate_tools import MITIMstate
 from mitim_tools.plasmastate_tools.utils import state_plotting
+from mitim_tools.gacode_tools import PROFILEStools
 from mitim_modules.powertorch.utils import TRANSFORMtools, POWERplot
 from mitim_tools.opt_tools.optimizers import multivariate_tools
 from mitim_modules.powertorch.utils import TARGETStools, CALCtools, TRANSPORTtools
 from mitim_modules.powertorch.physics_models import targets_analytic
 from mitim_tools.misc_tools.LOGtools import printMsg as print
+from fusio.classes.io import io
 from IPython import embed
 
 from mitim_tools.misc_tools.PLASMAtools import md_u
@@ -150,12 +152,14 @@ class powerstate:
         # Object type (e.g. input.gacode)
         # -------------------------------------------------------------------------------------
 
-        if isinstance(profiles_object, MITIMstate.mitim_state):
+        #if isinstance(profiles_object, MITIMstate.mitim_state):
+        if isinstance(profiles_object, io):
             self.to_powerstate = TRANSFORMtools.gacode_to_powerstate
             self.from_powerstate = MethodType(TRANSFORMtools.to_gacode, self)
 
             # Use a copy because I'm deriving, it may be expensive and I don't want to carry that out outside of this class
-            self.profiles = copy.deepcopy(profiles_object)
+            #self.profiles = copy.deepcopy(profiles_object)
+            self.profiles = PROFILEStools.gacode_state.from_scratch(profiles_object.to('gacode').to_dict())
             if "derived" not in self.profiles.__dict__:
                 self.profiles.derive_quantities()
 

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -14,7 +14,6 @@ from mitim_tools.opt_tools.optimizers import multivariate_tools
 from mitim_modules.powertorch.utils import TARGETStools, CALCtools, TRANSPORTtools
 from mitim_modules.powertorch.physics_models import targets_analytic
 from mitim_tools.misc_tools.LOGtools import printMsg as print
-from fusio.classes.io import io
 from IPython import embed
 
 from mitim_tools.misc_tools.PLASMAtools import md_u
@@ -152,14 +151,12 @@ class powerstate:
         # Object type (e.g. input.gacode)
         # -------------------------------------------------------------------------------------
 
-        #if isinstance(profiles_object, MITIMstate.mitim_state):
-        if isinstance(profiles_object, io):
+        if isinstance(profiles_object, MITIMstate.mitim_state):
             self.to_powerstate = TRANSFORMtools.gacode_to_powerstate
             self.from_powerstate = MethodType(TRANSFORMtools.to_gacode, self)
 
             # Use a copy because I'm deriving, it may be expensive and I don't want to carry that out outside of this class
-            #self.profiles = copy.deepcopy(profiles_object)
-            self.profiles = PROFILEStools.gacode_state.from_scratch(profiles_object.to('gacode').to_dict())
+            self.profiles = copy.deepcopy(profiles_object)
             if "derived" not in self.profiles.__dict__:
                 self.profiles.derive_quantities()
 

--- a/src/mitim_modules/powertorch/STATEtools.py
+++ b/src/mitim_modules/powertorch/STATEtools.py
@@ -168,7 +168,12 @@ class powerstate:
 
             # Use a copy because I'm deriving, it may be expensive and I don't want to carry that out outside of this class
             self.profiles = copy.deepcopy(profiles_object)
-            if "derived" not in self.profiles.__dict__:
+            # For plasma_io-backed states, .profiles/.derived are no longer stored attributes
+            # (see get_profiles()/get_derived() on mitim_state) -- derived quantities are
+            # sourced lazily on first get_derived() call instead, so this eager call is both
+            # unnecessary and would fail (gacode_state.derive_quantities() touches the dict
+            # attribute directly).
+            if getattr(self.profiles, "plasma_io", None) is None and "derived" not in self.profiles.__dict__:
                 self.profiles.derive_quantities()
 
         else:
@@ -188,7 +193,11 @@ class powerstate:
         # -------------------------------------------------------------------------------------
 
         # Resolution of input.gacode
-        if increase_profile_resol:
+        # (skipped for plasma_io-backed states: plasma_io_to_powerstate() deliberately reads
+        # from plasma_io's own native grid and never consumes this resampled dict -- see its
+        # docstring / plasma_io_migration_plan.md's "Performance" note. Also, .profiles is no
+        # longer a stored attribute for such states -- see get_profiles()/get_derived().)
+        if increase_profile_resol and getattr(self.profiles, "plasma_io", None) is None:
             smooth_around_coarsing = self.transport_options.get("flatten_gradients_at_control_points", True)
             TRANSFORMtools.improve_resolution_profiles(self.profiles, rho_vec, smooth_around_coarsing=smooth_around_coarsing)
 

--- a/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
@@ -3,7 +3,7 @@ import torch
 from pathlib import Path
 import numpy as np
 import pandas as pd
-from mitim_tools.misc_tools import LOGtools, IOtools
+from mitim_tools.misc_tools import LOGtools, IOtools, PLASMAtools
 from mitim_tools.plasmastate_tools.utils import state_plotting
 from mitim_modules.powertorch.physics_models import targets_analytic, parameterizers
 from mitim_tools.misc_tools.LOGtools import printMsg as print
@@ -39,6 +39,35 @@ def gacode_to_powerstate(self, rho_vec=None):
     # *********************************************************************************************
 
     rho_use = input_gacode.profiles["rho(-)"]
+
+    # *********************************************************************************************
+    # plasma_io propagation (see plasma_io_migration_plan.md, Part 2 Phase 2): when the source
+    # mitim_state was built from a fusio plasma_io object (via scratch()), prefer reading
+    # SI-native quantities straight from it instead of the GACODE-unit dict, one key at a time,
+    # each gated by a parity check against the dict-derived value it would otherwise replace.
+    # *********************************************************************************************
+    plasma_io_overrides = {}
+    plasma_io_obj = getattr(input_gacode, "plasma_io", None)
+    if plasma_io_obj is not None and "r_minor" in plasma_io_obj.output:
+        # Note: input_gacode.profiles may have already been resampled onto a different radial
+        # grid than plasma_io's own 'radius' coordinate (e.g. by improve_resolution_profiles,
+        # which only touches the dict, not the companion plasma_io object) — interpolate onto
+        # rho_use (the grid actually in use here) before comparing/substituting.
+        rho_plasma_io = plasma_io_obj.output["radius"].to_numpy()
+        rmin_plasma_io_native = plasma_io_obj.output["r_minor"].isel(time=-1).to_numpy()
+        rmin_from_plasma_io = interpolation_function(rho_use, rho_plasma_io, rmin_plasma_io_native)
+        rmin_from_dict = input_gacode.profiles["rmin(m)"]
+        # rmin_from_dict was itself resampled onto rho_use by improve_resolution_profiles()
+        # using a different interpolant (pchip) than the cubic spline used here, so a small
+        # (sub-mm, sub-percent) discrepancy near sharp-curvature regions (e.g. the axis) is
+        # expected even when both sources agree physically; this tolerance is loose enough to
+        # absorb that while still catching a real unit/shape/species mismatch.
+        if not np.allclose(rmin_from_plasma_io, rmin_from_dict, rtol=1e-2, atol=1e-3):
+            raise ValueError(
+                "[MITIM] plasma_io-derived 'rmin' (r_minor) does not match the gacode-dict-derived "
+                "'rmin(m)' value; refusing to substitute (parity check failed)."
+            )
+        plasma_io_overrides["rmin"] = rmin_from_plasma_io
 
     roa_array = interpolation_function(rho_vec.cpu(), rho_use, input_gacode.derived["roa"])
     rho_array = interpolation_function(rho_vec.cpu(), rho_use, input_gacode.profiles["rho(-)"])
@@ -99,7 +128,10 @@ def gacode_to_powerstate(self, rho_vec=None):
         quantities_to_interpolate.append(quant)
 
     for key in quantities_to_interpolate:
-        quant = input_gacode.derived[key[1]] if key[4] else input_gacode.profiles[key[1]]
+        if key[0] in plasma_io_overrides:
+            quant = plasma_io_overrides[key[0]]
+        else:
+            quant = input_gacode.derived[key[1]] if key[4] else input_gacode.profiles[key[1]]
 
         # *********************************************************************************************
         # Extract the quantity via interpolation and tensorization
@@ -206,6 +238,298 @@ def gacode_to_powerstate(self, rho_vec=None):
                 print(f"\t- All values of {key[0]} detected to be zero, to avoid NaNs, inserting {addT} at the edge",typeMsg="w")
                 self.plasma[f"aL{key[0]}"][..., -1] += addT
 
+def plasma_io_to_powerstate(self, rho_vec=None):
+    """
+    Equivalent of gacode_to_powerstate(), but sources data from a fusio plasma_io
+    object's own SI-native fields (via plasma_io.to_dict()) instead of the
+    GACODE-unit profiles/derived dict.
+
+    Requires:
+        - self.profiles.plasma_io is set (i.e. the source mitim_state was built via
+          scratch() from a plasma_io object).
+        - plasma_io.compute_derived_quantities() has already been run on it -- not
+          called here, since it's expensive (MXH shape decomposition) and callers
+          should control when it reruns rather than paying that cost on every
+          powerstate construction.
+
+    Scope (see plasma_io_migration_plan.md discussion):
+        - Sourced natively from plasma_io: radial grid, geometry (roa, Rmajoa,
+          volp, rmin, a, eps), kinetic profiles (te, ti, ne, nZ, w0), ion
+          densities/species bookkeeping, the gradient (aLx) parameterization
+          source arrays, the "additional_quantities_for_potential_use" tier
+          (B_unit, B_ref, q, s_q, Zeff, kappa, delta, betae, bare aLni), and the
+          "fixed targets" block (QeMWm2/QiMWm2/Ge/GZ/MtJm2_fixedtargets), which
+          are built from plasma_io's source-resolved heat/particle/momentum
+          integrals with MITIM's own sign/summation convention applied
+          explicitly (see mismatch #3 -- plasma_io stores loss-type sources
+          like ionization/radiation as negative, MITIM's dict convention adds
+          qione/qioni positively and defines qrad as a positive quantity).
+        - Note: aLte/aLti/aLne (unindexed, from the additional tier) are
+          intentionally NOT computed here even though gacode_to_powerstate
+          computes them -- they get immediately overwritten by the
+          cases_to_parameterize block below in both functions, so computing
+          them would be dead code. Only bare aLni (index-0 "main ion" gradient,
+          which is never overwritten since cases_to_parameterize only produces
+          per-species aLni{i}) is genuinely used.
+        - Bookkeeping attributes that scratch() already derives identically
+          either way (mi_first, Dion, Tion, Species) are reused from
+          self.profiles rather than re-derived from plasma_io, since they're
+          the same computation (readSpecies()) regardless of source.
+        - No attempt is made to replicate improve_resolution_profiles()'s
+          fine-grid resampling (mismatch #1, explicitly skipped per decision):
+          quantities are interpolated directly from plasma_io's native radial
+          grid onto rho_vec.
+    """
+
+    print("\t- Producing powerstate object from plasma_io")
+
+    input_gacode = self.profiles
+    plasma_io_obj = getattr(input_gacode, "plasma_io", None)
+    if plasma_io_obj is None:
+        raise ValueError("[MITIM] plasma_io_to_powerstate requires self.profiles.plasma_io to be set")
+
+    pdict = plasma_io_obj.to_dict(side="output")
+
+    if rho_vec is None:
+        rho_vec = self.plasma["rho"]
+
+    # *********************************************************************************************
+    # Radial grid (plasma_io's own native, un-resampled grid; see mismatch #1)
+    # *********************************************************************************************
+
+    rho_use = pdict["radius"]
+
+    roa_array = interpolation_function(rho_vec.cpu(), rho_use, pdict["r_minor_norm"])
+    rho_array = interpolation_function(rho_vec.cpu(), rho_use, pdict["radius"])
+
+    if len(rho_array) < 10:
+        print(f"\t\t@ rho = {[round(i,6) for i in rho_array]}")
+        print(f"\t\t@ r/a = {[round(i,6) for i in roa_array]}")
+    else:
+        print(f"\t\t@ {len(rho_array)} rho points")
+
+    # In case rho_vec is different than rho_vec_evaluate
+    self.indexes_simulation = []
+    for rho in rho_array:
+        self.indexes_simulation.append(np.argmin(np.abs(rho_array - rho)).item())
+
+    # *********************************************************************************************
+    # Quantities to interpolate and convert
+    # *********************************************************************************************
+
+    self.plasma["roa"] = torch.from_numpy(roa_array).to(rho_vec)
+    self.plasma["rho"] = torch.from_numpy(rho_array).to(rho_vec)
+    self.plasma["mi_u"] = torch.tensor(input_gacode.mi_first).to(rho_vec)
+    self.plasma["a"] = torch.tensor(pdict["r_minor_lcfs"]).to(rho_vec)
+    self.plasma["eps"] = torch.tensor(pdict["epsilon_lcfs"]).to(rho_vec)
+
+    # Composite quantities that need pre-computation on the native grid before interpolation
+    # (mirrors how MITIM's derive_quantities_full computes s_hat/s_q/betae once on the full
+    # profile grid, ahead of gacode_to_powerstate's later interpolation step).
+    s_q_native = (pdict["safety_factor"] / pdict["r_minor_norm"]) ** 2 * pdict["magnetic_shear"]
+    s_q_native[0] = 0.0  # infinite in first location, matching MITIMstate.py's explicit override
+    betae_native = PLASMAtools.betae(
+        pdict["temperature_e"] * 1.0e-3,   # eV -> keV
+        pdict["density_e"] * 1.0e-20,      # 1/m^3 -> 10^20/m^3
+        pdict["field_unit"],
+    )
+    # B_ref is NOT the same quantity as B_unit (a common confusion): MITIM defines it as
+    # |B_unit * bt_geo|, a genuine radius-varying profile that needs a proper flux-surface
+    # geometric factor (bt_geo) to compute correctly. plasma_io's closest existing candidate,
+    # mxh_field_ref, is numerically unstable near the axis (blows up to ~1e5, contaminating the
+    # whole interpolation) and isn't actually bt_geo-equivalent. Until a proper bt_geo-style
+    # calculation exists in plasma_io, use field_axis (bcentr) broadcast across the grid as a
+    # stable, order-of-magnitude placeholder rather than a per-radius profile.
+    B_ref_native = np.full_like(pdict["radius"], np.abs(pdict["field_axis"]))
+    precomputed = {"s_q": s_q_native, "betae": betae_native, "B_ref": B_ref_native}
+
+    # [powerstate key, plasma_io native key, ion index (None if not per-ion), unit-conversion factor]
+    quantities_to_interpolate = [
+        ["rho", "radius", None, 1.0],
+        ["roa", "r_minor_norm", None, 1.0],
+        ["Rmajoa", "r_geometric_norm", None, 1.0],
+        ["volp", "dvolume_dr", None, 1.0],
+        ["rmin", "r_minor", None, 1.0],
+        ["te", "temperature_e", None, 1.0e-3],          # eV -> keV
+        ["ti", "temperature_i", 0, 1.0e-3],              # eV -> keV, main-ion index 0
+        ["ne", "density_e", None, 1.0e-19],              # 1/m^3 -> 10^19/m^3
+        ["nZ", "density_i", self.impurityPosition, 1.0e-19],  # 1/m^3 -> 10^19/m^3
+        ["w0", "rotation_frequency_sonic", None, 1.0],
+        # "additional_quantities_for_potential_use" tier
+        ["B_unit", "field_unit", None, 1.0],
+        ["B_ref", None, None, 1.0],      # precomputed placeholder -- see note above
+        ["q", "safety_factor", None, 1.0],
+        ["s_q", None, None, 1.0],       # precomputed
+        ["aLni", "grad_density_i_norm", 0, 1.0],
+        ["Zeff", "effective_charge", None, 1.0],
+        ["kappa", "mxh_kappa", None, 1.0],
+        ["delta", "mxh_delta", None, 1.0],
+        ["betae", None, None, 1.0],     # precomputed
+    ]
+
+    for key in quantities_to_interpolate:
+        native = precomputed[key[0]] if key[1] is None else pdict[key[1]]
+        quant = (native if key[2] is None else native[:, key[2]]) * key[3]
+
+        # *********************************************************************************************
+        # Extract the quantity via interpolation and tensorization
+        # *********************************************************************************************
+        self.plasma[key[0]] = torch.from_numpy(
+            interpolation_function(rho_vec.cpu(), rho_use, quant)
+            ).to(rho_vec)
+        # *********************************************************************************************
+
+    # *********************************************************************************************
+    # Fixed targets
+    # *********************************************************************************************
+    # Built from plasma_io's already volume-integrated, source-resolved fields
+    # (_compute_integrated_quantities), applying MITIM's own sign/summation convention
+    # explicitly rather than reusing plasma_io's own aggregate fields, since plasma_io stores
+    # loss-type sources (ionization, radiation) as negative contributions while MITIM's dict
+    # convention adds qione/qioni positively and defines qrad as a positive quantity (mismatch #3).
+
+    source_names = list(pdict["source"])
+    def src(name):
+        return source_names.index(name)
+
+    heat_source_e_vol = pdict["heat_source_e_vol"]        # (radius, source), W
+    heat_source_i_vol = pdict["heat_source_i_vol"]        # (radius, ion, source), W
+    particle_source_e_vol = pdict["particle_source_e_vol"]  # (radius, source), particles/s
+    momentum_source_i_vol = pdict["momentum_source_i_vol"]  # (radius, ion, direction, source), N*m
+    direction_names = list(pdict["direction"])
+    tor = direction_names.index("toroidal")
+
+    # qe_aux = qrfe + qohme + qbeame + qione (all added positively in MITIM's convention;
+    # plasma_io stores ionization as a negative/loss source, hence the minus sign here)
+    qe_aux_native = (
+        heat_source_e_vol[:, src("ohmic")]
+        + heat_source_e_vol[:, src("neutral_beam")]
+        + heat_source_e_vol[:, src("ion_cyclotron")]
+        + heat_source_e_vol[:, src("electron_cyclotron")]
+        - heat_source_e_vol[:, src("ionization")]
+    ) * 1.0e-6  # W -> MW
+
+    # qi_aux = qrfi + qbeami + qioni (same ionization sign handling as qe_aux)
+    qi_aux_native = (
+        heat_source_i_vol[:, :, src("neutral_beam")].sum(axis=1)
+        + heat_source_i_vol[:, :, src("ion_cyclotron")].sum(axis=1)
+        + heat_source_i_vol[:, :, src("electron_cyclotron")].sum(axis=1)
+        - heat_source_i_vol[:, :, src("ionization")].sum(axis=1)
+    ) * 1.0e-6
+
+    qe_fus_native = pdict["fusion_heat_source_e_vol"] * 1.0e-6
+    qi_fus_native = pdict["fusion_heat_source_i_vol"].sum(axis=1) * 1.0e-6
+    # qrad is a positive quantity in MITIM's convention; plasma_io stores radiation as a
+    # negative (loss) source, hence the sign flip
+    qrad_native = -pdict["radiation_heat_source_vol"] * 1.0e-6
+    qe_exc_native = pdict["heat_exchange_ei_vol"] * 1.0e-6
+
+    ge_native = (
+        particle_source_e_vol[:, src("neutral_beam")]
+        + particle_source_e_vol[:, src("ionization")]
+        + particle_source_e_vol[:, src("charge_exchange")]
+    ) * 1.0e-20
+
+    mt_native = (
+        momentum_source_i_vol[:, 0, tor, src("neutral_beam")]
+        + momentum_source_i_vol[:, 0, tor, src("ionization")]
+        + momentum_source_i_vol[:, 0, tor, src("charge_exchange")]
+    )
+
+    quantitites = {}
+    quantitites["QeMWm2_fixedtargets"] = qe_aux_native
+    quantitites["QiMWm2_fixedtargets"] = qi_aux_native
+    quantitites["Ge_fixedtargets"] = ge_native
+    quantitites["GZ_fixedtargets"] = ge_native * 0.0
+    quantitites["MtJm2_fixedtargets"] = mt_native
+
+    if 'qfus' not in self.target_options["options"]["targets_evolve"]:
+        quantitites["QeMWm2_fixedtargets"] = quantitites["QeMWm2_fixedtargets"] + qe_fus_native
+        quantitites["QiMWm2_fixedtargets"] = quantitites["QiMWm2_fixedtargets"] + qi_fus_native
+
+    if 'qrad' not in self.target_options["options"]["targets_evolve"]:
+        quantitites["QeMWm2_fixedtargets"] = quantitites["QeMWm2_fixedtargets"] - qrad_native
+
+    if 'qie' not in self.target_options["options"]["targets_evolve"]:
+        quantitites["QeMWm2_fixedtargets"] = quantitites["QeMWm2_fixedtargets"] - qe_exc_native
+        quantitites["QiMWm2_fixedtargets"] = quantitites["QiMWm2_fixedtargets"] + qe_exc_native
+
+    # volp genuinely vanishes at the magnetic axis (it's a volume element); guard the division
+    # there rather than propagating a NaN/inf, matching similar safe-division guards elsewhere
+    # in this codebase (e.g. inv_j_r in fusio's plasma.py).
+    volp_safe = torch.where(torch.isclose(self.plasma["volp"], torch.zeros_like(self.plasma["volp"])), torch.ones_like(self.plasma["volp"]), self.plasma["volp"])
+    for key in quantitites:
+        self.plasma[key] = torch.from_numpy(interpolation_function(rho_vec.cpu(), rho_use, quantitites[key])).to(rho_vec) / volp_safe
+
+    # *********************************************************************************************
+    # Ion species need special treatment
+    # *********************************************************************************************
+
+    defineIonsFromPlasmaIO(self, input_gacode, pdict, rho_vec, rho_vec)
+
+    # *********************************************************************************************
+    # Treatment of rotation gradient
+    # *********************************************************************************************
+
+    self.plasma["kradcm"] = 1e-5 / self.plasma["a"]
+
+    # *********************************************************************************************
+    # Define profile_constructor functions for the varying profiles and gradients from here
+    # *********************************************************************************************
+
+    cases_to_parameterize = [
+        ["te", "temperature_e", None, 1.0e-3, 1.0, True],
+        ["ti", "temperature_i", 0, 1.0e-3, 1.0, True],
+        ["ne", "density_e", None, 1.0e-19, 1.0, True],
+        ["nZ", "density_i", self.impurityPosition, 1.0e-19, 1.0, True],
+        ["w0", "rotation_frequency_sonic", None, 1.0, self.plasma["kradcm"], False],
+    ]
+
+    n_ions = pdict["density_i"].shape[1]
+    for i in range(n_ions):
+        cases_to_parameterize.append([f"ni{i}", "density_i", i, 1.0e-19, 1.0, True])
+
+    smooth_around_coarsing = self.transport_options.get("flatten_gradients_at_control_points", True)
+
+    # profile_constructors_fine's fine grid must match input_gacode.profiles's own resolution
+    # (not plasma_io's native grid): powerstate_to_gacode() -- shared with the dict-based path,
+    # not aware of which dispatch built these constructors -- reconstructs full profiles from
+    # them and slice-assigns the result directly into input_gacode.profiles[key], which is fixed
+    # at whatever resolution improve_resolution_profiles() left it at. So even though
+    # plasma_io_to_powerstate otherwise reads straight from plasma_io's native grid (mismatch #1),
+    # this one piece needs plasma_io's quantities resampled onto input_gacode's fine grid first.
+    roa_use_dict = input_gacode.derived["roa"]
+    rho_use_dict = input_gacode.profiles["rho(-)"]
+
+    self.profile_constructors_fine, self.profile_constructors_coarse, self.profile_constructors_coarse_middle = {}, {}, {}
+    for key in cases_to_parameterize:
+        native = pdict[key[1]]
+        quant_native = (native if key[2] is None else native[:, key[2]]) * key[3]
+        quant = interpolation_function(rho_use_dict, rho_use, quant_native)
+
+        (
+            aLy_coarse,
+            self.profile_constructors_fine[key[0]],
+            self.profile_constructors_coarse[key[0]],
+            self.profile_constructors_coarse_middle[key[0]],
+        ) = parameterizers.piecewise_linear(
+            roa_use_dict,
+            quant,
+            self.plasma["roa"],
+            parameterize_in_aLx=key[5],
+            multiplier_quantity=key[4],
+            smooth_around_coarsing=smooth_around_coarsing,
+        )
+
+        self.plasma[f"aL{key[0]}"] = aLy_coarse[:, 1]
+
+        # Check that it's not completely zero
+        if key[0] in self.predicted_channels:
+            if self.plasma[f"aL{key[0]}"].sum() == 0.0:
+                addT = 1e-15
+                print(f"\t- All values of {key[0]} detected to be zero, to avoid NaNs, inserting {addT} at the edge",typeMsg="w")
+                self.plasma[f"aL{key[0]}"][..., -1] += addT
+
 def to_gacode(
     self,
     write_input_gacode=None,
@@ -218,6 +542,21 @@ def to_gacode(
     '''
     Notes:
         - insert_highres_powers: whether to insert high resolution powers (will calculate them with powerstate targets object, not other custom ones)
+        - Does NOT sync/refresh self.profiles.plasma_io: to_gacode()/from_powerstate() is
+          called from TRANSPORTtools.py's _produce_profiles() on *every* transport
+          evaluation, including every discarded intermediate flux-match sub-iteration
+          (STATEtools.flux_match()'s solver loop calls self.calculate() -> ... ->
+          _produce_profiles() many times per solve, most of which get immediately
+          superseded by the next sub-iteration), so syncing here would redo the
+          deepcopy+interpolation+postprocessing work for data nobody ever reads. The
+          returned profiles.plasma_io is therefore just whatever self.profiles.plasma_io
+          already was (stale hand-me-down, via powerstate_to_gacode's copy.deepcopy).
+          plasma_io should only track the result of a real BO step (newly-proposed
+          gradients, evaluated and fed back) -- see PORTALSmain.runModelEvaluator()'s
+          explicit powerstate.sync_plasma_io() call after its single
+          powerstate.calculate(X, ...), and plasma_io_migration_plan.md for why
+          flux_match()'s callers (SR initialization, surrogate flux-matching) are
+          deliberately excluded even though they also reach a "converged" point.
     '''
     print(">> Inserting powerstate into input.gacode")
 
@@ -246,6 +585,60 @@ def to_gacode(
             positionToUnrepeat=None)
 
     return profiles
+
+def to_plasma_io(
+    self,
+    write_plasma_io=None,
+    position_in_powerstate_batch=0,
+    time_index=-1,
+    postprocess_plasma_io={},
+    recompute_derived=True,
+):
+    '''
+    plasma_io-native sibling of to_gacode(): writes powerstate's currently-predicted
+    te/ti/ne/nZ/w0 profiles back into a deep copy of self.profiles.plasma_io and returns
+    the updated plasma_io instance. Does NOT replace to_gacode()/from_powerstate -- callers
+    that need input.gacode text output or gacode_state's species metadata/.derived dict for
+    TGYRO/downstream MITIM logic must still use to_gacode().
+    '''
+    print(">> Inserting powerstate into plasma_io")
+
+    plasma_io_obj = powerstate_to_plasma_io(
+        self,
+        position_in_powerstate_batch=position_in_powerstate_batch,
+        time_index=time_index,
+        postprocess_plasma_io=postprocess_plasma_io,
+        recompute_derived=recompute_derived,
+    )
+
+    if write_plasma_io is not None:
+        write_plasma_io = Path(write_plasma_io)
+        print(f"\t- Dumping plasma_io file: {IOtools.clipstr(write_plasma_io)}")
+        write_plasma_io.parent.mkdir(parents=True, exist_ok=True)
+        plasma_io_obj.dump(write_plasma_io, overwrite=True)
+
+    return plasma_io_obj
+
+def sync_plasma_io(self, position_in_powerstate_batch=0):
+    '''
+    Refresh self.profiles.plasma_io IN PLACE from the powerstate's current predicted
+    profiles (cheap path -- powerstate_to_plasma_io with recompute_derived=False, no MXH
+    geometry recompute). No-op if self.profiles.plasma_io is not set.
+
+    Call this once per real BO step -- newly-proposed gradients, evaluated and fed back into
+    the gacode representation -- i.e. right after a single powerstate.calculate(X, ...) call
+    in PORTALSmain's runModelEvaluator(). Deliberately NOT called from inside to_gacode()'s
+    hot path (see its docstring), nor from STATEtools.flux_match() (its callers -- SR
+    initialization's N parallel trajectories, and the post-hoc surrogate flux-match -- widen
+    the initial training set or run diagnostics, and are not "the" proposed-gradients result;
+    see plasma_io_migration_plan.md).
+    '''
+    if getattr(self.profiles, "plasma_io", None) is not None:
+        self.profiles.plasma_io = powerstate_to_plasma_io(
+            self,
+            position_in_powerstate_batch=position_in_powerstate_batch,
+            recompute_derived=False,
+        )
 
 def powerstate_to_gacode(
     self,
@@ -353,6 +746,158 @@ def powerstate_to_gacode(
         debug_transformation(self.profiles,profiles,self)
 
     return profiles
+
+def powerstate_to_plasma_io(
+    self,
+    position_in_powerstate_batch=0,
+    time_index=-1,
+    postprocess_plasma_io={},
+    recompute_derived=True,
+):
+    """
+    plasma_io-native sibling of powerstate_to_gacode(): writes powerstate's currently
+    predicted te/ti/ne/nZ/w0 profiles into a deep copy of self.profiles.plasma_io's own
+    SI-native DataTree, instead of the GACODE-unit dict.
+
+    Notes:
+        - Requires self.profiles.plasma_io is set (same precondition as
+          plasma_io_to_powerstate; if powerstate was constructed via that path,
+          self.profile_constructors_fine is already populated).
+        - Reciprocal of plasma_io_to_powerstate's quantities_to_interpolate unit factors:
+          te/ti keV->eV (x1e3), ne/nZ 10^19/m^3 -> 1/m^3 (x1e19), w0 unchanged.
+        - Only self.predicted_channels are written directly; everything else in the
+          returned plasma_io is left exactly as in the source snapshot, except for
+          the Ti_thermals/ni_thermals postprocessing below (which, like
+          powerstate_to_gacode, touches OTHER ion columns as a side effect).
+        - Ti_thermals/ni_thermals postprocessing (postprocess_plasma_io dict, both
+          default True, same keys/defaults as powerstate_to_gacode's
+          postprocess_input_gacode): mirrors powerstate_to_gacode's use of
+          gacode_state.makeAllThermalIonsHaveSameTemp()/scaleAllThermalDensities(),
+          via the plasma_io-native plasma_io.equalize_thermal_ion_temperatures()/
+          scale_thermal_ion_densities(). Applied in the same order/logic as the
+          gacode path: Ti_thermals only fires when "ti" was just written (leaves
+          ref_ion=0, the just-written channel, untouched); ni_thermals only fires
+          when "ne" was just written, and excludes the impurity ion index whenever
+          "nZ" is ALSO a predicted channel (so nZ's own direct write is the final
+          value there, not further perturbed by the ne-derived scale factor) --
+          exactly matching powerstate_to_gacode's insertion order (nZ processed
+          after ne, so its direct assignment overwrites whatever
+          scaleAllThermalDensities did to that index).
+        - No Tfast_ratio/force_mach equivalent (fast-ion and w0-from-Mach handling)
+          -- narrower scope than powerstate_to_gacode's postprocessing, since
+          plasma_io's fast-ion bookkeeping wasn't part of this pass.
+        - recompute_derived (default True): reruns plasma_io_copy.compute_derived_quantities()
+          after all writes/postprocessing. This is plasma_io's equivalent of
+          gacode_state.selfconsistentPTOT() -- unlike GACODE's separately-stored,
+          independently-writable ptot(Pa), plasma_io has no standalone total-pressure
+          field; pressure_thermal_total/pressure_total etc. are always derived fresh
+          from the current kinetic profiles, so making them self-consistent with what
+          was just written IS rerunning the derived-quantity pipeline (there is no
+          separate "ptot" correction to make on top of that). Expensive (redoes the
+          full MXH geometry decomposition every call even though geometry itself did
+          not change here) -- set recompute_derived=False to skip if only the raw
+          kinetic-profile fields are needed downstream.
+        - Does not insert powers (heat/particle/momentum sources); TGYRO/TGLF power
+          consumption remains served by to_gacode()'s input.gacode, unaffected.
+        - Batches all direct channel writes into a single update_output_data_vars() call
+          (one dataset copy on read via .output, one on write) rather than one call per
+          channel, since both .output and update_output_data_vars deep-copy the full
+          output Dataset. The Ti_thermals/ni_thermals postprocessing calls that follow
+          each do their own additional read-modify-write pass.
+    """
+
+    Ti_thermals = postprocess_plasma_io.get("Ti_thermals", True)
+    ni_thermals = postprocess_plasma_io.get("ni_thermals", True)
+
+    input_gacode = self.profiles
+    plasma_io_obj = getattr(input_gacode, "plasma_io", None)
+    if plasma_io_obj is None:
+        raise ValueError("[MITIM] powerstate_to_plasma_io requires self.profiles.plasma_io to be set")
+
+    plasma_io_copy = copy.deepcopy(plasma_io_obj)
+
+    output_ds = plasma_io_copy.output  # single deep-copy read buffer
+    n_ions = output_ds.sizes["ion"]
+
+    # [powerstate key, plasma_io native var, ion index (None if not per-ion), reciprocal unit factor]
+    quantities = [
+        ["te", "temperature_e", None, 1.0e3],
+        ["ti", "temperature_i", 0, 1.0e3],
+        ["ne", "density_e", None, 1.0e19],
+        ["nZ", "density_i", self.impurityPosition, 1.0e19],
+        ["w0", "rotation_frequency_sonic", None, 1.0],
+    ]
+
+    newvars = {}
+    ne_old_native, ne_new_native = None, None
+    for key in quantities:
+        if key[0] not in self.predicted_channels:
+            continue
+
+        ion_idx = key[2]
+        if ion_idx is not None and ion_idx >= n_ions:
+            raise ValueError(
+                f"[MITIM] powerstate_to_plasma_io: ion index {ion_idx} for '{key[0]}' "
+                f"out of range for plasma_io's {n_ions}-ion 'ion' dimension"
+            )
+
+        print(f"\t- Inserting {key[0]} into plasma_io output")
+
+        # *********************************************************************************************
+        # From a/Lx to x,y via the fixed-grid fine profile_constructor
+        # *********************************************************************************************
+        x_fine, y_fine = self.profile_constructors_fine[key[0]](
+            self.plasma["roa"][position_in_powerstate_batch, :],
+            self.plasma[f"aL{key[0]}"][position_in_powerstate_batch, :],
+        )
+        # *********************************************************************************************
+
+        x_fine = x_fine.cpu().numpy()
+        y_fine = y_fine[0, :].cpu().numpy()
+
+        # Interpolate from the dict-equivalent fixed grid onto plasma_io's own native grid
+        roa_native = output_ds["r_minor_norm"].isel(time=time_index).to_numpy()
+        y_native = interpolation_function(roa_native, x_fine, y_fine) * key[3]
+
+        var = key[1]
+        full_array = output_ds[var].to_numpy().copy()
+        if ion_idx is None:
+            if key[0] == "ne":
+                # Snapshot the pre-write value here (still the original, un-mutated
+                # full_array) so ni_thermals can derive its scale factor below.
+                ne_old_native = full_array[time_index, :].copy()
+                ne_new_native = y_native
+            full_array[time_index, :] = y_native
+        else:
+            full_array[time_index, :, ion_idx] = y_native
+
+        newvars[var] = (list(output_ds[var].dims), full_array)
+
+    if newvars:
+        plasma_io_copy.update_output_data_vars(newvars)
+
+    # ------------------------------------------------------------------------------------------
+    # Postprocessing: keep thermal-ion Ti/ni bookkeeping consistent with what was just written
+    # ------------------------------------------------------------------------------------------
+
+    if "ti" in self.predicted_channels and Ti_thermals:
+        print("\t- Ensuring Ti is equal for all thermal ions")
+        plasma_io_copy.equalize_thermal_ion_temperatures(ref_ion=0, side='output')
+
+    if "ne" in self.predicted_channels and ni_thermals:
+        print("\t- Adjusting ni of thermal ions")
+        scale_factor = ne_new_native / ne_old_native
+        exclude_ion_indices = [self.impurityPosition] if "nZ" in self.predicted_channels else []
+        plasma_io_copy.scale_thermal_ion_densities(scale_factor, side='output', exclude_ion_indices=exclude_ion_indices)
+
+    # ------------------------------------------------------------------------------------------
+    # Recalculate derived quantities to make them consistent (see recompute_derived note above)
+    # ------------------------------------------------------------------------------------------
+
+    if recompute_derived:
+        plasma_io_copy.compute_derived_quantities(side='output')
+
+    return plasma_io_copy
 
 def powerstate_to_gacode_powers(self, profiles, rederive_at_high_res=True):
 
@@ -467,6 +1012,57 @@ def defineIons(self, input_gacode, rho_vec, dfT):
     Tion = torch.tensor(input_gacode.Tion) if input_gacode.Tion is not None else torch.tensor(np.nan)
 
     # Only store as part of ions_set those IMMUTABLE parameters (NOTE: ni MAY change so that's why it's not here)
+    self.plasma["ions_set_mi"] = mi
+    self.plasma["ions_set_Zi"] = Zi
+    self.plasma["ions_set_Dion"] = Dion
+    self.plasma["ions_set_Tion"] = Tion
+    self.plasma["ions_set_c_rad"] = c_rad
+
+def defineIonsFromPlasmaIO(self, input_gacode, pdict, rho_vec, dfT):
+    """
+    plasma_io-native equivalent of defineIons(): stores as part of powerstate the
+    thermal ions densities (ni) and the information about how to interpret them
+    (ions_set), sourced from plasma_io's own type_i/mass_i/charge_i/ion fields
+    instead of the GACODE-unit dict's type/mass/z/name columns.
+
+    Notes:
+        - Species ordering is assumed identical between plasma_io's 'ion'
+          coordinate and the dict's 'name' column, since both originate from the
+          same scratch() conversion and are never reordered independently.
+        - Dion/Tion (positions of D/T for alpha power) and Species are reused
+          from input_gacode -- see plasma_io_to_powerstate()'s docstring.
+    """
+
+    rho_use = pdict["radius"]
+    rho_vec = rho_vec.clone().cpu()
+
+    ion_names = list(pdict["ion"])
+    thermal_mask = pdict["type_i"] == "thermal"
+
+    self.plasma["ni"], mi, Zi, c_rad = [], [], [], []
+    for i in range(len(ion_names)):
+        if thermal_mask[i]:
+            self.plasma["ni"].append(interpolation_function(rho_vec, rho_use, pdict["density_i"][:, i] * 1.0e-19))
+            mi.append(pdict["mass_i"][i])
+            Zi.append(pdict["charge_i"][:, i].mean())
+
+            data_df = pd.read_csv(__mitimroot__ / "src" / "mitim_modules" / "powertorch" / "physics_models" / "radiation_chebyshev.csv")
+            try:
+                c = data_df[data_df['Ion'].str.lower() == ion_names[i].lower()].to_numpy()[0, 2:].astype(float)
+            except IndexError:
+                print(f'\t- Specie {ion_names[i]} not found in radiation database, assuming zero radiation from it', typeMsg="w")
+                c = [-1e10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+            c_rad.append(c)
+
+    self.plasma["ni"] = torch.from_numpy(np.transpose(self.plasma["ni"])).to(dfT)
+    mi = torch.from_numpy(np.array(mi)).to(dfT)
+    Zi = torch.from_numpy(np.array(Zi)).to(dfT)
+    c_rad = torch.from_numpy(np.array(c_rad)).to(dfT)
+
+    Dion = torch.tensor(input_gacode.Dion) if input_gacode.Dion is not None else torch.tensor(np.nan)
+    Tion = torch.tensor(input_gacode.Tion) if input_gacode.Tion is not None else torch.tensor(np.nan)
+
     self.plasma["ions_set_mi"] = mi
     self.plasma["ions_set_Zi"] = Zi
     self.plasma["ions_set_Dion"] = Dion

--- a/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
@@ -335,12 +335,16 @@ def plasma_io_to_powerstate(self, rho_vec=None):
     )
     # B_ref is NOT the same quantity as B_unit (a common confusion): MITIM defines it as
     # |B_unit * bt_geo|, a genuine radius-varying profile that needs a proper flux-surface
-    # geometric factor (bt_geo) to compute correctly. plasma_io's closest existing candidate,
-    # mxh_field_ref, is numerically unstable near the axis (blows up to ~1e5, contaminating the
-    # whole interpolation) and isn't actually bt_geo-equivalent. Until a proper bt_geo-style
-    # calculation exists in plasma_io, use field_axis (bcentr) broadcast across the grid as a
-    # stable, order-of-magnitude placeholder rather than a per-radius profile.
-    B_ref_native = np.full_like(pdict["radius"], np.abs(pdict["field_axis"]))
+    # geometric factor (bt_geo) to compute correctly. plasma_io's mxh_field_inner stores
+    # [bt_inner, bp_inner] (direction order ['toroidal', 'poloidal'], dimensionless B/field_unit)
+    # at the inboard point of each flux surface, so its toroidal component scaled by field_unit
+    # gives a real per-radius profile, matching the gacode_to_powerstate branch's convention.
+    # Previously used field_axis (bcentr) broadcast as a flat placeholder instead, since
+    # plasma_io's only candidate at the time (mxh_field_ref) was numerically unstable near the
+    # axis (blew up to ~1e5) due to a Jacobian-sign bug in plasma_io's MXH synthesis step, since
+    # fixed -- mxh_field_inner comes from the same (now-fixed) synthesis and is bounded and
+    # radially smooth.
+    B_ref_native = np.abs(pdict["field_unit"] * pdict["mxh_field_inner"][:, 0])
     precomputed = {"s_q": s_q_native, "betae": betae_native, "B_ref": B_ref_native}
 
     # [powerstate key, plasma_io native key, ion index (None if not per-ion), unit-conversion factor]

--- a/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
@@ -49,14 +49,13 @@ def gacode_to_powerstate(self, rho_vec=None):
     # each gated by a parity check against the dict-derived value it would otherwise replace.
     # *********************************************************************************************
     plasma_io_overrides = {}
-    plasma_io_obj = getattr(input_gacode, "plasma_io", None)
-    if plasma_io_obj is not None and "r_minor" in plasma_io_obj.output:
+    if getattr(input_gacode, "has_output", False) and "r_minor" in input_gacode.output:
         # Note: input_gacode.profiles may have already been resampled onto a different radial
         # grid than plasma_io's own 'radius' coordinate (e.g. by improve_resolution_profiles,
-        # which only touches the dict, not the companion plasma_io object) — interpolate onto
+        # which only touches the dict, not input_gacode's own inherited tree) — interpolate onto
         # rho_use (the grid actually in use here) before comparing/substituting.
-        rho_plasma_io = plasma_io_obj.output["radius"].to_numpy()
-        rmin_plasma_io_native = plasma_io_obj.output["r_minor"].isel(time=-1).to_numpy()
+        rho_plasma_io = input_gacode.output["radius"].to_numpy()
+        rmin_plasma_io_native = input_gacode.output["r_minor"].isel(time=-1).to_numpy()
         rmin_from_plasma_io = interpolation_function(rho_use, rho_plasma_io, rmin_plasma_io_native)
         rmin_from_dict = input_gacode_profiles["rmin(m)"]
         # rmin_from_dict was itself resampled onto rho_use by improve_resolution_profiles()
@@ -247,9 +246,9 @@ def plasma_io_to_powerstate(self, rho_vec=None):
     GACODE-unit profiles/derived dict.
 
     Requires:
-        - self.profiles.plasma_io is set (i.e. the source mitim_state was built via
+        - self.profiles.has_output is True (i.e. the source mitim_state was built via
           scratch() from a plasma_io object).
-        - plasma_io.compute_derived_quantities() has already been run on it -- not
+        - compute_derived_quantities() has already been run on it -- not
           called here, since it's expensive (MXH shape decomposition) and callers
           should control when it reruns rather than paying that cost on every
           powerstate construction.
@@ -286,11 +285,10 @@ def plasma_io_to_powerstate(self, rho_vec=None):
     print("\t- Producing powerstate object from plasma_io")
 
     input_gacode = self.profiles
-    plasma_io_obj = getattr(input_gacode, "plasma_io", None)
-    if plasma_io_obj is None:
-        raise ValueError("[MITIM] plasma_io_to_powerstate requires self.profiles.plasma_io to be set")
+    if not input_gacode.has_output:
+        raise ValueError("[MITIM] plasma_io_to_powerstate requires self.profiles to be plasma_io-backed (has_output)")
 
-    pdict = plasma_io_obj.to_dict(side="output")
+    pdict = input_gacode.to_dict(side="output")
 
     if rho_vec is None:
         rho_vec = self.plasma["rho"]
@@ -548,16 +546,16 @@ def to_gacode(
     '''
     Notes:
         - insert_highres_powers: whether to insert high resolution powers (will calculate them with powerstate targets object, not other custom ones)
-        - Does NOT sync/refresh self.profiles.plasma_io: to_gacode()/from_powerstate() is
+        - Does NOT sync/refresh self.profiles.output: to_gacode()/from_powerstate() is
           called from TRANSPORTtools.py's _produce_profiles() on *every* transport
           evaluation, including every discarded intermediate flux-match sub-iteration
           (STATEtools.flux_match()'s solver loop calls self.calculate() -> ... ->
           _produce_profiles() many times per solve, most of which get immediately
           superseded by the next sub-iteration), so syncing here would redo the
           deepcopy+interpolation+postprocessing work for data nobody ever reads. The
-          returned profiles.plasma_io is therefore just whatever self.profiles.plasma_io
+          returned profiles.output is therefore just whatever self.profiles.output
           already was (stale hand-me-down, via powerstate_to_gacode's copy.deepcopy).
-          plasma_io should only track the result of a real BO step (newly-proposed
+          .output should only track the result of a real BO step (newly-proposed
           gradients, evaluated and fed back) -- see PORTALSmain.runModelEvaluator()'s
           explicit powerstate.sync_plasma_io() call after its single
           powerstate.calculate(X, ...), and plasma_io_migration_plan.md for why
@@ -604,8 +602,8 @@ def to_plasma_io(
 ):
     '''
     plasma_io-native sibling of to_gacode(): writes powerstate's currently-predicted
-    te/ti/ne/nZ/w0 profiles back into a deep copy of self.profiles.plasma_io and returns
-    the updated plasma_io instance. Does NOT replace to_gacode()/from_powerstate -- callers
+    te/ti/ne/nZ/w0 profiles back into a deep copy of self.profiles and returns the
+    updated mitim_state/gacode_state instance. Does NOT replace to_gacode()/from_powerstate -- callers
     that need input.gacode text output or gacode_state's species metadata/.derived dict for
     TGYRO/downstream MITIM logic must still use to_gacode().
 
@@ -648,9 +646,15 @@ def to_plasma_io(
 
 def sync_plasma_io(self, position_in_powerstate_batch=0):
     '''
-    Refresh self.profiles.plasma_io IN PLACE from the powerstate's current predicted
+    Refresh self.profiles.output IN PLACE from the powerstate's current predicted
     profiles (cheap path -- powerstate_to_plasma_io with recompute_derived=False, no MXH
-    geometry recompute). No-op if self.profiles.plasma_io is not set.
+    geometry recompute). No-op if self.profiles.has_output is False.
+
+    Mutates self.profiles.output in place (rather than reassigning self.profiles wholesale)
+    to preserve self.profiles's own object identity and Species/mi_first bookkeeping --
+    powerstate_to_plasma_io() returns a full mitim_state/gacode_state copy, so only its
+    .output is pulled across; .input (and this method's scope generally) is left untouched,
+    matching powerstate_to_plasma_io()'s own current scope of only ever writing .output.
 
     Call this once per real BO step -- newly-proposed gradients, evaluated and fed back into
     the gacode representation -- i.e. right after a single powerstate.calculate(X, ...) call
@@ -660,12 +664,12 @@ def sync_plasma_io(self, position_in_powerstate_batch=0):
     the initial training set or run diagnostics, and are not "the" proposed-gradients result;
     see plasma_io_migration_plan.md).
     '''
-    if getattr(self.profiles, "plasma_io", None) is not None:
-        self.profiles.plasma_io = powerstate_to_plasma_io(
+    if getattr(self.profiles, "has_output", False):
+        self.profiles.output = powerstate_to_plasma_io(
             self,
             position_in_powerstate_batch=position_in_powerstate_batch,
             recompute_derived=False,
-        )
+        ).output
 
 def powerstate_to_gacode(
     self,
@@ -768,7 +772,7 @@ def powerstate_to_gacode(
     # (expensive, dict-based) recompute; selfconsistentPTOT() below sources ptot_manual via its
     # own cheap, get_profiles()-based local calculation (_ptot_manual()) regardless, so it
     # doesn't need this call either way. See "New phase (2026-08-12)" in the migration plan doc.
-    if (rederive or recalculate_ptot) and getattr(profiles, "plasma_io", None) is None:
+    if (rederive or recalculate_ptot) and not getattr(profiles, "has_output", False):
         profiles.derive_quantities(rederiveGeometry=False)
 
     if recalculate_ptot:
@@ -796,13 +800,15 @@ def powerstate_to_plasma_io(
 ):
     """
     plasma_io-native sibling of powerstate_to_gacode(): writes powerstate's currently
-    predicted te/ti/ne/nZ/w0 profiles into a deep copy of self.profiles.plasma_io's own
-    SI-native DataTree, instead of the GACODE-unit dict.
+    predicted te/ti/ne/nZ/w0 profiles into a deep copy of self.profiles' own SI-native
+    DataTree, instead of the GACODE-unit dict.
 
     Notes:
-        - Requires self.profiles.plasma_io is set (same precondition as
+        - Requires self.profiles.has_output is True (same precondition as
           plasma_io_to_powerstate; if powerstate was constructed via that path,
-          self.profile_constructors_fine is already populated).
+          self.profile_constructors_fine is already populated). Returns a full
+          mitim_state/gacode_state copy (not a bare fusio plasma_io), mirroring
+          powerstate_to_gacode()'s own copy.deepcopy(self.profiles) pattern.
         - Reciprocal of plasma_io_to_powerstate's quantities_to_interpolate unit factors:
           te/ti keV->eV (x1e3), ne/nZ 10^19/m^3 -> 1/m^3 (x1e19), w0 unchanged.
         - Only self.predicted_channels are written directly; everything else in the
@@ -863,11 +869,10 @@ def powerstate_to_plasma_io(
     force_mach = postprocess_plasma_io.get("force_mach", None)
 
     input_gacode = self.profiles
-    plasma_io_obj = getattr(input_gacode, "plasma_io", None)
-    if plasma_io_obj is None:
-        raise ValueError("[MITIM] powerstate_to_plasma_io requires self.profiles.plasma_io to be set")
+    if not input_gacode.has_output:
+        raise ValueError("[MITIM] powerstate_to_plasma_io requires self.profiles to be plasma_io-backed (has_output)")
 
-    plasma_io_copy = copy.deepcopy(plasma_io_obj)
+    plasma_io_copy = copy.deepcopy(input_gacode)  # whole mitim_state/gacode_state, not a sub-object
 
     output_ds = plasma_io_copy.output  # single deep-copy read buffer
     n_ions = output_ds.sizes["ion"]
@@ -1061,7 +1066,7 @@ def _compute_highres_powers(self, profiles, rederive_at_high_res=True):
 
 def powerstate_to_gacode_powers(self, profiles, rederive_at_high_res=True):
 
-    if getattr(profiles, "plasma_io", None) is None:
+    if not getattr(profiles, "has_output", False):
         profiles.derive_quantities(rederiveGeometry=False)
     profiles_dict = profiles.get_profiles()
 

--- a/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
+++ b/src/mitim_modules/powertorch/utils/TRANSFORMtools.py
@@ -31,6 +31,8 @@ def gacode_to_powerstate(self, rho_vec=None):
     print("\t- Producing powerstate object from input.gacode")
 
     input_gacode = self.profiles
+    input_gacode_profiles = input_gacode.get_profiles()
+    input_gacode_derived = input_gacode.get_derived()
     if rho_vec is None:
         rho_vec = self.plasma["rho"]
 
@@ -38,7 +40,7 @@ def gacode_to_powerstate(self, rho_vec=None):
     # Radial grid
     # *********************************************************************************************
 
-    rho_use = input_gacode.profiles["rho(-)"]
+    rho_use = input_gacode_profiles["rho(-)"]
 
     # *********************************************************************************************
     # plasma_io propagation (see plasma_io_migration_plan.md, Part 2 Phase 2): when the source
@@ -56,7 +58,7 @@ def gacode_to_powerstate(self, rho_vec=None):
         rho_plasma_io = plasma_io_obj.output["radius"].to_numpy()
         rmin_plasma_io_native = plasma_io_obj.output["r_minor"].isel(time=-1).to_numpy()
         rmin_from_plasma_io = interpolation_function(rho_use, rho_plasma_io, rmin_plasma_io_native)
-        rmin_from_dict = input_gacode.profiles["rmin(m)"]
+        rmin_from_dict = input_gacode_profiles["rmin(m)"]
         # rmin_from_dict was itself resampled onto rho_use by improve_resolution_profiles()
         # using a different interpolant (pchip) than the cubic spline used here, so a small
         # (sub-mm, sub-percent) discrepancy near sharp-curvature regions (e.g. the axis) is
@@ -69,8 +71,8 @@ def gacode_to_powerstate(self, rho_vec=None):
             )
         plasma_io_overrides["rmin"] = rmin_from_plasma_io
 
-    roa_array = interpolation_function(rho_vec.cpu(), rho_use, input_gacode.derived["roa"])
-    rho_array = interpolation_function(rho_vec.cpu(), rho_use, input_gacode.profiles["rho(-)"])
+    roa_array = interpolation_function(rho_vec.cpu(), rho_use, input_gacode_derived["roa"])
+    rho_array = interpolation_function(rho_vec.cpu(), rho_use, input_gacode_profiles["rho(-)"])
     
     if len(rho_array) < 10:
         print(f"\t\t@ rho = {[round(i,6) for i in rho_array]}")
@@ -90,8 +92,8 @@ def gacode_to_powerstate(self, rho_vec=None):
     self.plasma["roa"] = torch.from_numpy(roa_array).to(rho_vec)
     self.plasma["rho"] = torch.from_numpy(rho_array).to(rho_vec)
     self.plasma["mi_u"] = torch.tensor(input_gacode.mi_first).to(rho_vec)
-    self.plasma["a"] = torch.tensor(input_gacode.derived["a"]).to(rho_vec)
-    self.plasma["eps"] = torch.tensor(input_gacode.derived["eps"]).to(rho_vec)
+    self.plasma["a"] = torch.tensor(input_gacode_derived["a"]).to(rho_vec)
+    self.plasma["eps"] = torch.tensor(input_gacode_derived["eps"]).to(rho_vec)
 
     # Add more stuff: name, original name, index, unit conversion, is derived
     quantities_to_interpolate = [
@@ -131,7 +133,7 @@ def gacode_to_powerstate(self, rho_vec=None):
         if key[0] in plasma_io_overrides:
             quant = plasma_io_overrides[key[0]]
         else:
-            quant = input_gacode.derived[key[1]] if key[4] else input_gacode.profiles[key[1]]
+            quant = input_gacode_derived[key[1]] if key[4] else input_gacode_profiles[key[1]]
 
         # *********************************************************************************************
         # Extract the quantity via interpolation and tensorization
@@ -146,25 +148,25 @@ def gacode_to_powerstate(self, rho_vec=None):
     # *********************************************************************************************
 
     quantitites = {}
-    quantitites["QeMWm2_fixedtargets"] = input_gacode.derived["qe_aux_MW"]
-    quantitites["QiMWm2_fixedtargets"] = input_gacode.derived["qi_aux_MW"]
-    quantitites["Ge_fixedtargets"] = input_gacode.derived["ge_10E20"]
-    quantitites["GZ_fixedtargets"] = input_gacode.derived["ge_10E20"] * 0.0
-    quantitites["MtJm2_fixedtargets"] = input_gacode.derived["mt_J"]
+    quantitites["QeMWm2_fixedtargets"] = input_gacode_derived["qe_aux_MW"]
+    quantitites["QiMWm2_fixedtargets"] = input_gacode_derived["qi_aux_MW"]
+    quantitites["Ge_fixedtargets"] = input_gacode_derived["ge_10E20"]
+    quantitites["GZ_fixedtargets"] = input_gacode_derived["ge_10E20"] * 0.0
+    quantitites["MtJm2_fixedtargets"] = input_gacode_derived["mt_J"]
 
     if 'qfus' not in self.target_options["options"]["targets_evolve"]:
         # Fusion fixed
-        quantitites["QeMWm2_fixedtargets"] += input_gacode.derived["qe_fus_MW"]
-        quantitites["QiMWm2_fixedtargets"] += input_gacode.derived["qi_fus_MW"]
+        quantitites["QeMWm2_fixedtargets"] += input_gacode_derived["qe_fus_MW"]
+        quantitites["QiMWm2_fixedtargets"] += input_gacode_derived["qi_fus_MW"]
    
     if 'qrad' not in self.target_options["options"]["targets_evolve"]:
         # Fusion fixed
-        quantitites["QeMWm2_fixedtargets"] -= input_gacode.derived["qrad_MW"]
+        quantitites["QeMWm2_fixedtargets"] -= input_gacode_derived["qrad_MW"]
     
     if 'qie' not in self.target_options["options"]["targets_evolve"]:
         # Exchange fixed if 1
-        quantitites["QeMWm2_fixedtargets"] -= input_gacode.derived["qe_exc_MW"]
-        quantitites["QiMWm2_fixedtargets"] += input_gacode.derived["qe_exc_MW"]
+        quantitites["QeMWm2_fixedtargets"] -= input_gacode_derived["qe_exc_MW"]
+        quantitites["QiMWm2_fixedtargets"] += input_gacode_derived["qe_exc_MW"]
 
     for key in quantitites:
         
@@ -206,14 +208,14 @@ def gacode_to_powerstate(self, rho_vec=None):
     ]
 
     # Add all ions
-    for i in range(input_gacode.profiles['ni(10^19/m^3)'].shape[1]):
+    for i in range(input_gacode_profiles['ni(10^19/m^3)'].shape[1]):
         cases_to_parameterize.append([f"ni{i}", "ni(10^19/m^3)", i, 1.0, True])
 
     smooth_around_coarsing = self.transport_options.get("flatten_gradients_at_control_points", True)
 
     self.profile_constructors_fine, self.profile_constructors_coarse, self.profile_constructors_coarse_middle = {}, {}, {}
     for key in cases_to_parameterize:
-        quant = input_gacode.profiles[key[1]] if key[2] is None else input_gacode.profiles[key[1]][:, key[2]]
+        quant = input_gacode_profiles[key[1]] if key[2] is None else input_gacode_profiles[key[1]][:, key[2]]
 
         (
             aLy_coarse,
@@ -221,7 +223,7 @@ def gacode_to_powerstate(self, rho_vec=None):
             self.profile_constructors_coarse[key[0]],
             self.profile_constructors_coarse_middle[key[0]],
         ) = parameterizers.piecewise_linear(
-            input_gacode.derived["roa"],
+            input_gacode_derived["roa"],
             quant,
             self.plasma["roa"],
             parameterize_in_aLx=key[4],
@@ -502,8 +504,8 @@ def plasma_io_to_powerstate(self, rho_vec=None):
     # at whatever resolution improve_resolution_profiles() left it at. So even though
     # plasma_io_to_powerstate otherwise reads straight from plasma_io's native grid (mismatch #1),
     # this one piece needs plasma_io's quantities resampled onto input_gacode's fine grid first.
-    roa_use_dict = input_gacode.derived["roa"]
-    rho_use_dict = input_gacode.profiles["rho(-)"]
+    roa_use_dict = input_gacode.get_derived()["roa"]
+    rho_use_dict = input_gacode.get_profiles()["rho(-)"]
 
     self.profile_constructors_fine, self.profile_constructors_coarse, self.profile_constructors_coarse_middle = {}, {}, {}
     for key in cases_to_parameterize:
@@ -597,6 +599,8 @@ def to_plasma_io(
     time_index=-1,
     postprocess_plasma_io={},
     recompute_derived=True,
+    insert_highres_powers=False,
+    gacode_profiles=None,
 ):
     '''
     plasma_io-native sibling of to_gacode(): writes powerstate's currently-predicted
@@ -604,6 +608,14 @@ def to_plasma_io(
     the updated plasma_io instance. Does NOT replace to_gacode()/from_powerstate -- callers
     that need input.gacode text output or gacode_state's species metadata/.derived dict for
     TGYRO/downstream MITIM logic must still use to_gacode().
+
+    insert_highres_powers (default False, matching to_gacode()'s own default): if True,
+    also writes qie/qrad_*/qfus* into plasma_io_obj's heat_exchange_ei/heat_source_e/
+    heat_source_i via powerstate_to_plasma_io_powers() -- done here, between the channel
+    writes and the final recompute_derived, matching to_gacode()'s own ordering (powers
+    inserted before its recalculate_ptot). gacode_profiles is passed straight through to
+    powerstate_to_plasma_io_powers() as its fine-grid source; defaults to self.profiles
+    (get_profiles() works whether or not that's plasma_io-backed).
     '''
     print(">> Inserting powerstate into plasma_io")
 
@@ -612,8 +624,19 @@ def to_plasma_io(
         position_in_powerstate_batch=position_in_powerstate_batch,
         time_index=time_index,
         postprocess_plasma_io=postprocess_plasma_io,
-        recompute_derived=recompute_derived,
+        recompute_derived=False,
     )
+
+    if insert_highres_powers:
+        plasma_io_obj = powerstate_to_plasma_io_powers(
+            self,
+            plasma_io_obj,
+            gacode_profiles if gacode_profiles is not None else self.profiles,
+            time_index=time_index,
+        )
+
+    if recompute_derived:
+        plasma_io_obj.compute_derived_quantities(side='output')
 
     if write_plasma_io is not None:
         write_plasma_io = Path(write_plasma_io)
@@ -674,6 +697,7 @@ def powerstate_to_gacode(
 
     # Start from the originally stored (at initialization) in this powerstate object
     profiles = copy.deepcopy(self.profiles)
+    profiles_dict = profiles.get_profiles()
 
     quantities = [
         ["te", "te(keV)", None],
@@ -699,11 +723,11 @@ def powerstate_to_gacode(
             y_new = y[0, :].cpu().numpy()
                 
             if key[2] is None:
-                Y_copy = copy.deepcopy(profiles.profiles[key[1]])
-                profiles.profiles[key[1]] = y_new
+                Y_copy = copy.deepcopy(profiles_dict[key[1]])
+                profiles_dict[key[1]] = y_new
             else:
-                Y_copy = copy.deepcopy(profiles.profiles[key[1]][:, key[2]])
-                profiles.profiles[key[1]][:, key[2]] = y_new
+                Y_copy = copy.deepcopy(profiles_dict[key[1]][:, key[2]])
+                profiles_dict[key[1]][:, key[2]] = y_new
 
             # ------------------------------------------------------------------------------------------
             # Special treatments
@@ -714,7 +738,7 @@ def powerstate_to_gacode(
                 for sp in range(len(profiles.Species)):
                     if profiles.Species[sp]["S"] == "fast":
                         print(f"\t\t\t- Modifying temperature of species #{sp}")
-                        profiles.profiles["ti(keV)"][:, sp] = profiles.profiles["ti(keV)"][:, sp] * (profiles.profiles["te(keV)"] / Y_copy)
+                        profiles_dict["ti(keV)"][:, sp] = profiles_dict["ti(keV)"][:, sp] * (profiles_dict["te(keV)"] / Y_copy)
 
             if key[0] == "ti" and Ti_thermals:
                 print("\t\t* Ensuring Ti is equal for all thermal ions", typeMsg="i")
@@ -740,7 +764,11 @@ def powerstate_to_gacode(
     # Recalculate and change ptot to make it consistent?
     # ------------------------------------------------------------------------------------------
 
-    if rederive or recalculate_ptot:
+    # For plasma_io-backed profiles, .derived is no longer a stored attribute -- skip the
+    # (expensive, dict-based) recompute; selfconsistentPTOT() below sources ptot_manual via its
+    # own cheap, get_profiles()-based local calculation (_ptot_manual()) regardless, so it
+    # doesn't need this call either way. See "New phase (2026-08-12)" in the migration plan doc.
+    if (rederive or recalculate_ptot) and getattr(profiles, "plasma_io", None) is None:
         profiles.derive_quantities(rederiveGeometry=False)
 
     if recalculate_ptot:
@@ -748,6 +776,14 @@ def powerstate_to_gacode(
 
     if debugPlot:
         debug_transformation(self.profiles,profiles,self)
+
+    # The channel inserts above (te/ti/ne/nZ/w0) and the Ti_thermals/ni_thermals postprocessing
+    # all mutate profiles.get_profiles()'s cached dict in place -- but nothing about that
+    # mutation is visible to get_derived()'s own, separate cache. Without this, every consumer
+    # of the returned profiles object that reads get_derived() (to_tglf() and friends) would
+    # keep seeing whatever derived dict was cached before this call, deep-copied forward
+    # unchanged into every subsequent evaluation. See invalidate_derived_cache()'s docstring.
+    profiles.invalidate_derived_cache()
 
     return profiles
 
@@ -787,9 +823,17 @@ def powerstate_to_plasma_io(
           exactly matching powerstate_to_gacode's insertion order (nZ processed
           after ne, so its direct assignment overwrites whatever
           scaleAllThermalDensities did to that index).
-        - No Tfast_ratio/force_mach equivalent (fast-ion and w0-from-Mach handling)
-          -- narrower scope than powerstate_to_gacode's postprocessing, since
-          plasma_io's fast-ion bookkeeping wasn't part of this pass.
+        - Tfast_ratio/force_mach (postprocess_plasma_io dict, both default matching
+          powerstate_to_gacode's own defaults: Tfast_ratio=False, force_mach=None): mirror
+          powerstate_to_gacode's fast-ion Ti-ratio and Mach-number-fixed w0 postprocessing.
+          Tfast_ratio scales each fast species' temperature_i by the just-written
+          temperature_e's ratio to its pre-write value, applied directly on plasma_io's
+          native grid (no extra interpolation needed, since the te channel write already
+          happened on that grid). force_mach recomputes w0 via
+          PLASMAtools.constructVtorFromMach() using mbg/R_LF/ti sourced from a throwaway
+          gacode_state.scratch(plasma_io_copy) shadow (the same get_derived() mechanism
+          used throughout this migration) -- interpolated from that shadow's gacode-dict
+          grid onto plasma_io's native grid, same as the channel writes above.
         - recompute_derived (default True): reruns plasma_io_copy.compute_derived_quantities()
           after all writes/postprocessing. This is plasma_io's equivalent of
           gacode_state.selfconsistentPTOT() -- unlike GACODE's separately-stored,
@@ -801,8 +845,11 @@ def powerstate_to_plasma_io(
           full MXH geometry decomposition every call even though geometry itself did
           not change here) -- set recompute_derived=False to skip if only the raw
           kinetic-profile fields are needed downstream.
-        - Does not insert powers (heat/particle/momentum sources); TGYRO/TGLF power
-          consumption remains served by to_gacode()'s input.gacode, unaffected.
+        - Does not itself insert heat-source powers (qie/qrad_*/qfus*) -- that's
+          to_plasma_io()'s job (insert_highres_powers=True, via
+          powerstate_to_plasma_io_powers()), applied after this function returns. Does
+          not insert particle/momentum sources at all yet; TGYRO/TGLF power consumption
+          remains served by to_gacode()'s input.gacode either way, unaffected.
         - Batches all direct channel writes into a single update_output_data_vars() call
           (one dataset copy on read via .output, one on write) rather than one call per
           channel, since both .output and update_output_data_vars deep-copy the full
@@ -812,6 +859,8 @@ def powerstate_to_plasma_io(
 
     Ti_thermals = postprocess_plasma_io.get("Ti_thermals", True)
     ni_thermals = postprocess_plasma_io.get("ni_thermals", True)
+    Tfast_ratio = postprocess_plasma_io.get("Tfast_ratio", False)
+    force_mach = postprocess_plasma_io.get("force_mach", None)
 
     input_gacode = self.profiles
     plasma_io_obj = getattr(input_gacode, "plasma_io", None)
@@ -834,6 +883,7 @@ def powerstate_to_plasma_io(
 
     newvars = {}
     ne_old_native, ne_new_native = None, None
+    te_old_native, te_new_native = None, None
     for key in quantities:
         if key[0] not in self.predicted_channels:
             continue
@@ -871,6 +921,10 @@ def powerstate_to_plasma_io(
                 # full_array) so ni_thermals can derive its scale factor below.
                 ne_old_native = full_array[time_index, :].copy()
                 ne_new_native = y_native
+            if key[0] == "te":
+                # Same idea, for Tfast_ratio below.
+                te_old_native = full_array[time_index, :].copy()
+                te_new_native = y_native
             full_array[time_index, :] = y_native
         else:
             full_array[time_index, :, ion_idx] = y_native
@@ -895,6 +949,47 @@ def powerstate_to_plasma_io(
         plasma_io_copy.scale_thermal_ion_densities(scale_factor, side='output', exclude_ion_indices=exclude_ion_indices)
 
     # ------------------------------------------------------------------------------------------
+    # Tfast_ratio: keep fast species' Ti at a fixed ratio to the just-written Te, matching
+    # powerstate_to_gacode()'s "for sp in Species: if S == 'fast': ti[sp] *= te_new/te_old"
+    # ------------------------------------------------------------------------------------------
+
+    if "te" in self.predicted_channels and Tfast_ratio:
+        print("\t- If any fast species, changing Tfast to ensure fixed Tfast/Te ratio")
+        te_ratio_native = te_new_native / te_old_native
+        output_ds_now = plasma_io_copy.output
+        ti_full = output_ds_now["temperature_i"].to_numpy().copy()
+        for sp in range(len(input_gacode.Species)):
+            if input_gacode.Species[sp]["S"] == "fast":
+                print(f"\t\t- Modifying temperature of species #{sp}")
+                ti_full[time_index, :, sp] = ti_full[time_index, :, sp] * te_ratio_native
+        plasma_io_copy.update_output_data_vars({"temperature_i": (list(output_ds_now["temperature_i"].dims), ti_full)})
+
+    # ------------------------------------------------------------------------------------------
+    # force_mach: fix w0 to a target low-field-side Mach number, matching
+    # powerstate_to_gacode()'s introduceRotationProfile(Mach_LF=force_mach) call
+    # ------------------------------------------------------------------------------------------
+
+    if "w0" not in self.predicted_channels and force_mach is not None:
+        print(f"\t- Enforcing Mach Number in LF of {force_mach}")
+        from mitim_tools.gacode_tools import PROFILEStools
+        # Throwaway shadow, built on the just-written plasma_io_copy, purely to source
+        # mbg/R_LF/ti(keV) via the same get_derived()/get_profiles() machinery used
+        # everywhere else in this migration -- not a new derived-quantity computation.
+        shadow = PROFILEStools.gacode_state.scratch(plasma_io_copy)
+        profiles_snapshot = shadow.get_profiles()
+        derived_snapshot = shadow.get_derived()
+        Vtor_LF = PLASMAtools.constructVtorFromMach(
+            force_mach, profiles_snapshot["ti(keV)"][:, 0], derived_snapshot["mbg"]
+        )  # m/s
+        w0_dict_grid = Vtor_LF / derived_snapshot["R_LF"]  # rad/s, on the shadow's gacode-dict grid
+        output_ds_now = plasma_io_copy.output
+        roa_native = output_ds_now["r_minor_norm"].isel(time=time_index).to_numpy()
+        w0_native = interpolation_function(roa_native, derived_snapshot["roa"], w0_dict_grid)
+        full_array = output_ds_now["rotation_frequency_sonic"].to_numpy().copy()
+        full_array[time_index, :] = w0_native
+        plasma_io_copy.update_output_data_vars({"rotation_frequency_sonic": (list(output_ds_now["rotation_frequency_sonic"].dims), full_array)})
+
+    # ------------------------------------------------------------------------------------------
     # Recalculate derived quantities to make them consistent (see recompute_derived note above)
     # ------------------------------------------------------------------------------------------
 
@@ -903,22 +998,33 @@ def powerstate_to_plasma_io(
 
     return plasma_io_copy
 
-def powerstate_to_gacode_powers(self, profiles, rederive_at_high_res=True):
+def _compute_highres_powers(self, profiles, rederive_at_high_res=True):
+    """
+    Shared fine-grid target-power computation used by both powerstate_to_gacode_powers()
+    (GACODE-dict write target) and powerstate_to_plasma_io_powers() (plasma_io write
+    target), factored out so both write exactly the same computed numbers -- only the
+    final write destination differs, removing any risk of the two diverging.
 
-    profiles.derive_quantities(rederiveGeometry=False)
-
-    print("\t- Inserting powers")
+    Returns (state_temp, conversions, extra_points): for each key in conversions,
+    state_temp.plasma[key][position_in_powerstate_batch, :] (roa-indexed, aligned with
+    state_temp.plasma["roa"][position_in_powerstate_batch, :]) holds the computed power
+    value in the same MW/m^3-equivalent units/sign convention as the GACODE columns named
+    in `conversions.values()`. extra_points is how many trailing grid points the
+    high-res reconstruction's fine grid drops (0 when rederive_at_high_res=False).
+    """
+    profiles_dict = profiles.get_profiles()
 
     state_temp = self.copy_state()
 
+    extra_points = 2 if rederive_at_high_res else 0
     if rederive_at_high_res:
         # ------------------------------------------------------------------------------------------
         # Recalculate powers with powerstate on the gacode-original fine grid
         # ------------------------------------------------------------------------------------------
 
         # Modify power flows by tricking the powerstate into a fine grid (same as does TGYRO)
-        extra_points = 2  # If I don't allow this, it will fail
-        rhoy = profiles.profiles["rho(-)"][1:-extra_points]
+        # extra_points=2: if I don't allow this, it will fail
+        rhoy = profiles_dict["rho(-)"][1:-extra_points]
         with LOGtools.HiddenPrints():
             state_temp.__init__(
                 profiles,
@@ -939,19 +1045,6 @@ def powerstate_to_gacode_powers(self, profiles, rederive_at_high_res=True):
         state_temp.calculateTargets()
         # ------------------------------------------------------------------------------------------
 
-        def state_to_profiles(state, profiles, state_key, profiles_key,position_in_powerstate_batch, **kwargs):
-            profiles.profiles[conversions[ikey]][:-extra_points] = state.plasma[ikey][position_in_powerstate_batch,:].cpu().numpy()
-
-    else:
-        # Just interpolate from powerstate to gacode grid
-        def state_to_profiles(state, profiles, state_key, profiles_key,position_in_powerstate_batch, **kwargs):
-            profiles.profiles[conversions[ikey]] = interpolation_function(
-                profiles.profiles["rho(-)"],
-                state.plasma["rho"][position_in_powerstate_batch,:].cpu().numpy(),
-                state.plasma[ikey][position_in_powerstate_batch,:].cpu().numpy()
-            )
-
-
     conversions = {}
 
     if 'qie' in self.target_options["options"]["targets_evolve"]:
@@ -964,14 +1057,117 @@ def powerstate_to_gacode_powers(self, profiles, rederive_at_high_res=True):
         conversions['qfuse'] = "qfuse(MW/m^3)"
         conversions['qfusi'] = "qfusi(MW/m^3)"
 
+    return state_temp, conversions, extra_points
+
+def powerstate_to_gacode_powers(self, profiles, rederive_at_high_res=True):
+
+    if getattr(profiles, "plasma_io", None) is None:
+        profiles.derive_quantities(rederiveGeometry=False)
+    profiles_dict = profiles.get_profiles()
+
+    print("\t- Inserting powers")
+
+    state_temp, conversions, extra_points = _compute_highres_powers(self, profiles, rederive_at_high_res=rederive_at_high_res)
+
+    if rederive_at_high_res:
+        def state_to_profiles(state, profiles, state_key, profiles_key,position_in_powerstate_batch, **kwargs):
+            profiles.get_profiles()[conversions[ikey]][:-extra_points] = state.plasma[ikey][position_in_powerstate_batch,:].cpu().numpy()
+
+    else:
+        # Just interpolate from powerstate to gacode grid
+        def state_to_profiles(state, profiles, state_key, profiles_key,position_in_powerstate_batch, **kwargs):
+            profiles.get_profiles()[conversions[ikey]] = interpolation_function(
+                profiles.get_profiles()["rho(-)"],
+                state.plasma["rho"][position_in_powerstate_batch,:].cpu().numpy(),
+                state.plasma[ikey][position_in_powerstate_batch,:].cpu().numpy()
+            )
+
     position_in_powerstate_batch = 0
 
     for ikey in conversions:
-        if conversions[ikey] in profiles.profiles:
+        if conversions[ikey] in profiles_dict:
             state_to_profiles(state_temp, profiles, ikey, conversions[ikey], position_in_powerstate_batch)
         else:
-            profiles.profiles[conversions[ikey]] = np.zeros(len(profiles.profiles["qei(MW/m^3)"]))
+            profiles_dict[conversions[ikey]] = np.zeros(len(profiles_dict["qei(MW/m^3)"]))
             state_to_profiles(state_temp, profiles, ikey, conversions[ikey], position_in_powerstate_batch)
+
+def powerstate_to_plasma_io_powers(self, plasma_io_obj, gacode_profiles, time_index=-1, rederive_at_high_res=True):
+    """
+    plasma_io-native sibling of powerstate_to_gacode_powers(): writes the same fine-grid
+    -computed target powers (qie/qrad_bremms/qrad_sync/qrad_line/qfuse/qfusi) into a deep
+    copy of plasma_io_obj's heat_exchange_ei/heat_source_e/heat_source_i output fields,
+    instead of the GACODE-unit profile dict.
+
+    Reuses _compute_highres_powers() -- the exact same state_temp/conversions computation
+    powerstate_to_gacode_powers() uses -- so the two write targets see identical numbers;
+    only the final destination differs. `gacode_profiles` plays the same role
+    powerstate_to_gacode_powers()'s own `profiles` argument does -- it's only used to
+    source rho(-)'s fine grid for the underlying high-res powerstate reconstruction, so
+    any gacode-unit-capable mitim_state works (self.profiles is fine, plasma_io-backed
+    or not: get_profiles() handles both).
+
+    Unit/sign conventions for the heat_source_e/i 'source'-slice writes match fusio's own
+    from_gacode() conversion exactly (plasma.py): qrad_sync/qrad_bremms/qrad_line are loss
+    terms and get sign-flipped relative to their GACODE-convention positive magnitude;
+    qie/qfuse/qfusi are not. qfusi (ion fusion heating) is written to ion index 0 only,
+    matching from_gacode()'s own "assumes all ion heat sources apply to the first ion
+    species only" convention -- not a new limitation introduced here. Source-slice
+    positions are looked up by label (plasma_io_obj.sources.index(name)), not hardcoded,
+    so they track fusio's own source ordering if it ever changes.
+
+    Does not insert particle/momentum sources -- matches powerstate_to_plasma_io()'s
+    existing scope note (no equivalent to those in powerstate_to_gacode() either).
+    """
+    print("\t- Inserting powers into plasma_io")
+
+    state_temp, conversions, extra_points = _compute_highres_powers(self, gacode_profiles, rederive_at_high_res=rederive_at_high_res)
+
+    plasma_io_copy = copy.deepcopy(plasma_io_obj)
+    output_ds = plasma_io_copy.output
+    roa_native = output_ds["r_minor_norm"].isel(time=time_index).to_numpy()
+
+    position_in_powerstate_batch = 0
+    x_fine = state_temp.plasma["roa"][position_in_powerstate_batch, :].cpu().numpy()
+
+    source_index = {name: plasma_io_copy.sources.index(name) for name in
+                     ("synchrotron", "bremsstrahlung", "line_radiation", "fusion")}
+
+    # [powerstate key, sign (matches fusio's from_gacode() convention), target var, source index or None]
+    writes = []
+    if 'qie' in conversions:
+        writes.append(('qie', 1.0, 'heat_exchange_ei', None))
+    if 'qrad_sync' in conversions:
+        writes.append(('qrad_sync', -1.0, 'heat_source_e', source_index['synchrotron']))
+    if 'qrad_bremms' in conversions:
+        writes.append(('qrad_bremms', -1.0, 'heat_source_e', source_index['bremsstrahlung']))
+    if 'qrad_line' in conversions:
+        writes.append(('qrad_line', -1.0, 'heat_source_e', source_index['line_radiation']))
+    if 'qfuse' in conversions:
+        writes.append(('qfuse', 1.0, 'heat_source_e', source_index['fusion']))
+    if 'qfusi' in conversions:
+        writes.append(('qfusi', 1.0, 'heat_source_i', source_index['fusion']))
+
+    newvars = {}
+    for key, sign, target, src_idx in writes:
+        y_fine = state_temp.plasma[key][position_in_powerstate_batch, :].cpu().numpy()
+        # MW/m^3 (powerstate/GACODE convention) -> W/m^3 (plasma_io native): same 1e6
+        # factor fusio's own from_gacode() uses for these exact fields.
+        y_native = sign * 1.0e6 * interpolation_function(roa_native, x_fine, y_fine)
+
+        if target not in newvars:
+            newvars[target] = (list(output_ds[target].dims), output_ds[target].to_numpy().copy())
+        full_array = newvars[target][1]
+        if target == 'heat_source_i':
+            full_array[time_index, :, 0, src_idx] = y_native
+        elif src_idx is None:
+            full_array[time_index, :] = y_native
+        else:
+            full_array[time_index, :, src_idx] = y_native
+
+    if newvars:
+        plasma_io_copy.update_output_data_vars(newvars)
+
+    return plasma_io_copy
     
 def defineIons(self, input_gacode, rho_vec, dfT):
     """
@@ -982,26 +1178,28 @@ def defineIons(self, input_gacode, rho_vec, dfT):
             - Note that this means that it won't calculate radiation based on fast species (e.g. 5% He3 minority won't radiate)
     """
 
+    input_gacode_profiles = input_gacode.get_profiles()
+
     # What is the radial coordinate of rho_vec?
-    rho_use = input_gacode.profiles["rho(-)"]
+    rho_use = input_gacode_profiles["rho(-)"]
 
     # If I'm grabbing original axis, include as part of powerstate all the grid points near axis
     rho_vec = rho_vec.clone().cpu()
 
     # ** Store the information about the thermal ions, including the cooling coefficients
     self.plasma["ni"], mi, Zi, c_rad = [], [], [], []
-    for i in range(len(input_gacode.profiles["mass"])):
-        if input_gacode.profiles["type"][i] == "[therm]":
-            self.plasma["ni"].append(interpolation_function(rho_vec, rho_use, input_gacode.profiles["ni(10^19/m^3)"][:, i]))
-            mi.append(input_gacode.profiles["mass"][i])
-            Zi.append(input_gacode.profiles["z"][i])
+    for i in range(len(input_gacode_profiles["mass"])):
+        if input_gacode_profiles["type"][i] == "[therm]":
+            self.plasma["ni"].append(interpolation_function(rho_vec, rho_use, input_gacode_profiles["ni(10^19/m^3)"][:, i]))
+            mi.append(input_gacode_profiles["mass"][i])
+            Zi.append(input_gacode_profiles["z"][i])
 
             # Grab chebyshev coefficients from file
             data_df = pd.read_csv(__mitimroot__ / "src" / "mitim_modules" / "powertorch" / "physics_models" / "radiation_chebyshev.csv")
             try:
-                c = data_df[data_df['Ion'].str.lower()==input_gacode.profiles["name"][i].lower()].to_numpy()[0,2:].astype(float)
+                c = data_df[data_df['Ion'].str.lower()==input_gacode_profiles["name"][i].lower()].to_numpy()[0,2:].astype(float)
             except IndexError:
-                print(f'\t- Specie {input_gacode.profiles["name"][i]} not found in radiation database, assuming zero radiation from it',typeMsg="w")
+                print(f'\t- Specie {input_gacode_profiles["name"][i]} not found in radiation database, assuming zero radiation from it',typeMsg="w")
                 c = [-1e10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
             c_rad.append(c)

--- a/src/mitim_tools/gacode_tools/PROFILEStools.py
+++ b/src/mitim_tools/gacode_tools/PROFILEStools.py
@@ -221,14 +221,32 @@ class gacode_state(MITIMstate.mitim_state):
 
         self._produce_shape_lists()
 
-        (
-            self.derived["volp_geo"],
-            self.derived["surf_geo"],
-            self.derived["gradr_geo"],
-            self.derived["bp2_geo"],
-            self.derived["bt2_geo"],
-            self.derived["bt_geo"],
-        ) = calculateGeometricFactors(self,n_theta=n_theta_geo)
+        # _geometry_factor_prepop (set only by MITIMstate._compute_derived_from_plasma_io(),
+        # never by any public entry point) lets that caller sidestep calculateGeometricFactors()
+        # for plasma_io-backed states, sourcing these same six quantities from plasma_io's own
+        # native derived-quantity fields instead -- see derived_field_map.geometry_factors_from_native()
+        # for the mapping and why: calculateGeometricFactors() operates on shape_cosN(-)/shape_sinN(-),
+        # which get_profiles() zero-fills whenever they aren't available from the source plasma_io
+        # object, silently corrupting geometry across the whole profile (not just noise at the r/a=1
+        # edge -- see plasma_io_migration_plan.md). Everything else in this method (flux-surface
+        # reconstruction, kappa95/delta95/etc., B_ref) is unaffected and still runs normally either way.
+        geometry_prepop = getattr(self, "_geometry_factor_prepop", None)
+        if geometry_prepop is not None:
+            self.derived["volp_geo"] = geometry_prepop["volp_geo"]
+            self.derived["surf_geo"] = geometry_prepop["surf_geo"]
+            self.derived["gradr_geo"] = geometry_prepop["gradr_geo"]
+            self.derived["bp2_geo"] = geometry_prepop["bp2_geo"]
+            self.derived["bt2_geo"] = geometry_prepop["bt2_geo"]
+            self.derived["bt_geo"] = geometry_prepop["bt_geo"]
+        else:
+            (
+                self.derived["volp_geo"],
+                self.derived["surf_geo"],
+                self.derived["gradr_geo"],
+                self.derived["bp2_geo"],
+                self.derived["bt2_geo"],
+                self.derived["bt_geo"],
+            ) = calculateGeometricFactors(self,n_theta=n_theta_geo)
 
         # Calculate flux surfaces
         cn = np.array(self.shape_cos).T
@@ -288,12 +306,24 @@ class gacode_state(MITIMstate.mitim_state):
 
         [ax00c,ax10c,ax20c,ax01c,ax11c,ax21c,ax02c,ax12c,ax22c,ax3D,ax2D] = axs3
 
-        rho = self.profiles["rho(-)"]
+        profiles = self.get_profiles()
+
+        # self.shape_cos/self.shape_sin are instance attributes set by the physics-engine
+        # _produce_shape_lists() (only ever run on the plain-dict shadow inside get_derived(),
+        # never on a plasma_io-backed self directly -- see get_profiles()'s docstring). Rebuilt
+        # here locally from get_profiles()'s own shape_cosN/shape_sinN keys instead, which are
+        # always present (real MXH-refit values if available, zero-filled otherwise) regardless
+        # of backing -- same convention _produce_shape_lists() itself uses, just sourced via the
+        # accessor rather than the raw dict.
+        shape_cos = [profiles[f"shape_cos{i}(-)"] for i in range(7)]
+        shape_sin = [None, None, None] + [profiles[f"shape_sin{i}(-)"] for i in range(3, 7)]
+
+        rho = profiles["rho(-)"]
         lines = GRAPHICStools.listLS()
 
         ax = ax00c
 
-        var = self.derived['r']
+        var = self.get_derived()['r']
         ax.plot(rho, var, "-", lw=lw, c=color)
 
         ax.set_xlim([0, 1])
@@ -305,7 +335,7 @@ class gacode_state(MITIMstate.mitim_state):
         GRAPHICStools.autoscale_y(ax, bottomy=0)
 
         ax = ax01c
-        ax.plot(self.profiles["rho(-)"], self.derived['volp_geo'], color=color, lw=lw, label = extralab)
+        ax.plot(self.get_profiles()["rho(-)"], self.get_derived()['volp_geo'], color=color, lw=lw, label = extralab)
         ax.set_xlabel('$\\rho_N$'); ax.set_xlim(0, 1)
         ax.set_ylabel(f"$dV/dr$ ($m^3/[r]$)")
         GRAPHICStools.addDenseAxis(ax)
@@ -315,7 +345,7 @@ class gacode_state(MITIMstate.mitim_state):
 
 
         ax = ax02c
-        var = self.profiles["polflux(Wb/radian)"]
+        var = self.get_profiles()["polflux(Wb/radian)"]
         ax.plot(rho, var, lw=lw, ls="-", c=color)
 
         ax.set_xlim([0, 1])
@@ -335,7 +365,7 @@ class gacode_state(MITIMstate.mitim_state):
         ax = ax10c
         cont = 0
         yl = 0
-        for i, s in enumerate(self.shape_sin):
+        for i, s in enumerate(shape_sin):
             if s is not None:
                 valmax = np.abs(s).max()
                 if valmax > minShape:
@@ -357,7 +387,7 @@ class gacode_state(MITIMstate.mitim_state):
         ax = ax11c
         cont = 0
         yl = 0
-        for i, s in enumerate(self.shape_cos):
+        for i, s in enumerate(shape_cos):
             if s is not None:
                 valmax = np.abs(s).max()
                 if valmax > minShape:
@@ -381,7 +411,7 @@ class gacode_state(MITIMstate.mitim_state):
 
         ax = ax12c
 
-        var = self.profiles["kappa(-)"]
+        var = self.get_profiles()["kappa(-)"]
         ax.plot(rho, var, "-", lw=lw, c=color)
 
         ax.set_xlim([0, 1])
@@ -392,10 +422,10 @@ class gacode_state(MITIMstate.mitim_state):
         GRAPHICStools.autoscale_y(ax, bottomy=1)
 
         ax = ax20c
-        var = self.profiles["delta(-)"]
+        var = self.get_profiles()["delta(-)"]
         ax.plot(rho, var, "-", lw=lw, c=color, label = extralab + ', $\\delta$')
 
-        var = self.profiles["zeta(-)"]
+        var = self.get_profiles()["zeta(-)"]
         ax.plot(rho, var, "--", lw=lw, c=color, label = extralab + ', $\\zeta$')
 
 
@@ -412,7 +442,7 @@ class gacode_state(MITIMstate.mitim_state):
 
         ax = ax21c
 
-        var = self.profiles["rmaj(m)"]
+        var = self.get_profiles()["rmaj(m)"]
         ax.plot(rho, var, "-", lw=lw, c=color)
 
         ax.set_xlim([0, 1])
@@ -424,7 +454,7 @@ class gacode_state(MITIMstate.mitim_state):
 
         ax = ax22c
 
-        var = self.profiles["zmag(m)"]
+        var = self.get_profiles()["zmag(m)"]
         ax.plot(rho, var, "-", lw=lw, c=color)
 
         ax.set_xlim([0, 1])
@@ -472,16 +502,16 @@ class gacode_state(MITIMstate.mitim_state):
             errors do not cancel, and the rings separate by up to ~5 mm on a 0.57 m plasma
             with no physical difference behind it.
             '''
-            R = self.derived["R_surface"][i_toroidal]
-            Z = self.derived["Z_surface"][i_toroidal]
+            R = self.get_derived()["R_surface"][i_toroidal]
+            Z = self.get_derived()["Z_surface"][i_toroidal]
             return (
                 np.array([np.interp(value, coordinate, R[:, j]) for j in range(R.shape[1])]),
                 np.array([np.interp(value, coordinate, Z[:, j]) for j in range(Z.shape[1])]),
             )
 
         for rho in surfaces_rho:
-            for i_toroidal in range(self.derived["R_surface"].shape[0]):
-                R, Z = surface_at(self.profiles["rho(-)"], rho, i_toroidal)
+            for i_toroidal in range(self.get_derived()["R_surface"].shape[0]):
+                R, Z = surface_at(self.get_profiles()["rho(-)"], rho, i_toroidal)
                 ax.plot(
                     R,
                     Z,
@@ -502,8 +532,8 @@ class gacode_state(MITIMstate.mitim_state):
         if include995:
             # Interpolated in psi_N, not rho: this curve is DEFINED as a fixed normalized
             # poloidal flux surface, and each state maps 0.995 to its own rho
-            for i_toroidal in range(self.derived["R_surface"].shape[0]):
-                R, Z = surface_at(self.derived["psi_pol_n"], 0.995, i_toroidal)
+            for i_toroidal in range(self.get_derived()["R_surface"].shape[0]):
+                R, Z = surface_at(self.get_derived()["psi_pol_n"], 0.995, i_toroidal)
                 ax.plot(
                     R,
                     Z,
@@ -525,8 +555,8 @@ class gacode_state(MITIMstate.mitim_state):
 
         ax.axhline(y=0, ls="--", lw=0.2, c="k")
         ax.plot(
-            [self.profiles["rmaj(m)"][0]],
-            [self.profiles["zmag(m)"][0]],
+            [self.get_profiles()["rmaj(m)"][0]],
+            [self.get_profiles()["zmag(m)"][0]],
             "o",
             markersize=2,
             c=color,
@@ -546,8 +576,8 @@ class gacode_state(MITIMstate.mitim_state):
 
         n_phi = 50 # Number of toroidal points for the surface mesh
 
-        R = self.derived["R_surface"][0,-1,:]  # Outermost flux surface R coordinates
-        Z = self.derived["Z_surface"][0,-1,:]  # Outermost flux surface Z coordinates
+        R = self.get_derived()["R_surface"][0,-1,:]  # Outermost flux surface R coordinates
+        Z = self.get_derived()["Z_surface"][0,-1,:]  # Outermost flux surface Z coordinates
 
         # Create toroidal angle array
         phi = np.linspace(0, 2*np.pi, n_phi)

--- a/src/mitim_tools/gacode_tools/PROFILEStools.py
+++ b/src/mitim_tools/gacode_tools/PROFILEStools.py
@@ -141,7 +141,7 @@ class gacode_state(MITIMstate.mitim_state):
                     if title in self.titles_singleArr:
                         self.profiles[title] = np.array([float(i) for i in var0])
                     else:
-                        self.profiles[title] = np.array(var0)
+                        self.profiles[title] = np.array([float(i) for i in var0]) if title in ["nexp", "nion", "shot", "time"] else np.array(var0)
                 else:
                     # varT = [float(j) for j in var0[1:]]
                     if len(var0) == 0:

--- a/src/mitim_tools/gacode_tools/utils/NORMtools.py
+++ b/src/mitim_tools/gacode_tools/utils/NORMtools.py
@@ -98,25 +98,27 @@ def normalizations_tgyro(tgyro, rho, roa):
 def normalizations_profiles(profiles):
 
     if profiles is not None:
+        profiles_dict = profiles.get_profiles()
+        derived_dict = profiles.get_derived()
         Set_norm = {
-            "rho": profiles.profiles["rho(-)"],
-            "roa": profiles.derived["roa"],
-            "rmin": np.abs(profiles.profiles["rmin(m)"]),
-            "q_gb": np.abs(profiles.derived["q_gb"]),
-            "g_gb": np.abs(profiles.derived["g_gb"]),
-            "pi_gb": np.abs(profiles.derived["pi_gb"]),
-            "s_gb": np.abs(profiles.derived["s_gb"]),
-            "B_unit": np.abs(profiles.derived["B_unit"]),
-            "rho_s": np.abs(profiles.derived["rho_s"]),
-            "c_s": np.abs(profiles.derived["c_s"]),
-            "Te_keV": np.abs(profiles.profiles["te(keV)"]),
-            "ne_20": np.abs(profiles.profiles["ne(10^19/m^3)"]) * 1e-1,
-            "Ti_keV": np.abs(profiles.profiles["ti(keV)"][:, 0]),
-            "ni_20": np.abs(profiles.derived["ni_thrAll"]) * 1e-1,
-            "exp_Qe": profiles.derived["qe_MWm2"] ,  # This is the same as qe_MWm2
-            "exp_Qi": profiles.derived["qi_MWm2"] ,
-            "exp_Ge": profiles.derived["ge_10E20m2"],
-            "mi_ref": profiles.derived["mi_ref"],
+            "rho": profiles_dict["rho(-)"],
+            "roa": derived_dict["roa"],
+            "rmin": np.abs(profiles_dict["rmin(m)"]),
+            "q_gb": np.abs(derived_dict["q_gb"]),
+            "g_gb": np.abs(derived_dict["g_gb"]),
+            "pi_gb": np.abs(derived_dict["pi_gb"]),
+            "s_gb": np.abs(derived_dict["s_gb"]),
+            "B_unit": np.abs(derived_dict["B_unit"]),
+            "rho_s": np.abs(derived_dict["rho_s"]),
+            "c_s": np.abs(derived_dict["c_s"]),
+            "Te_keV": np.abs(profiles_dict["te(keV)"]),
+            "ne_20": np.abs(profiles_dict["ne(10^19/m^3)"]) * 1e-1,
+            "Ti_keV": np.abs(profiles_dict["ti(keV)"][:, 0]),
+            "ni_20": np.abs(derived_dict["ni_thrAll"]) * 1e-1,
+            "exp_Qe": derived_dict["qe_MWm2"] ,  # This is the same as qe_MWm2
+            "exp_Qi": derived_dict["qi_MWm2"] ,
+            "exp_Ge": derived_dict["ge_10E20m2"],
+            "mi_ref": derived_dict["mi_ref"],
         }
 
         return Set_norm, Set_norm["rho"], Set_norm["roa"], Set_norm["mi_ref"]

--- a/src/mitim_tools/plasmastate_tools/MITIMstate.py
+++ b/src/mitim_tools/plasmastate_tools/MITIMstate.py
@@ -7,6 +7,7 @@ from mitim_tools.misc_tools import GRAPHICStools, MATHtools, PLASMAtools, IOtool
 from mitim_modules.powertorch.utils import CALCtools
 from mitim_tools.gacode_tools.utils import GACODEdefaults
 from mitim_tools.plasmastate_tools.utils import state_plotting
+from mitim_tools.plasmastate_tools.utils.derived_field_map import DERIVED_FIELD_MAP, geometry_factors_from_native
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools import __version__
 from fusio.classes.io import io
@@ -110,6 +111,16 @@ class mitim_state:
     Class to manipulate the plasma state in MITIM.
     '''
 
+    # Class-level fallback for the plasma_io property's backing attribute. Instances
+    # constructed via __init__() always shadow this with their own instance-level
+    # _plasma_io (set through the property setter below). But unpickling an object
+    # pickled by code *older* than this property (e.g. a pre-2026-08-13 run) restores
+    # __dict__ directly, bypassing __init__ entirely -- such an instance never had
+    # _plasma_io in its pickled state, so without this class default, the property
+    # getter's `return self._plasma_io` raises AttributeError on first access
+    # (surfaced e.g. via get_profiles()/get_derived() on any old, legacy-pickled run).
+    _plasma_io = None
+
     def __init__(self, type_file = 'input.gacode'):
 
         self.type = type_file
@@ -118,6 +129,31 @@ class mitim_state:
         # (see scratch()); kept around so downstream code can eventually source
         # data from it directly instead of only from the flattened profiles dict.
         self.plasma_io = None
+
+    @property
+    def plasma_io(self):
+        return self._plasma_io
+
+    @plasma_io.setter
+    def plasma_io(self, value):
+        # Assigning a new plasma_io object (construction, or a live-update reassignment like
+        # TRANSFORMtools.sync_plasma_io()'s self.profiles.plasma_io = powerstate_to_plasma_io(...))
+        # invalidates both lazy caches below -- they were derived from whichever plasma_io object
+        # was assigned before, so leaving them in place would make every subsequent
+        # get_profiles()/get_derived() call keep returning data from the *old* object. This is
+        # what makes plasma_io reassignment a sufficient way to keep get_profiles()/get_derived()
+        # current on its own, with no caller needing to separately remember to invalidate anything.
+        #
+        # Does NOT cover mutating the *contents* of an already-cached get_profiles() dict in place
+        # (get_profiles()'s own docstring documents that as deliberately supported, e.g.
+        # TRANSFORMtools.powerstate_to_gacode()'s slice assignment) -- that path doesn't reassign
+        # .plasma_io at all, so it still needs its own explicit invalidate_derived_cache() call;
+        # see that method's docstring.
+        self._plasma_io = value
+        self._profiles_cache = None
+        self._profiles_cache_side = None
+        self._derived_cache = None
+        self._derived_cache_side = None
 
     @classmethod
     def scratch(cls, profiles, label_header='', **kwargs_process):
@@ -133,11 +169,24 @@ class mitim_state:
 '''
         # `profiles` may be given as a fusio object (e.g. plasma_io) instead of
         # an already-flattened dict. In that case, keep a handle on the source
-        # object and derive the "name(unit)"-keyed dict from its gacode
-        # conversion, the same way MITIM's file-based readers do.
+        # object; `.profiles`/`.derived` are NOT populated as stored attributes
+        # for this branch -- consumers must call get_profiles()/get_derived(),
+        # which lazily source from `instance.plasma_io` on first access. See
+        # test/fusio_integration/plasma_io_migration_plan.md, "New phase
+        # (2026-08-12)". Species bookkeeping (readSpecies()/DTplasma()/
+        # sumFast(), the cheap prefix of derive_quantities_base()) is still
+        # done eagerly here -- plasma_io_to_powerstate()/defineIonsFromPlasmaIO()
+        # already depend on the resulting self.Species/self.mi_first/self.Dion/
+        # self.Tion instance attributes directly, and these calls are cheap
+        # (get_profiles()-backed dict lookups, not the expensive MXH-geometry
+        # derived-quantity pipeline that get_derived() defers).
         if isinstance(profiles, io):
             instance.plasma_io = profiles
-            profiles = profiles.to("gacode").to_dict(side="input")
+            instance.readSpecies()
+            instance.mi_first = instance.Species[0]["A"]
+            instance.DTplasma()
+            instance.sumFast()
+            return instance
 
         # Add data to profiles
         instance.profiles = profiles
@@ -145,6 +194,164 @@ class mitim_state:
         instance.derive_quantities(**kwargs_process)
 
         return instance
+
+    def get_profiles(self, side="output"):
+        """
+        Dict-of-arrays view of the profile data, keyed/unit-suffixed exactly
+        like the legacy `.profiles` attribute (e.g. "te(keV)"). For
+        plasma_io-backed instances (`self.plasma_io is not None`), this is
+        lazily materialized from `plasma_io.to("gacode", side=...).to_dict(side="input")`
+        (the same conversion `scratch()` used to make eagerly) and cached
+        privately per-instance -- NOT re-derived on every call, since some
+        callers perform in-place mutation on the returned arrays (e.g.
+        `TRANSFORMtools.powerstate_to_gacode()`'s slice assignment) and expect
+        that mutation to be visible on subsequent access. For legacy,
+        dict-backed instances, just returns `.profiles` unchanged.
+
+        `side` selects which side of `self.plasma_io` (the source object) to
+        read -- NOT which side of the resulting dict (fusio's `.to(fmt)`
+        conversion always lands its output on the target's `.input`, per
+        `io.py`'s convention, so `to_dict(side="input")` is fixed regardless
+        of this parameter). Defaults to "output", matching the convention
+        established throughout PORTALS' plasma_io construction paths (both
+        the `.gacode` and `.nc` branches leave the live data on `.output` by
+        the time `scratch()` receives the object -- see
+        `PORTALS_workflow.py`), and matching what the original eager
+        `scratch()` code did implicitly (it never passed `side` to `.to()`,
+        so fusio's own `_from()` default of `side='output'` applied).
+        """
+        if self.plasma_io is not None:
+            if getattr(self, "_profiles_cache", None) is None or self._profiles_cache_side != side:
+                cache = self.plasma_io.to("gacode", side=side).to_dict(side="input")
+                # gacode_io.from_plasma() (the .to("gacode") conversion) does not populate
+                # shape_cosN(-)/shape_sinN(-) (MXH shape coefficients) -- unlike plasma_io, fusio
+                # has no method that derives them from a plasma_io object's own mxh_cos/mxh_sin
+                # fields (the only fusio code that writes them needs a *separate EQDSK file*,
+                # add_geometry_from_eqdsk-style, not applicable here); this is a genuine, open
+                # fusio gap, not something to route around further on the MITIM side (see
+                # plasma_io_migration_plan.md, "New phase (2026-08-12)"). Zero-fill them here,
+                # mirroring PROFILEStools._ensure_shaping_coeffs()'s exact convention for the
+                # legacy hand-rolled-parser path, so downstream consumers (e.g. to_neo()/to_tglf())
+                # see the same key set either way -- zero shape coefficients (spherical/Miller
+                # geometry) rather than silently missing keys. Real shape data is lost by this
+                # fallback whenever the source file had non-trivial MXH shaping; tracked as the
+                # open fusio-side follow-up.
+                num_moments = 7
+                if "shape_cos0(-)" not in cache:
+                    cache["shape_cos0(-)"] = np.zeros(cache["rmaj(m)"].shape)
+                for i in range(num_moments):
+                    if f"shape_cos{i + 1}(-)" not in cache:
+                        cache[f"shape_cos{i + 1}(-)"] = np.zeros(cache["rmaj(m)"].shape)
+                    if f"shape_sin{i + 1}(-)" not in cache and i > 1:
+                        cache[f"shape_sin{i + 1}(-)"] = np.zeros(cache["rmaj(m)"].shape)
+                self._profiles_cache = cache
+                self._profiles_cache_side = side
+            return self._profiles_cache
+        return self.profiles
+
+    def get_derived(self, side="output"):
+        """
+        Dict of derived quantities, keyed exactly like the legacy `.derived`
+        attribute (e.g. "aLTe", "Q", "Pfus"). For plasma_io-backed instances,
+        lazily computed and cached privately per-instance on first access
+        (never on every call -- `plasma_io.compute_derived_quantities()` is
+        expensive, and nothing in PORTALS' BO sub-iteration hot path reads
+        `.derived` except `ptot_manual`, which is handled separately by
+        `selfconsistentPTOT()` without going through this cache at all -- see
+        the migration plan doc). For legacy, dict-backed instances, just
+        returns `.derived` unchanged.
+
+        `side` selects which side of `self.plasma_io` to read/compute on;
+        default "output" for the same reason as `get_profiles()`.
+        """
+        if self.plasma_io is not None:
+            if getattr(self, "_derived_cache", None) is None or self._derived_cache_side != side:
+                self._derived_cache = self._compute_derived_from_plasma_io(side=side)
+                self._derived_cache_side = side
+            return self._derived_cache
+        # Legacy dict-backed instances: self-heal if .derived is missing/empty. This happens for
+        # any unpickled powerstate whose profiles were saved via PORTALSmain._dropped_derived()
+        # (stripped to {} to shrink the pickle) -- plasma_io-backed instances self-heal for free
+        # above since they always recompute from self.plasma_io regardless of what's cached, but
+        # a legacy instance has no such fallback source, so it must rebuild via derive_quantities()
+        # once here instead of raising a KeyError on every derived-quantity read downstream (e.g.
+        # PORTALSanalysis.prep_metrics()'s Q/Pfus/tauE reads).
+        if not getattr(self, "derived", None):
+            self.derive_quantities()
+        return self.derived
+
+    def invalidate_derived_cache(self):
+        """
+        Clear get_derived()'s cache so the next call recomputes from the current get_profiles()
+        dict. No-op for legacy dict-backed instances (.derived is a plain, directly-mutated
+        attribute there, not a lazily-cached copy, so there's nothing to invalidate).
+
+        get_profiles() deliberately returns its cached dict by reference so callers can mutate
+        it in place (see its docstring) -- but get_derived()'s own cache has no way to detect
+        that mutation. Any caller that mutates a plasma_io-backed instance's get_profiles()
+        dict MUST call this afterward, or every later get_derived() call -- on this instance,
+        and on every future copy.deepcopy() of it -- keeps returning whatever was cached before
+        the mutation, silently stale forever (nothing else ever recomputes it).
+
+        This was a real, live bug in PORTALS: TRANSFORMtools.powerstate_to_gacode() mutates
+        get_profiles() (inserting the newly-predicted te/ti/ne/nZ, plus Ti_thermals/ni_thermals
+        postprocessing) on every transport evaluation, and self.profiles gets copy.deepcopy'd
+        into the next evaluation's starting point each time -- so the very first get_derived()
+        call of a run cached gradients once, and every subsequent evaluation's to_tglf() (which
+        reads aLTe/aLTi/aLne etc. straight out of get_derived()) kept silently reusing that first
+        cache, regardless of what X the BO optimizer actually proposed on later iterations. See
+        test/fusio_integration/plasma_io_migration_plan.md.
+        """
+        if self.plasma_io is not None:
+            self._derived_cache = None
+            self._derived_cache_side = None
+
+    def _compute_derived_from_plasma_io(self, side="output"):
+        # Baseline: reuse the existing, unmodified derive_quantities_base/
+        # derive_quantities_full pipeline, via a throwaway "shadow" instance built from
+        # get_profiles()'s already-correct dict. This keeps get_derived() byte-identical to
+        # today's `.derived` for every key that doesn't yet have a validated DERIVED_FIELD_MAP
+        # entry (or, for the geometry_prepop case below, structurally can't have one -- see
+        # geometry_factors_from_native()'s docstring).
+        #
+        # native/geometry_prepop are read here (not inside derive_quantities()) deliberately
+        # without calling self.plasma_io.compute_derived_quantities() first: that's an
+        # expensive six-stage call, and forcing it on every get_derived() cache miss (i.e.
+        # every BO evaluation, per invalidate_derived_cache()) would be a real cost regression
+        # over just falling back to calculateGeometricFactors() for this call. Whenever
+        # self.plasma_io already has fresh derived quantities (e.g. after
+        # sync_plasma_io()/powerstate_to_plasma_io()), this is free.
+        native = self.plasma_io.to_dict(side=side)
+        geometry_prepop = geometry_factors_from_native(native)
+
+        # Shadow construction is replicated manually here (rather than calling scratch()
+        # directly) so _geometry_factor_prepop can be set *before* derive_quantities() runs --
+        # scratch() is a single atomic call with no injection point for that. Falls back to
+        # the normal scratch() call (calculateGeometricFactors() runs as before) whenever
+        # geometry_prepop is None.
+        profiles_dict = copy.deepcopy(self.get_profiles(side=side))
+        if geometry_prepop is not None:
+            shadow = type(self)(None)
+            shadow.header = f'''
+#  Created from scratch with MITIM version {__version__}
+#
+'''
+            shadow.profiles = profiles_dict
+            shadow._geometry_factor_prepop = geometry_prepop
+            shadow.derive_quantities()
+        else:
+            shadow = type(self).scratch(profiles_dict)
+        local_derived = shadow.derived
+
+        # Overlay plasma_io-native fields validated so far (see
+        # plasmastate_tools/utils/derived_field_map.py -- empty until Phase 3
+        # of the self.profiles/self.derived removal work populates it
+        # module-by-module, each entry parity-tested first).
+        if DERIVED_FIELD_MAP:
+            for mitim_key, mapping in DERIVED_FIELD_MAP.items():
+                local_derived[mitim_key] = mapping.apply(native)
+
+        return local_derived
 
     @IOtools.hook_method(before=ensure_variables_existence)
     def derive_quantities_base(self, mi_ref=None, derive_quantities=True, rederiveGeometry=True, **kwargs_rederive_geometry):
@@ -193,18 +400,20 @@ class mitim_state:
         if file is None:
             file = self.files[0]
 
+        profiles = self.get_profiles()
+
         with open(file, "w") as f:
             for line in self.header:
                 f.write(line)
 
-            for i in self.profiles:
+            for i in profiles:
                 if "(" not in i:
                     f.write(f"# {i}\n")
                 else:
                     f.write(f"# {i.split('(')[0]} | {i.split('(')[-1].split(')')[0]}\n")
 
                 if i in self.titles_single:
-                    listWrite = self.profiles[i]
+                    listWrite = profiles[i]
 
                     if i in ["nexp", "nion", "shot"] and IOtools.isnum(listWrite[0]):
                         # Integer fields per the GACODE format; they may live as floats
@@ -217,13 +426,13 @@ class mitim_state:
                         f.write(f"{' '.join(listWrite)}\n")
 
                 else:
-                    if len(self.profiles[i].shape) == 1:
-                        for j, val in enumerate(self.profiles[i]):
+                    if len(profiles[i].shape) == 1:
+                        for j, val in enumerate(profiles[i]):
                             pos = f"{j + 1}".rjust(3)
                             valt = f"{round(val,99):.7e}".rjust(15)
                             f.write(f"{pos}{valt}\n")
                     else:
-                        for j, val in enumerate(self.profiles[i]):
+                        for j, val in enumerate(profiles[i]):
                             pos = f"{j + 1}".rjust(3)
                             txt = "".join([f"{k:.7e}".rjust(15) for k in val])
                             f.write(f"{pos}{txt}\n")
@@ -301,47 +510,49 @@ class mitim_state:
             self.write_state(file=write_new_file)
 
     def readSpecies(self, maxSpecies=100, correct_zeff = True):
-        maxSpecies = int(self.profiles["nion"][0])
+        profiles = self.get_profiles()
+        maxSpecies = int(profiles["nion"][0])
 
         Species = []
         for j in range(maxSpecies):
             # To determine later if this specie has zero density
-            niT = self.profiles["ni(10^19/m^3)"][0, j]
+            niT = profiles["ni(10^19/m^3)"][0, j]
 
             sp = {
-                "N": self.profiles["name"][j],
-                "Z": float(self.profiles["z"][j]),
-                "A": float(self.profiles["mass"][j]),
-                "S": self.profiles["type"][j].split("[")[-1].split("]")[0],
+                "N": profiles["name"][j],
+                "Z": float(profiles["z"][j]),
+                "A": float(profiles["mass"][j]),
+                "S": profiles["type"][j].split("[")[-1].split("]")[0],
                 "n0": niT,
             }
 
             Species.append(sp)
 
         self.Species = Species
-        
+
         # Correct Zeff if needed
         if correct_zeff:
             self.correct_zeff_array()
-            
+
     def correct_zeff_array(self):
-        
-        self.profiles["z_eff(-)"] = np.sum(self.profiles["ni(10^19/m^3)"] * self.profiles["z"] ** 2, axis=1) / self.profiles["ne(10^19/m^3)"]
-            
+        profiles = self.get_profiles()
+        profiles["z_eff(-)"] = np.sum(profiles["ni(10^19/m^3)"] * profiles["z"] ** 2, axis=1) / profiles["ne(10^19/m^3)"]
+
     def sumFast(self):
-        self.nFast = self.profiles["ne(10^19/m^3)"] * 0.0
-        self.nZFast = self.profiles["ne(10^19/m^3)"] * 0.0
-        self.nThermal = self.profiles["ne(10^19/m^3)"] * 0.0
-        self.nZThermal = self.profiles["ne(10^19/m^3)"] * 0.0
+        profiles = self.get_profiles()
+        self.nFast = profiles["ne(10^19/m^3)"] * 0.0
+        self.nZFast = profiles["ne(10^19/m^3)"] * 0.0
+        self.nThermal = profiles["ne(10^19/m^3)"] * 0.0
+        self.nZThermal = profiles["ne(10^19/m^3)"] * 0.0
         for sp in range(len(self.Species)):
             if self.Species[sp]["S"] == "fast":
-                self.nFast += self.profiles["ni(10^19/m^3)"][:, sp]
+                self.nFast += profiles["ni(10^19/m^3)"][:, sp]
                 self.nZFast += (
-                    self.profiles["ni(10^19/m^3)"][:, sp] * self.profiles["z"][sp]
+                    profiles["ni(10^19/m^3)"][:, sp] * profiles["z"][sp]
                 )
             else:
-                self.nThermal += self.profiles["ni(10^19/m^3)"][:, sp]
-                self.nZThermal += self.profiles["ni(10^19/m^3)"][:, sp] * self.profiles["z"][sp]
+                self.nThermal += profiles["ni(10^19/m^3)"][:, sp]
+                self.nZThermal += profiles["ni(10^19/m^3)"][:, sp] * profiles["z"][sp]
 
     def derive_quantities_full(self, mi_ref=None, rederiveGeometry=True, **kwargs_rederive_geometry):
         """
@@ -1245,7 +1456,7 @@ class mitim_state:
             self.derived['Te_lcfs_lengyel_mode'] = mode
 
     def _deriv_gacode(self,y):
-        return grad(self.derived["r"],y)
+        return grad(self.get_derived()["r"],y)
 
     def calculateMass(self):
         self.derived["mbg"] = 0.0
@@ -1430,22 +1641,24 @@ class mitim_state:
         return table
 
     def makeAllThermalIonsHaveSameTemp(self, refIon=0):
+        profiles = self.get_profiles()
         SpecRef = self.Species[refIon]["N"]
-        tiRef = self.profiles["ti(keV)"][:, refIon]
+        tiRef = profiles["ti(keV)"][:, refIon]
 
         for sp in range(len(self.Species)):
             if self.Species[sp]["S"] == "therm" and sp != refIon:
                 print(f"\t\t\t- Temperature forcing {self.Species[sp]['N']} --> {SpecRef}")
-                self.profiles["ti(keV)"][:, sp] = tiRef
+                profiles["ti(keV)"][:, sp] = tiRef
 
     def scaleAllThermalDensities(self, scaleFactor=1.0):
+        profiles = self.get_profiles()
         scaleFactor_ions = scaleFactor
 
         for sp in range(len(self.Species)):
             if self.Species[sp]["S"] == "therm":
                 print(f"\t\t\t- Scaling density of {self.Species[sp]['N']} by an average factor of {np.mean(scaleFactor_ions):.3f}")
-                ni_orig = self.profiles["ni(10^19/m^3)"][:, sp]
-                self.profiles["ni(10^19/m^3)"][:, sp] = scaleFactor_ions * ni_orig
+                ni_orig = profiles["ni(10^19/m^3)"][:, sp]
+                profiles["ni(10^19/m^3)"][:, sp] = scaleFactor_ions * ni_orig
 
     def toNumpyArrays(self):
         self.profiles.update({key: tensor.cpu().detach().cpu().numpy() for key, tensor in self.profiles.items() if isinstance(tensor, torch.Tensor)})
@@ -1563,13 +1776,14 @@ class mitim_state:
         print(f"\t\t- Profiles smoothed via gradient-integration (relative_smoothing={relative_smoothing:.3f}): {variables}", typeMsg="i")
 
     def DTplasma(self):
+        profiles = self.get_profiles()
         self.Dion, self.Tion = None, None
         try:
-            self.Dion = np.where(self.profiles["name"] == "D")[0][0]
+            self.Dion = np.where(profiles["name"] == "D")[0][0]
         except:
             pass
         try:
-            self.Tion = np.where(self.profiles["name"] == "T")[0][0]
+            self.Tion = np.where(profiles["name"] == "T")[0][0]
         except:
             pass
 
@@ -1922,6 +2136,15 @@ class mitim_state:
 
         print("\t- Custom correction of input.gacode file has been requested")
 
+        # NOTE: remove()/enforce_same_density_gradients()/enforce_quasineutrality()/
+        # introduceRotationProfile()/make_fast_ions_thermal() (the shape-changing/species-
+        # mutating branches below, each gated by an options[] flag not yet converted here) still
+        # read/write .profiles directly and are not yet plasma_io-get_profiles()-aware -- fine for
+        # now since PORTALSinit.py's only caller passes just {"recalculate_ptot": True}, so none
+        # of those branches are reached in the plasma_io-backed path. See "New phase
+        # (2026-08-12)" in plasma_io_migration_plan.md.
+        profiles = self.get_profiles()
+
         # ----------------------------------------------------------------------
         # Correct
         # ----------------------------------------------------------------------
@@ -1946,22 +2169,22 @@ class mitim_state:
             self.make_fast_ions_thermal()
 
         # Correct LUMPED
-        for i in range(len(self.profiles["name"])):
-            if self.profiles["name"][i] in ["LUMPED", "None"]:
+        for i in range(len(profiles["name"])):
+            if profiles["name"][i] in ["LUMPED", "None"]:
                 name = ionName(
-                    int(self.profiles["z"][i]), int(self.profiles["mass"][i])
+                    int(profiles["z"][i]), int(profiles["mass"][i])
                 )
                 if name is not None:
-                    print(f'\t\t- Ion in position #{i+1} was named LUMPED with Z={self.profiles["z"][i]}, now it is renamed to {name}',typeMsg="i",)
-                    self.profiles["name"][i] = name
+                    print(f'\t\t- Ion in position #{i+1} was named LUMPED with Z={profiles["z"][i]}, now it is renamed to {name}',typeMsg="i",)
+                    profiles["name"][i] = name
                 else:
-                    print(f'\t\t- Ion in position #{i+1} was named LUMPED with Z={self.profiles["z"][i]}, but I could not find what element it is, so doing nothing',typeMsg="w",)
+                    print(f'\t\t- Ion in position #{i+1} was named LUMPED with Z={profiles["z"][i]}, but I could not find what element it is, so doing nothing',typeMsg="w",)
 
         # Correct qione
-        if groupQIONE and (np.abs(self.profiles["qione(MW/m^3)"].sum()) > 1e-14):
+        if groupQIONE and (np.abs(profiles["qione(MW/m^3)"].sum()) > 1e-14):
             print('\t\t- Inserting "qione" into "qrfe"', typeMsg="i")
-            self.profiles["qrfe(MW/m^3)"] += self.profiles["qione(MW/m^3)"]
-            self.profiles["qione(MW/m^3)"] = self.profiles["qione(MW/m^3)"] * 0.0
+            profiles["qrfe(MW/m^3)"] += profiles["qione(MW/m^3)"]
+            profiles["qione(MW/m^3)"] = profiles["qione(MW/m^3)"] * 0.0
 
         # Make all thermal ions have the same gradient as the electron density, by keeping volume average constant
         if enforce_same_aLn:
@@ -1971,7 +2194,7 @@ class mitim_state:
         if quasineutrality:
             self.enforce_quasineutrality()
 
-        print(f"\t\t\t* Quasineutrality error = {self.derived['QN_Error']:.1e}")
+        print(f"\t\t\t* Quasineutrality error = {self.get_derived()['QN_Error']:.1e}")
 
         # Zero seed source blocks (e.g. drop TRANSP-supplied radiation/alpha/
         # ohmic so PORTALS sees an "all-auxiliary" sources picture). Run before
@@ -1982,22 +2205,26 @@ class mitim_state:
                 continue
             keys_zeroed = []
             for key in _SOURCE_BLOCK_ALIASES[alias]:
-                if key in self.profiles:
-                    self.profiles[key] = self.profiles[key] * 0.0
+                if key in profiles:
+                    profiles[key] = profiles[key] * 0.0
                     keys_zeroed.append(key)
             if keys_zeroed:
                 print(f"\t\t- Zeroed seed source block '{alias}' ({', '.join(keys_zeroed)})", typeMsg="i")
 
         # Recompute ptot
         if recalculate_ptot:
-            self.derive_quantities(rederiveGeometry=False)
+            # For plasma_io-backed instances, .derived is no longer stored -- skip the
+            # (expensive, dict-based) recompute; selfconsistentPTOT() sources ptot_manual via
+            # its own cheap, get_profiles()-based local calculation regardless.
+            if getattr(self, "plasma_io", None) is None:
+                self.derive_quantities(rederiveGeometry=False)
             self.selfconsistentPTOT()
 
         # If I don't trust the negative particle flux in the core that comes from TRANSP...
         if ensure_positive_Gamma:
             print("\t\t- Making particle flux always positive", typeMsg="i")
-            self.profiles["qpar_beam(1/m^3/s)"] = self.profiles["qpar_beam(1/m^3/s)"].clip(0)
-            self.profiles["qpar_wall(1/m^3/s)"] = self.profiles["qpar_wall(1/m^3/s)"].clip(0)
+            profiles["qpar_beam(1/m^3/s)"] = profiles["qpar_beam(1/m^3/s)"].clip(0)
+            profiles["qpar_wall(1/m^3/s)"] = profiles["qpar_wall(1/m^3/s)"].clip(0)
 
         # Mach
         if force_mach is not None:
@@ -2007,7 +2234,10 @@ class mitim_state:
         # Re-derive
         # ----------------------------------------------------------------------
 
-        self.derive_quantities(rederiveGeometry=False) 
+        # For plasma_io-backed instances .derived is sourced lazily via get_derived() instead
+        # of eagerly stored -- nothing here needs it recomputed as a post-condition.
+        if getattr(self, "plasma_io", None) is None:
+            self.derive_quantities(rederiveGeometry=False)
 
         # ----------------------------------------------------------------------
         # Write
@@ -2166,9 +2396,31 @@ class mitim_state:
         if modified_num > 0:
             print("\t- Making fast species as if they were thermal (to keep dilution effect and Qi-sum of fluxes)",typeMsg="w")
     
+    def _ptot_manual(self):
+        # Cheap, self-contained pressure calculation from get_profiles()'s te/ti/ne/ni alone --
+        # deliberately kept as local MITIM math (not sourced from plasma_io) rather than going
+        # through the full derive_quantities_full()/get_derived() pipeline, since this is the one
+        # derived quantity actually read inside PORTALS' BO sub-iteration hot path (via
+        # selfconsistentPTOT(), below) and needs a cheap per-sub-iteration recompute that
+        # plasma_io.compute_derived_quantities()'s monolithic six-stage call doesn't cheaply
+        # support (see test/fusio_integration/plasma_io_migration_plan.md, "New phase
+        # (2026-08-12)" -- follow-up noted there to eventually add a cheap, geometry-independent
+        # pressure calculation to fusio so this carve-out can retire). Formula matches
+        # derive_quantities_full()'s "ptot_manual" computation exactly.
+        profiles = self.get_profiles()
+        ptot_manual, _, _, _ = PLASMAtools.calculatePressure(
+            np.expand_dims(profiles["te(keV)"], 0),
+            np.expand_dims(np.transpose(profiles["ti(keV)"]), 0),
+            np.expand_dims(profiles["ne(10^19/m^3)"] * 0.1, 0),
+            np.expand_dims(np.transpose(profiles["ni(10^19/m^3)"] * 0.1), 0),
+        )
+        return ptot_manual[0, ...]
+
     def selfconsistentPTOT(self):
-        print(f"\t\t* Recomputing ptot and inserting it as ptot(Pa), changed from p0 = {self.profiles['ptot(Pa)'][0] * 1e-3:.1f} to {self.derived['ptot_manual'][0]*1e+3:.1f} kPa",typeMsg="i")
-        self.profiles["ptot(Pa)"] = self.derived["ptot_manual"] * 1e6
+        profiles = self.get_profiles()
+        ptot_manual = self._ptot_manual()
+        print(f"\t\t* Recomputing ptot and inserting it as ptot(Pa), changed from p0 = {profiles['ptot(Pa)'][0] * 1e-3:.1f} to {ptot_manual[0]*1e+3:.1f} kPa",typeMsg="i")
+        profiles["ptot(Pa)"] = ptot_manual * 1e6
 
     # DEPRECATED
     def enforceQuasineutrality(self, *args, **kwargs):
@@ -2732,14 +2984,17 @@ class mitim_state:
         # <> Function to interpolate a curve <>
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
+        profiles = self.get_profiles()
+        derived = self.get_derived()
+
         # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
         r_labels = r  # preserve original values for dict keys / filenames
         if r_is_rho:
-            r = interpolation_function(np.atleast_1d(r), self.profiles['rho(-)'], self.derived['roa']).tolist()
-        r_interpolation = self.derived['roa']
+            r = interpolation_function(np.atleast_1d(r), profiles['rho(-)'], derived['roa']).tolist()
+        r_interpolation = derived['roa']
 
         # Determine the number of species to use in TGLF
-        max_species_tglf = 6  # TGLF only accepts up to 6 species  
+        max_species_tglf = 6  # TGLF only accepts up to 6 species
         if len(self.Species) > max_species_tglf-1:
             print(f"\t- Warning: TGLF only accepts {max_species_tglf} species, but there are {len(self.Species)} ions pecies in the GACODE input. The first {max_species_tglf-1} will be used.", typeMsg="w")
             tglf_ions_num = max_species_tglf - 1
@@ -2749,46 +3004,46 @@ class mitim_state:
         # Determine the mass reference for TGLF (use 2.0 for D-mass normalization; derivatives use mD_u elsewhere)
         mass_ref = 2.0
 
-        self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', self.derived["a"], 1.0, mass_ref)
+        self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', derived["a"], 1.0, mass_ref)
 
         # -----------------------------------------------------------------------
         # Derived profiles
         # -----------------------------------------------------------------------
-        
-        sign_it = -np.sign(self.profiles["current(MA)"][-1])
-        sign_bt = -np.sign(self.profiles["bcentr(T)"][-1])
 
-        s_kappa  = self.derived["r"] / self.profiles["kappa(-)"] * self._deriv_gacode(self.profiles["kappa(-)"])
-        s_delta  = self.derived["r"]                             * self._deriv_gacode(self.profiles["delta(-)"])
-        s_zeta   = self.derived["r"]                             * self._deriv_gacode(self.profiles["zeta(-)"])
-        
+        sign_it = -np.sign(profiles["current(MA)"][-1])
+        sign_bt = -np.sign(profiles["bcentr(T)"][-1])
+
+        s_kappa  = derived["r"] / profiles["kappa(-)"] * self._deriv_gacode(profiles["kappa(-)"])
+        s_delta  = derived["r"]                             * self._deriv_gacode(profiles["delta(-)"])
+        s_zeta   = derived["r"]                             * self._deriv_gacode(profiles["zeta(-)"])
+
         '''
         Total pressure
         --------------------------------------------------------
             Recompute pprime with those species that belong to this run             #TODO not exact?
         '''
-        
+
         dpdr = self._calculate_pressure_gradient_from_aLx(
-            self.derived['pe'], self.derived['pi_all'][:,:tglf_ions_num],
-            self.derived['aLTe'], self.derived['aLTi'][:,:tglf_ions_num],
-            self.derived['aLne'], self.derived['aLni'][:,:tglf_ions_num],
-            self.derived['a']
+            derived['pe'], derived['pi_all'][:,:tglf_ions_num],
+            derived['aLTe'], derived['aLTi'][:,:tglf_ions_num],
+            derived['aLne'], derived['aLni'][:,:tglf_ions_num],
+            derived['a']
         )
-        
-        pprime = 1E-7 * abs(self.profiles["q(-)"])*self.derived['a']**2/self.derived["r"]/self.derived["B_unit"]**2*dpdr
+
+        pprime = 1E-7 * abs(profiles["q(-)"])*derived['a']**2/derived["r"]/derived["B_unit"]**2*dpdr
         pprime[0] = 0 # infinite in first location
 
         '''
         Rotations
         --------------------------------------------------------
             E×B and parallel-velocity shear are derived once in derive_quantities
-            (self.derived['gamma_exb'] / ['gamma_p'], TGLF VEXB_SHEAR / VPAR_SHEAR normalization).
+            (derived['gamma_exb'] / ['gamma_p'], TGLF VEXB_SHEAR / VPAR_SHEAR normalization).
             VPAR (parallel velocity, not a shear) stays local.
         '''
 
-        vexb_shear  = self.derived["gamma_exb"]
-        vpar_shear  = self.derived["gamma_p"]
-        vpar        = -sign_it * self.profiles["rmaj(m)"]*self.profiles["w0(rad/s)"]/self.derived['c_s']
+        vexb_shear  = derived["gamma_exb"]
+        vpar_shear  = derived["gamma_p"]
+        vpar        = -sign_it * profiles["rmaj(m)"]*profiles["w0(rad/s)"]/derived['c_s']
 
         # ---------------------------------------------------------------------------------------------------------------------------------------
         # Prepare the inputs for TGLF
@@ -2818,8 +3073,8 @@ class mitim_state:
                 1: {
                     'ZS': -1.0,
                     'MASS': PLASMAtools.me_u / mass_ref,
-                    'RLNS': interpolator(self.derived['aLne']),
-                    'RLTS': interpolator(self.derived['aLTe']),
+                    'RLNS': interpolator(derived['aLne']),
+                    'RLTS': interpolator(derived['aLTe']),
                     'TAUS': 1.0,
                     'AS': 1.0,
                     'VPAR': interpolator(vpar),
@@ -2832,10 +3087,10 @@ class mitim_state:
                 species[i+2] = {
                     'ZS': self.Species[i]['Z'],
                     'MASS': self.Species[i]['A']/mass_ref,
-                    'RLNS': interpolator(self.derived['aLni'][:,i]),
-                    'RLTS': interpolator(self.derived["aLTi"][:,i]),
-                    'TAUS': interpolator(self.derived["tite_all"][:,i]),
-                    'AS': interpolator(self.derived['fi'][:,i]),
+                    'RLNS': interpolator(derived['aLni'][:,i]),
+                    'RLTS': interpolator(derived["aLTi"][:,i]),
+                    'TAUS': interpolator(derived["tite_all"][:,i]),
+                    'AS': interpolator(derived['fi'][:,i]),
                     'VPAR': interpolator(vpar),
                     'VPAR_SHEAR': interpolator(vpar_shear),
                     'VNS_SHEAR': 0.0,
@@ -2852,10 +3107,10 @@ class mitim_state:
                 'SIGN_IT': sign_it,
                 'VEXB': 0.0,
                 'VEXB_SHEAR': interpolator(vexb_shear),
-                'XNUE': interpolator(self.derived['xnue']),
-                'ZEFF': interpolator(self.derived['Zeff']),
-                'DEBYE': interpolator(self.derived['debye']),
-                'BETAE': interpolator(self.derived['betae']),
+                'XNUE': interpolator(derived['xnue']),
+                'ZEFF': interpolator(derived['Zeff']),
+                'DEBYE': interpolator(derived['debye']),
+                'BETAE': interpolator(derived['betae']),
                 }
 
 
@@ -2864,25 +3119,25 @@ class mitim_state:
             # ---------------------------------------------------------------------------------------------------------------------------------------
 
             parameters = {
-                'RMIN_LOC':     self.derived['roa'],
-                'RMAJ_LOC':     self.derived['Rmajoa'],
-                'ZMAJ_LOC':     self.derived["Zmagoa"],
-                'DRMINDX_LOC':  np.ones(self.profiles["rho(-)"].shape), # Force 1.0 because of numerical issues in TGLF
-                'DRMAJDX_LOC':  self._deriv_gacode(self.profiles["rmaj(m)"]),
-                'DZMAJDX_LOC':  self._deriv_gacode(self.profiles["zmag(m)"]),
-                'Q_LOC':        np.abs(self.profiles["q(-)"]),
-                'KAPPA_LOC':    self.profiles["kappa(-)"],
+                'RMIN_LOC':     derived['roa'],
+                'RMAJ_LOC':     derived['Rmajoa'],
+                'ZMAJ_LOC':     derived["Zmagoa"],
+                'DRMINDX_LOC':  np.ones(profiles["rho(-)"].shape), # Force 1.0 because of numerical issues in TGLF
+                'DRMAJDX_LOC':  self._deriv_gacode(profiles["rmaj(m)"]),
+                'DZMAJDX_LOC':  self._deriv_gacode(profiles["zmag(m)"]),
+                'Q_LOC':        np.abs(profiles["q(-)"]),
+                'KAPPA_LOC':    profiles["kappa(-)"],
                 'S_KAPPA_LOC':  s_kappa,
-                'DELTA_LOC':    self.profiles["delta(-)"],
+                'DELTA_LOC':    profiles["delta(-)"],
                 'S_DELTA_LOC':  s_delta,
-                'ZETA_LOC':     self.profiles["zeta(-)"],
+                'ZETA_LOC':     profiles["zeta(-)"],
                 'S_ZETA_LOC':   s_zeta,
-                'Q_PRIME_LOC':  self.derived['s_q'],
+                'Q_PRIME_LOC':  derived['s_q'],
                 'P_PRIME_LOC':  pprime,
             }
 
             # Add MXH and derivatives
-            for ikey in self.profiles:
+            for ikey in profiles:
                 if 'shape_cos' in ikey or 'shape_sin' in ikey:
 
                     # TGLF only accepts 6, as of July 2025
@@ -2891,8 +3146,8 @@ class mitim_state:
 
                     key_mod = ikey.upper().split('(')[0]
 
-                    parameters[key_mod] = self.profiles[ikey]
-                    parameters[f"{key_mod.split('_')[0]}_S_{key_mod.split('_')[-1]}"] = self.derived["r"] * self._deriv_gacode(self.profiles[ikey])
+                    parameters[key_mod] = profiles[ikey]
+                    parameters[f"{key_mod.split('_')[0]}_S_{key_mod.split('_')[-1]}"] = derived["r"] * self._deriv_gacode(profiles[ikey])
 
             for k in parameters:
                 par = torch.nan_to_num(torch.from_numpy(parameters[k]) if type(parameters[k]) is np.ndarray else parameters[k], nan=0.0, posinf=1E10, neginf=-1E10)
@@ -2920,11 +3175,14 @@ class mitim_state:
         # <> Function to interpolate a curve <>
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
+        profiles = self.get_profiles()
+        derived = self.get_derived()
+
         # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
         r_labels = r  # preserve original values for dict keys / filenames
         if r_is_rho:
-            r = interpolation_function(np.atleast_1d(r), self.profiles['rho(-)'], self.derived['roa']).tolist()
-        r_interpolation = self.derived['roa']
+            r = interpolation_function(np.atleast_1d(r), profiles['rho(-)'], derived['roa']).tolist()
+        r_interpolation = derived['roa']
 
         # ---------------------------------------------------------------------------------------------------------------------------------------
         # Prepare the inputs
@@ -2933,34 +3191,34 @@ class mitim_state:
         # Determine the mass reference
         mass_ref = 2.0
         
-        sign_it = int(-np.sign(self.profiles["current(MA)"][-1]))
-        sign_bt = int(-np.sign(self.profiles["bcentr(T)"][-1]))
+        sign_it = int(-np.sign(profiles["current(MA)"][-1]))
+        sign_bt = int(-np.sign(profiles["bcentr(T)"][-1]))
         
-        s_kappa  = self.derived["r"] / self.profiles["kappa(-)"] * self._deriv_gacode(self.profiles["kappa(-)"])
-        s_delta  = self.derived["r"]                             * self._deriv_gacode(self.profiles["delta(-)"])
-        s_zeta   = self.derived["r"]                             * self._deriv_gacode(self.profiles["zeta(-)"])
+        s_kappa  = derived["r"] / profiles["kappa(-)"] * self._deriv_gacode(profiles["kappa(-)"])
+        s_delta  = derived["r"]                             * self._deriv_gacode(profiles["delta(-)"])
+        s_zeta   = derived["r"]                             * self._deriv_gacode(profiles["zeta(-)"])
 
         # Rotations
-        rmaj = self.derived['Rmajoa']
-        cs = self.derived['c_s']
-        a = self.derived['a']
-        mach = self.profiles["w0(rad/s)"] * (self.derived['Rmajoa']*a)
-        gamma_p = self._deriv_gacode(self.profiles["w0(rad/s)"]) * (self.derived['Rmajoa']*a)
+        rmaj = derived['Rmajoa']
+        cs = derived['c_s']
+        a = derived['a']
+        mach = profiles["w0(rad/s)"] * (derived['Rmajoa']*a)
+        gamma_p = self._deriv_gacode(profiles["w0(rad/s)"]) * (derived['Rmajoa']*a)
 
         # NEO definition: 'OMEGA_ROT=',mach_loc/rmaj_loc/cs_loc
-        omega_rot = mach / rmaj / cs        # Equivalent to: self.profiles["w0(rad/s)"] / self.derived['c_s'] * a
+        omega_rot = mach / rmaj / cs        # Equivalent to: profiles["w0(rad/s)"] / derived['c_s'] * a
         
         # NEO definition: 'OMEGA_ROT_DERIV=',-gamma_p_loc*a/cs_loc/rmaj_loc
-        omega_rot_deriv = gamma_p * a / cs / rmaj # Equivalent to: self._deriv_gacode(self.profiles["w0(rad/s)"])/ self.derived['c_s'] * self.derived['a']**2
+        omega_rot_deriv = gamma_p * a / cs / rmaj # Equivalent to: self._deriv_gacode(profiles["w0(rad/s)"])/ derived['c_s'] * derived['a']**2
 
-        self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', self.derived["a"], 1.0, mass_ref)
+        self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', derived["a"], 1.0, mass_ref)
 
         # With zero rotation everywhere, ROTATION_MODEL=2 gives fluxes identical to model 1
         # but its sonic quasineutrality Newton solve dies SILENTLY (exit 0, empty transport
         # files) for Ti/Te <~ 1e-2, which extreme optimizer candidates can reach. Downgrade
         # to model 1 in that case; an explicit extraOptions ROTATION_MODEL still wins (it is
         # applied downstream, on top of these controls).
-        zero_rotation = bool(np.all(self.profiles["w0(rad/s)"] == 0.0))
+        zero_rotation = bool(np.all(profiles["w0(rad/s)"] == 0.0))
         if zero_rotation:
             print("\t- w0 = 0 everywhere: using NEO ROTATION_MODEL=1 (identical fluxes, robust at extreme Ti/Te)", typeMsg='i')
 
@@ -2989,18 +3247,18 @@ class mitim_state:
                 species[i+1] = {
                     'Z': self.Species[i]['Z'],
                     'MASS': self.Species[i]['A']/mass_ref,
-                    'DLNNDR': interpolator(self.derived['aLni'][:,i]),
-                    'DLNTDR': interpolator(self.derived["aLTi"][:,i]),
-                    'TEMP': interpolator(self.derived["tite_all"][:,i]),
-                    'DENS': interpolator(self.derived['fi'][:,i]),
+                    'DLNNDR': interpolator(derived['aLni'][:,i]),
+                    'DLNTDR': interpolator(derived["aLTi"][:,i]),
+                    'TEMP': interpolator(derived["tite_all"][:,i]),
+                    'DENS': interpolator(derived['fi'][:,i]),
                     }
 
             ie = i+2
             species[ie] = {
                     'Z': -1.0,
                     'MASS': 0.000272445,
-                    'DLNNDR': interpolator(self.derived['aLne']),
-                    'DLNTDR': interpolator(self.derived['aLTe']),
+                    'DLNNDR': interpolator(derived['aLne']),
+                    'DLNTDR': interpolator(derived['aLTe']),
                     'TEMP': 1.0,
                     'DENS': 1.0,
                 }
@@ -3020,8 +3278,8 @@ class mitim_state:
                 'BTCCW': sign_bt,
                 'OMEGA_ROT': interpolator(omega_rot),
                 'OMEGA_ROT_DERIV': interpolator(omega_rot_deriv),
-                'NU_1': interpolator(self.derived['xnue'])* factor_nu,
-                'RHO_STAR': interpolator(self.derived["rho_sa"]),
+                'NU_1': interpolator(derived['xnue'])* factor_nu,
+                'RHO_STAR': interpolator(derived["rho_sa"]),
                 }
 
 
@@ -3030,23 +3288,23 @@ class mitim_state:
             # ---------------------------------------------------------------------------------------------------------------------------------------
 
             parameters = {
-                'RMIN_OVER_A':  self.derived['roa'],
-                'RMAJ_OVER_A':  self.derived['Rmajoa'],
-                'SHIFT':         self._deriv_gacode(self.profiles["rmaj(m)"]),
-                'ZMAG_OVER_A':  self.derived["Zmagoa"],
-                'S_ZMAG':       self._deriv_gacode(self.profiles["zmag(m)"]),
-                'Q':            np.abs(self.profiles["q(-)"]),
-                'SHEAR':        self.derived["s_hat"],
-                'KAPPA':        self.profiles["kappa(-)"],
+                'RMIN_OVER_A':  derived['roa'],
+                'RMAJ_OVER_A':  derived['Rmajoa'],
+                'SHIFT':         self._deriv_gacode(profiles["rmaj(m)"]),
+                'ZMAG_OVER_A':  derived["Zmagoa"],
+                'S_ZMAG':       self._deriv_gacode(profiles["zmag(m)"]),
+                'Q':            np.abs(profiles["q(-)"]),
+                'SHEAR':        derived["s_hat"],
+                'KAPPA':        profiles["kappa(-)"],
                 'S_KAPPA':      s_kappa,
-                'DELTA':        self.profiles["delta(-)"],
+                'DELTA':        profiles["delta(-)"],
                 'S_DELTA':      s_delta,
-                'ZETA':         self.profiles["zeta(-)"],
+                'ZETA':         profiles["zeta(-)"],
                 'S_ZETA':       s_zeta,
             }
             
             # Add MXH and derivatives
-            for ikey in self.profiles:
+            for ikey in profiles:
                 if 'shape_cos' in ikey or 'shape_sin' in ikey:
                     
                     # TGLF only accepts 6, as of July 2025
@@ -3055,8 +3313,8 @@ class mitim_state:
                     
                     key_mod = ikey.upper().split('(')[0]
                     
-                    parameters[key_mod] = self.profiles[ikey]
-                    parameters[f"{key_mod.split('_')[0]}_S_{key_mod.split('_')[-1]}"] = self.derived["r"] * self._deriv_gacode(self.profiles[ikey])
+                    parameters[key_mod] = profiles[ikey]
+                    parameters[f"{key_mod.split('_')[0]}_S_{key_mod.split('_')[-1]}"] = derived["r"] * self._deriv_gacode(profiles[ikey])
 
             for k in parameters:
                 par = torch.nan_to_num(torch.from_numpy(parameters[k]) if type(parameters[k]) is np.ndarray else parameters[k], nan=0.0, posinf=1E10, neginf=-1E10)
@@ -3084,11 +3342,14 @@ class mitim_state:
         # <> Function to interpolate a curve <>
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
+        profiles = self.get_profiles()
+        derived = self.get_derived()
+
         # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
         r_labels = r  # preserve original values for dict keys / filenames
         if r_is_rho:
-            r = interpolation_function(np.atleast_1d(r), self.profiles['rho(-)'], self.derived['roa']).tolist()
-        r_interpolation = self.derived['roa']
+            r = interpolation_function(np.atleast_1d(r), profiles['rho(-)'], derived['roa']).tolist()
+        r_interpolation = derived['roa']
             
         # ---------------------------------------------------------------------------------------------------------------------------------------
         # Prepare the inputs
@@ -3097,19 +3358,19 @@ class mitim_state:
         # Determine the mass reference
         mass_ref = 2.0
         
-        sign_it = int(-np.sign(self.profiles["current(MA)"][-1]))
-        sign_bt = int(-np.sign(self.profiles["bcentr(T)"][-1]))
+        sign_it = int(-np.sign(profiles["current(MA)"][-1]))
+        sign_bt = int(-np.sign(profiles["bcentr(T)"][-1]))
         
-        s_kappa  = self.derived["r"] / self.profiles["kappa(-)"] * self._deriv_gacode(self.profiles["kappa(-)"])
-        s_delta  = self.derived["r"]                             * self._deriv_gacode(self.profiles["delta(-)"])
-        s_zeta   = self.derived["r"]                             * self._deriv_gacode(self.profiles["zeta(-)"])
+        s_kappa  = derived["r"] / profiles["kappa(-)"] * self._deriv_gacode(profiles["kappa(-)"])
+        s_delta  = derived["r"]                             * self._deriv_gacode(profiles["delta(-)"])
+        s_zeta   = derived["r"]                             * self._deriv_gacode(profiles["zeta(-)"])
 
         # Rotations
-        cs = self.derived['c_s']
-        a = self.derived['a']
-        mach = self.profiles["w0(rad/s)"] * (self.derived['Rmajoa']*a)
-        gamma_p = -self._deriv_gacode(self.profiles["w0(rad/s)"]) * (self.derived['Rmajoa']*a)
-        gamma_e = -self._deriv_gacode(self.profiles["w0(rad/s)"]) * (self.profiles['rmin(m)'] / self.profiles['q(-)'])
+        cs = derived['c_s']
+        a = derived['a']
+        mach = profiles["w0(rad/s)"] * (derived['Rmajoa']*a)
+        gamma_p = -self._deriv_gacode(profiles["w0(rad/s)"]) * (derived['Rmajoa']*a)
+        gamma_e = -self._deriv_gacode(profiles["w0(rad/s)"]) * (profiles['rmin(m)'] / profiles['q(-)'])
 
         # CGYRO definition: 'MACH=',mach_loc/cs_loc
         mach = mach / cs
@@ -3121,9 +3382,9 @@ class mitim_state:
         gamma_e = gamma_e * a / cs
             
         # Because in MITIMstate I keep Bunit always positive, but CGYRO routines may need it negative? #TODO
-        sign_Bunit = np.sign(self.profiles['torfluxa(Wb/radian)'][0])
+        sign_Bunit = np.sign(profiles['torfluxa(Wb/radian)'][0])
             
-        self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', self.derived["a"], 1.0, mass_ref)
+        self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', derived["a"], 1.0, mass_ref)
             
         input_parameters = {}
         for roa, rho_label in zip(r, r_labels):
@@ -3151,18 +3412,18 @@ class mitim_state:
                 species[i+1] = {
                     'Z': self.Species[i]['Z'],
                     'MASS': self.Species[i]['A']/mass_ref,
-                    'DLNNDR': interpolator(self.derived['aLni'][:,i]),
-                    'DLNTDR': interpolator(self.derived["aLTi"][:,i]),
-                    'TEMP': interpolator(self.derived["tite_all"][:,i]),
-                    'DENS': interpolator(self.derived['fi'][:,i]),
+                    'DLNNDR': interpolator(derived['aLni'][:,i]),
+                    'DLNTDR': interpolator(derived["aLTi"][:,i]),
+                    'TEMP': interpolator(derived["tite_all"][:,i]),
+                    'DENS': interpolator(derived['fi'][:,i]),
                     }
 
             ie = i+2
             species[ie] = {
                     'Z': -1.0,
                     'MASS': 0.000272445,
-                    'DLNNDR': interpolator(self.derived['aLne']),
-                    'DLNTDR': interpolator(self.derived['aLTe']),
+                    'DLNNDR': interpolator(derived['aLne']),
+                    'DLNTDR': interpolator(derived['aLTe']),
                     'TEMP': 1.0,
                     'DENS': 1.0,
                 }
@@ -3180,9 +3441,9 @@ class mitim_state:
                 'MACH': interpolator(mach),
                 'GAMMA_E': interpolator(gamma_e),
                 'GAMMA_P': interpolator(gamma_p),
-                'NU_EE': interpolator(self.derived['xnue']),
-                'BETAE_UNIT': interpolator(self.derived['betae']),
-                'LAMBDA_STAR': interpolator(self.derived['debye']) * sign_Bunit,
+                'NU_EE': interpolator(derived['xnue']),
+                'BETAE_UNIT': interpolator(derived['betae']),
+                'LAMBDA_STAR': interpolator(derived['debye']) * sign_Bunit,
                 }
 
 
@@ -3191,23 +3452,23 @@ class mitim_state:
             # ---------------------------------------------------------------------------------------------------------------------------------------
 
             parameters = {
-                'RMIN':     self.derived['roa'],
-                'RMAJ':     self.derived['Rmajoa'],
-                'SHIFT':    self._deriv_gacode(self.profiles["rmaj(m)"]),
-                'ZMAG':     self.derived["Zmagoa"],
-                'DZMAG':    self._deriv_gacode(self.profiles["zmag(m)"]),
-                'Q':        np.abs(self.profiles["q(-)"]),
-                'S':        self.derived["s_hat"],
-                'KAPPA':    self.profiles["kappa(-)"],
+                'RMIN':     derived['roa'],
+                'RMAJ':     derived['Rmajoa'],
+                'SHIFT':    self._deriv_gacode(profiles["rmaj(m)"]),
+                'ZMAG':     derived["Zmagoa"],
+                'DZMAG':    self._deriv_gacode(profiles["zmag(m)"]),
+                'Q':        np.abs(profiles["q(-)"]),
+                'S':        derived["s_hat"],
+                'KAPPA':    profiles["kappa(-)"],
                 'S_KAPPA':  s_kappa,
-                'DELTA':    self.profiles["delta(-)"],
+                'DELTA':    profiles["delta(-)"],
                 'S_DELTA':  s_delta,
-                'ZETA':     self.profiles["zeta(-)"],
+                'ZETA':     profiles["zeta(-)"],
                 'S_ZETA':   s_zeta,
             }
             
             # Add MXH and derivatives
-            for ikey in self.profiles:
+            for ikey in profiles:
                 if 'shape_cos' in ikey or 'shape_sin' in ikey:
                     
                     # TGLF only accepts 6, as of July 2025
@@ -3216,8 +3477,8 @@ class mitim_state:
                     
                     key_mod = ikey.upper().split('(')[0]
                     
-                    parameters[key_mod] = self.profiles[ikey]
-                    parameters[f"{key_mod.split('_')[0]}_S_{key_mod.split('_')[-1]}"] = self.derived["r"] * self._deriv_gacode(self.profiles[ikey])
+                    parameters[key_mod] = profiles[ikey]
+                    parameters[f"{key_mod.split('_')[0]}_S_{key_mod.split('_')[-1]}"] = derived["r"] * self._deriv_gacode(profiles[ikey])
 
             for k in parameters:
                 par = torch.nan_to_num(torch.from_numpy(parameters[k]) if type(parameters[k]) is np.ndarray else parameters[k], nan=0.0, posinf=1E10, neginf=-1E10)
@@ -3242,11 +3503,14 @@ class mitim_state:
         # <> Function to interpolate a curve <>
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
+        profiles = self.get_profiles()
+        derived = self.get_derived()
+
         # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
         r_labels = r  # preserve original values for dict keys / filenames
         if r_is_rho:
-            r = interpolation_function(np.atleast_1d(r), self.profiles['rho(-)'], self.derived['roa']).tolist()
-        r_interpolation = self.derived['roa']
+            r = interpolation_function(np.atleast_1d(r), profiles['rho(-)'], derived['roa']).tolist()
+        r_interpolation = derived['roa']
             
         # ---------------------------------------------------------------------------------------------------------------------------------------
         # Prepare the inputs
@@ -3256,17 +3520,17 @@ class mitim_state:
         mass_ref = 2.0
 
         dpdr = self._calculate_pressure_gradient_from_aLx(
-            self.derived['pe'], self.derived['pi_all'][:,:],
-            self.derived['aLTe'], self.derived['aLTi'][:,:],
-            self.derived['aLne'], self.derived['aLni'][:,:],
-            self.derived['a']
+            derived['pe'], derived['pi_all'][:,:],
+            derived['aLTe'], derived['aLTi'][:,:],
+            derived['aLne'], derived['aLni'][:,:],
+            derived['a']
         )
-        betaprim = -(8*np.pi*1E-7) * self.derived['a'] / self.derived['B_unit']**2 * dpdr
+        betaprim = -(8*np.pi*1E-7) * derived['a'] / derived['B_unit']**2 * dpdr
         
-        s_kappa  = np.gradient(self.profiles['kappa(-)'], self.derived['roa'])
-        s_delta  = np.gradient(self.profiles['delta(-)'], self.derived['roa'])
+        s_kappa  = np.gradient(profiles['kappa(-)'], derived['roa'])
+        s_delta  = np.gradient(profiles['delta(-)'], derived['roa'])
 
-        self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', self.derived["a"], 1.0, mass_ref)
+        self._print_gb_normalizations('a', 'Z_D', 'A_D', 'n_e', 'T_e', 'B_unit', derived["a"], 1.0, mass_ref)
             
         input_parameters = {}
         for roa, rho_label in zip(r, r_labels):
@@ -3293,19 +3557,19 @@ class mitim_state:
             # Ions
             for i in range(len(self.Species)):
 
-                nu_ii = self.derived['xnue'] * \
-                    (self.Species[i]['Z']/self.profiles['ze'][0])**4 * \
-                        (self.profiles['ni(10^19/m^3)'][:,0]/self.profiles['ne(10^19/m^3)']) * \
-                            (self.profiles['mass'][i]/self.profiles['masse'][0])**-0.5 * \
-                                (self.profiles['ti(keV)'][:,0]/self.profiles['te(keV)'])**-1.5
+                nu_ii = derived['xnue'] * \
+                    (self.Species[i]['Z']/profiles['ze'][0])**4 * \
+                        (profiles['ni(10^19/m^3)'][:,0]/profiles['ne(10^19/m^3)']) * \
+                            (profiles['mass'][i]/profiles['masse'][0])**-0.5 * \
+                                (profiles['ti(keV)'][:,0]/profiles['te(keV)'])**-1.5
 
                 species[i+1] = {
                     'z': self.Species[i]['Z'],
                     'mass': self.Species[i]['A']/mass_ref,
-                    'temp': interpolator(self.derived["tite_all"][:,i]),
-                    'dens': interpolator(self.derived['fi'][:,i]),
-                    'fprim': interpolator(self.derived['aLni'][:,i]),
-                    'tprim': interpolator(self.derived["aLTi"][:,i]),
+                    'temp': interpolator(derived["tite_all"][:,i]),
+                    'dens': interpolator(derived['fi'][:,i]),
+                    'fprim': interpolator(derived['aLni'][:,i]),
+                    'tprim': interpolator(derived["aLTi"][:,i]),
                     'vnewk': interpolator(nu_ii),
                     'type': 'ion',
                     }
@@ -3317,9 +3581,9 @@ class mitim_state:
                     'mass': 0.000272445,
                     'temp': 1.0,
                     'dens': 1.0,
-                    'fprim': interpolator(self.derived['aLne']),
-                    'tprim': interpolator(self.derived['aLTe']),
-                    'vnewk': interpolator(self.derived['xnue']),
+                    'fprim': interpolator(derived['aLne']),
+                    'tprim': interpolator(derived['aLTe']),
+                    'vnewk': interpolator(derived['xnue']),
                     'type': 'electron'
                 }
 
@@ -3332,27 +3596,27 @@ class mitim_state:
             } 
 
             parameters = {
-                'beta':     self.derived['betae'],
+                'beta':     derived['betae'],
             }
             
             # Standard geometry specification
             if self.type == 'input.gacode':
                 parameters_geometry = {
-                    'rhoc':     self.derived['roa'],
-                    'Rmaj':     self.derived['Rmajoa'],
-                    'R_geo':    self.derived['Rmajoa'] / abs(self.derived['B_unit'] / self.derived['B0']),
-                    'shift':    self._deriv_gacode(self.profiles["rmaj(m)"]),
-                    'qinp':     np.abs(self.profiles["q(-)"]),
-                    'shat':     self.derived["s_hat"],
-                    'akappa':   self.profiles["kappa(-)"],
+                    'rhoc':     derived['roa'],
+                    'Rmaj':     derived['Rmajoa'],
+                    'R_geo':    derived['Rmajoa'] / abs(derived['B_unit'] / derived['B0']),
+                    'shift':    self._deriv_gacode(profiles["rmaj(m)"]),
+                    'qinp':     np.abs(profiles["q(-)"]),
+                    'shat':     derived["s_hat"],
+                    'akappa':   profiles["kappa(-)"],
                     'akappri':  s_kappa,
-                    'tri':      self.profiles["delta(-)"],
+                    'tri':      profiles["delta(-)"],
                     'tripri':   s_delta,
                     'betaprim': betaprim,
                 }
             elif self.type == 'vmec':
                 parameters_geometry = {
-                    'torflux': self.profiles['rho(-)']**2,
+                    'torflux': profiles['rho(-)']**2,
                 }
             
             params = parameters | parameters_geometry
@@ -3397,43 +3661,45 @@ class mitim_state:
         from mitim_tools.misc_tools.MATHtools import extrapolateCubicSpline as interpolation_function
 
         p = self
+        profiles = self.get_profiles()
+        derived = self.get_derived()
 
         # Always interpolate in r/a (rmin) space, matching GACODE's expro_locsim cub_spline
         r = np.atleast_1d(np.array(r, dtype=float))
         if r_is_rho:
             rhos = r
-            roa_targets = interpolation_function(rhos, p.profiles['rho(-)'], p.derived['roa'])
+            roa_targets = interpolation_function(rhos, profiles['rho(-)'], derived['roa'])
         else:
             roa_targets = r
-            rhos = interpolation_function(roa_targets, p.derived['roa'], p.profiles['rho(-)'])
-        r_interpolation = p.derived["roa"]
+            rhos = interpolation_function(roa_targets, derived['roa'], profiles['rho(-)'])
+        r_interpolation = derived["roa"]
 
         def interp_vec(y):
             return np.atleast_1d(interpolation_function(roa_targets, r_interpolation, y))
 
         n_ions = min(len(p.Species), max_ions)
 
-        sign_it = -np.sign(p.profiles["current(MA)"][-1])
+        sign_it = -np.sign(profiles["current(MA)"][-1])
 
         # QuaLiKiz normalises logarithmic gradients by major radius R (R/LT, R/Ln),
         # whereas MITIM's gacode convention uses minor radius a (a/LT, a/Ln).
         # Convert: R/L = (R/a) * (a/L), using the local Ro already interpolated above.
-        Ro_over_a = interp_vec(p.profiles["rmaj(m)"]) / p.derived["a"]
+        Ro_over_a = interp_vec(profiles["rmaj(m)"]) / derived["a"]
 
         cref = 3.094969e5  # defined in QuaLiKiz as sqrt(1 keV / proton_mass)
 
         # MHD alpha = -(2 mu0 R q^2 / B^2) dp/dr
         dpdr = p._calculate_pressure_gradient_from_aLx(
-            p.derived["pe"], p.derived["pi_all"][:, :n_ions],
-            p.derived["aLTe"], p.derived["aLTi"][:, :n_ions],
-            p.derived["aLne"], p.derived["aLni"][:, :n_ions],
-            p.derived["a"],
+            derived["pe"], derived["pi_all"][:, :n_ions],
+            derived["aLTe"], derived["aLTi"][:, :n_ions],
+            derived["aLne"], derived["aLni"][:, :n_ions],
+            derived["a"],
         )
         alpha_mhd = (
             2.0 * 4 * np.pi * 1e-7
-            * p.profiles["q(-)"] ** 2
-            * p.profiles["rmaj(m)"]
-            / np.abs(p.profiles["bcentr(T)"][-1]) ** 2
+            * profiles["q(-)"] ** 2
+            * profiles["rmaj(m)"]
+            / np.abs(profiles["bcentr(T)"][-1]) ** 2
             * dpdr
         )
         alpha_mhd[0] = 0.0
@@ -3442,26 +3708,26 @@ class mitim_state:
         # Machtor/Autor/Machpar/Aupar are NOT computed here -- only Machtor (a
         # best-effort R*Omega_tor/c_s) and gammaE are returned; QuaLiKizXpoint.set_puretor()
         # derives the rest assuming pure toroidal rotation.
-        gamma_eb0 = -p._deriv_gacode(p.profiles["w0(rad/s)"]) * p.derived["r"] / np.abs(p.profiles["q(-)"])
-        vexb_shear = -sign_it * gamma_eb0 * p.profiles["rmaj(m)"] / cref
-        vpar = -sign_it * p.profiles["rmaj(m)"] * p.profiles["w0(rad/s)"] / cref
+        gamma_eb0 = -p._deriv_gacode(profiles["w0(rad/s)"]) * derived["r"] / np.abs(profiles["q(-)"])
+        vexb_shear = -sign_it * gamma_eb0 * profiles["rmaj(m)"] / cref
+        vpar = -sign_it * profiles["rmaj(m)"] * profiles["w0(rad/s)"] / cref
 
         geometry_scan = {
             "x": roa_targets,
             "rho": rhos,
-            "Ro": interp_vec(p.profiles["rmaj(m)"]),
-            "q": np.abs(interp_vec(p.profiles["q(-)"])),
-            "smag": interp_vec(p.derived["s_hat"]),
+            "Ro": interp_vec(profiles["rmaj(m)"]),
+            "q": np.abs(interp_vec(profiles["q(-)"])),
+            "smag": interp_vec(derived["s_hat"]),
             "alpha": interp_vec(alpha_mhd),
             "Machtor": interp_vec(vpar),
             "gammaE": interp_vec(vexb_shear),
         }
 
         electron_scan = {
-            "Te": interp_vec(p.profiles["te(keV)"]),
-            "ne": interp_vec(p.profiles["ne(10^19/m^3)"]),
-            "Ate": interp_vec(p.derived["aLTe"]) * Ro_over_a,
-            "Ane": interp_vec(p.derived["aLne"]) * Ro_over_a,
+            "Te": interp_vec(profiles["te(keV)"]),
+            "ne": interp_vec(profiles["ne(10^19/m^3)"]),
+            "Ate": interp_vec(derived["aLTe"]) * Ro_over_a,
+            "Ane": interp_vec(derived["aLne"]) * Ro_over_a,
         }
 
         ion_scan = {}
@@ -3473,10 +3739,10 @@ class mitim_state:
                 "Z": p.Species[i]["Z"],
                 "type": 4 if is_fast else 1,
             })
-            ion_scan[f"Ti{i}"] = interp_vec(p.profiles["ti(keV)"][:, i])
-            ion_scan[f"ni{i}"] = interp_vec(p.derived["fi"][:, i])
-            ion_scan[f"Ati{i}"] = interp_vec(p.derived["aLTi"][:, i]) * Ro_over_a
-            ion_scan[f"Ani{i}"] = interp_vec(p.derived["aLni"][:, i]) * Ro_over_a
+            ion_scan[f"Ti{i}"] = interp_vec(profiles["ti(keV)"][:, i])
+            ion_scan[f"ni{i}"] = interp_vec(derived["fi"][:, i])
+            ion_scan[f"Ati{i}"] = interp_vec(derived["aLTi"][:, i]) * Ro_over_a
+            ion_scan[f"Ani{i}"] = interp_vec(derived["aLni"][:, i]) * Ro_over_a
 
         # Same "which ion absorbs quasineutrality" choice as the QuaLiKizXpoint
         # options QLKtools passes downstream (set_qn_normni/set_qn_An): highest-Z
@@ -3514,8 +3780,8 @@ class mitim_state:
             "ion_scan": ion_scan,
             "ion_species": ion_species,
             "qn_ion_index": qn_ion_index,
-            "a": float(p.derived["a"]),
-            "Bo": float(abs(p.profiles["bcentr(T)"][-1])),
+            "a": float(derived["a"]),
+            "Bo": float(abs(profiles["bcentr(T)"][-1])),
         }
 
     def to_transp(self, folder = '~/scratch/', shot = '12345', runid = 'P01', times = [0.0,1.0], Vsurf = 0.0, mxh_coeffs_smooth = 5, boundary_surface_psin = 1.0, boundary_override = None, equilibrium_mode = 'evolve'):
@@ -3535,20 +3801,23 @@ class mitim_state:
 
     def to_eped(self, ped_rho = 0.95, beta_pass = "BetaN_engineering"):
 
-        neped_19 = np.interp(ped_rho, self.profiles['rho(-)'], self.profiles['ne(10^19/m^3)'])
+        profiles = self.get_profiles()
+        derived = self.get_derived()
+
+        neped_19 = np.interp(ped_rho, profiles['rho(-)'], profiles['ne(10^19/m^3)'])
 
         eped_evaluation = {
-            'Ip': np.abs(self.profiles['current(MA)'][0]),
-            'Bt': np.abs(self.profiles['bcentr(T)'][0]),
-            'R': np.abs(self.profiles['rcentr(m)'][0]),
-            'a': np.abs(self.derived['a']),
-            'kappa995': np.abs(self.derived['kappa995']),
-            'delta995': np.abs(self.derived['delta995']),
+            'Ip': np.abs(profiles['current(MA)'][0]),
+            'Bt': np.abs(profiles['bcentr(T)'][0]),
+            'R': np.abs(profiles['rcentr(m)'][0]),
+            'a': np.abs(derived['a']),
+            'kappa995': np.abs(derived['kappa995']),
+            'delta995': np.abs(derived['delta995']),
             'neped': np.abs(neped_19),
-            'betan': np.abs(self.derived[beta_pass]),
-            'zeff': np.abs(self.derived['Zeff_vol']),
-            'tesep': np.abs(self.profiles['te(keV)'][-1])*1E3,
-            'nesep_ratio': np.abs(self.profiles['ne(10^19/m^3)'][-1] / neped_19),
+            'betan': np.abs(derived[beta_pass]),
+            'zeff': np.abs(derived['Zeff_vol']),
+            'tesep': np.abs(profiles['te(keV)'][-1])*1E3,
+            'nesep_ratio': np.abs(profiles['ne(10^19/m^3)'][-1] / neped_19),
         }
 
         return eped_evaluation

--- a/src/mitim_tools/plasmastate_tools/MITIMstate.py
+++ b/src/mitim_tools/plasmastate_tools/MITIMstate.py
@@ -1,6 +1,7 @@
 import copy
 import torch
 import csv
+from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 from mitim_tools.misc_tools import GRAPHICStools, MATHtools, PLASMAtools, IOtools
@@ -11,6 +12,8 @@ from mitim_tools.plasmastate_tools.utils.derived_field_map import DERIVED_FIELD_
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools import __version__
 from fusio.classes.io import io
+from fusio.classes.gacode import gacode_io
+from fusio.classes.plasma import plasma_io
 from IPython import embed
 
 from mitim_tools.misc_tools.PLASMAtools import md_u
@@ -92,6 +95,44 @@ def ensure_variables_existence(self):
             self.profiles[key] = copy.deepcopy(self.profiles[template_key_1d]) * 0.0 if dim == 1 else np.atleast_2d(copy.deepcopy(self.profiles[template_key_1d]) * 0.0).T
 
 
+def _ensure_plasma_io_deepcopy(obj):
+    """
+    Establishes fusio's .input side as MITIM/PORTALS' canonical, untouched starting-state
+    snapshot and .output as an independent deep-copied working copy -- the rest of PORTALS
+    then reads from and overwrites only .output as BO iterations progress
+    (get_profiles()/get_derived() default to side="output" throughout). io.py's input/output
+    getters and setters already deep-copy on both read and write, so `obj.output = obj.input`
+    below is a true independent copy, not an alias.
+
+    Idempotent/safe to call more than once on the same object -- once both sides are
+    populated, this is a no-op. This matters because callers (e.g. PORTALSinit.py's
+    initializeProblem()) can call this at several points that all see the same object -- an
+    unconditional `obj.output = obj.input` would silently clobber .output's already-
+    preprocessed state (post remove_fast_ions()/compute_derived_quantities(), which run on
+    .output right after the first call) with the stale, unprocessed .input snapshot on the
+    second call. Must still run exactly once as the very first *effective* operation on any
+    plasma_io/gacode_io object MITIM receives -- NOT inside mitim_state.scratch(), which is
+    called repeatedly throughout a run (every transport evaluation) and, unlike this
+    idempotent guard, has no way to distinguish "fresh object" from "object with real
+    accumulated BO progress on .output".
+
+    If the object arrives with only .output populated (e.g. a caller-constructed object
+    that ran its own preprocessing directly on .output), .input is backfilled from it first
+    so a reference snapshot still exists. This is deliberately a backfill, not a hard
+    requirement that callers populate .input themselves, so existing scripts' own
+    loading/preprocessing conventions don't need to change.
+    """
+    if not obj.has_input:
+        if not obj.has_output:
+            raise ValueError(
+                f"{type(obj).__name__} object has neither .input nor .output populated -- "
+                "cannot establish a starting state for MITIM/PORTALS."
+            )
+        obj.input = obj.output
+    if not obj.has_output:
+        obj.output = obj.input
+
+
 '''
 The mitim_state class is the base class for manipulating plasma states in MITIM.
 Any class that inherits from this class should implement the methods:
@@ -106,50 +147,85 @@ Any class that inherits from this class should implement the methods:
 
 '''
 
-class mitim_state:
+class mitim_state(plasma_io):
     '''
     Class to manipulate the plasma state in MITIM.
     '''
 
-    # Class-level fallback for the plasma_io property's backing attribute. Instances
-    # constructed via __init__() always shadow this with their own instance-level
-    # _plasma_io (set through the property setter below). But unpickling an object
-    # pickled by code *older* than this property (e.g. a pre-2026-08-13 run) restores
-    # __dict__ directly, bypassing __init__ entirely -- such an instance never had
-    # _plasma_io in its pickled state, so without this class default, the property
-    # getter's `return self._plasma_io` raises AttributeError on first access
-    # (surfaced e.g. via get_profiles()/get_derived() on any old, legacy-pickled run).
-    _plasma_io = None
-
     def __init__(self, type_file = 'input.gacode'):
-
+        super().__init__()          # -> plasma_io.__init__ -> io.__init__, sets self._tree
         self.type = type_file
-
-        # Populated when this state is constructed from a fusio plasma_io object
-        # (see scratch()); kept around so downstream code can eventually source
-        # data from it directly instead of only from the flattened profiles dict.
-        self.plasma_io = None
+        self._profiles_cache = None
+        self._profiles_cache_side = None
+        self._derived_cache = None
+        self._derived_cache_side = None
 
     @property
-    def plasma_io(self):
-        return self._plasma_io
+    def format(self):
+        # io.format derives the format string from the class name minus a "_io"
+        # suffix -- mitim_state/gacode_state don't end in "_io", so without this
+        # override self.format would resolve to the wrong string and break
+        # self.to("gacode", ...)'s dispatch (gacode_io.from_plasma lookup) and
+        # dump()/load() roundtrips.
+        return 'plasma'
 
-    @plasma_io.setter
-    def plasma_io(self, value):
-        # Assigning a new plasma_io object (construction, or a live-update reassignment like
-        # TRANSFORMtools.sync_plasma_io()'s self.profiles.plasma_io = powerstate_to_plasma_io(...))
-        # invalidates both lazy caches below -- they were derived from whichever plasma_io object
-        # was assigned before, so leaving them in place would make every subsequent
-        # get_profiles()/get_derived() call keep returning data from the *old* object. This is
-        # what makes plasma_io reassignment a sufficient way to keep get_profiles()/get_derived()
-        # current on its own, with no caller needing to separately remember to invalidate anything.
-        #
-        # Does NOT cover mutating the *contents* of an already-cached get_profiles() dict in place
-        # (get_profiles()'s own docstring documents that as deliberately supported, e.g.
-        # TRANSFORMtools.powerstate_to_gacode()'s slice assignment) -- that path doesn't reassign
-        # .plasma_io at all, so it still needs its own explicit invalidate_derived_cache() call;
-        # see that method's docstring.
-        self._plasma_io = value
+    def autoformat(self):
+        self._tree.attrs['class'] = self.format
+
+    def __setstate__(self, state):
+        # Default unpickling bypasses __init__ entirely, so any object pickled before this
+        # class inherited from plasma_io has no _tree in its restored __dict__ -- the first
+        # touch of has_output/.output/.to() etc. would raise AttributeError without this
+        # fallback. Two distinct pre-refactor eras land here:
+        #   1. Deep-legacy pickles (pure dict-backed, no plasma_io involvement at all): no
+        #      _plasma_io either -- just .profiles/.derived dicts. Giving them a real but
+        #      empty _tree is sufficient; has_output correctly reads False and .profiles is
+        #      still there, untouched.
+        #   2. Intermediate-era pickles (the short-lived composed self.plasma_io property
+        #      design that predated this inheritance-based refactor): their real fusio data
+        #      lives on the now-orphaned self._plasma_io backing attribute, NOT in
+        #      .profiles/.derived (that design's scratch() never populated those for
+        #      plasma_io-backed instances) -- without migrating it, has_output would read
+        #      False (empty _tree) while .profiles also doesn't exist, so any accessor call
+        #      falls through to a nonexistent .profiles and raises AttributeError anyway.
+        self.__dict__.update(state)
+        if '_tree' not in self.__dict__:
+            old_plasma_io = self.__dict__.pop('_plasma_io', None)
+            io.__init__(self)
+            if old_plasma_io is not None:
+                if old_plasma_io.has_input:
+                    self.input = old_plasma_io.input
+                if old_plasma_io.has_output:
+                    self.output = old_plasma_io.output
+
+    # io.input/io.output are plain data properties with no notion of the caches below --
+    # neither io nor plasma_io override them. Reassigning either side (e.g.
+    # TRANSFORMtools.sync_plasma_io()'s self.profiles.output = powerstate_to_plasma_io(...).output)
+    # must invalidate both get_profiles()/get_derived()'s lazy caches, exactly as the old composed
+    # `plasma_io` property's setter used to when this class had a separate `self.plasma_io`
+    # sub-object instead of being one itself -- without this, get_profiles()/get_derived() keep
+    # silently returning whatever was cached before the reassignment forever (the same class of
+    # live bug invalidate_derived_cache()'s docstring describes for in-place profiles-dict
+    # mutation, but for whole-side reassignment instead).
+    @property
+    def input(self):
+        return super().input
+
+    @input.setter
+    def input(self, data):
+        io.input.fset(self, data)
+        self._profiles_cache = None
+        self._profiles_cache_side = None
+        self._derived_cache = None
+        self._derived_cache_side = None
+
+    @property
+    def output(self):
+        return super().output
+
+    @output.setter
+    def output(self, data):
+        io.output.fset(self, data)
         self._profiles_cache = None
         self._profiles_cache_side = None
         self._derived_cache = None
@@ -159,6 +235,28 @@ class mitim_state:
     def scratch(cls, profiles, label_header='', **kwargs_process):
         # Method to write a scratch file
 
+        # `profiles` may be given as a raw .gacode/.nc filename -- route it through
+        # fusio's conversion pipeline directly (the exact per-suffix preprocessing
+        # PORTALSinit.py used to do itself), then recurse into the fusio-object
+        # branch below to adopt the result. Preserves the use_main_ion=True vs.
+        # omitted distinction so already-validated Ricci-metric/residual numbers
+        # don't shift.
+        if isinstance(profiles, (str, Path)):
+            path = Path(profiles)
+            if path.suffix == ".gacode":
+                src = gacode_io.from_file(path).to("plasma")
+                _ensure_plasma_io_deepcopy(src)
+                src.remove_fast_ions(enforce_quasineutrality=True, use_main_ion=True, side='output')
+                src.compute_derived_quantities(side='output')
+            elif path.suffix == ".nc":
+                src = plasma_io.from_file(input=path)
+                _ensure_plasma_io_deepcopy(src)
+                src.remove_fast_ions(enforce_quasineutrality=True, side='output')
+                src.compute_derived_quantities(side='output')
+            else:
+                raise ValueError(f"scratch(): unrecognized suffix for fusio-routed load: {path}")
+            return cls.scratch(src, label_header=label_header, **kwargs_process)
+
         instance = cls(None)
 
         # Header
@@ -167,21 +265,54 @@ class mitim_state:
 #  {label_header}
 #
 '''
-        # `profiles` may be given as a fusio object (e.g. plasma_io) instead of
-        # an already-flattened dict. In that case, keep a handle on the source
-        # object; `.profiles`/`.derived` are NOT populated as stored attributes
-        # for this branch -- consumers must call get_profiles()/get_derived(),
-        # which lazily source from `instance.plasma_io` on first access. See
-        # test/fusio_integration/plasma_io_migration_plan.md, "New phase
-        # (2026-08-12)". Species bookkeeping (readSpecies()/DTplasma()/
-        # sumFast(), the cheap prefix of derive_quantities_base()) is still
-        # done eagerly here -- plasma_io_to_powerstate()/defineIonsFromPlasmaIO()
-        # already depend on the resulting self.Species/self.mi_first/self.Dion/
-        # self.Tion instance attributes directly, and these calls are cheap
-        # (get_profiles()-backed dict lookups, not the expensive MXH-geometry
-        # derived-quantity pipeline that get_derived() defers).
+        # `profiles` may be given as an already-built fusio object (plasma_io/
+        # gacode_io, bare or already a mitim_state) instead of an already-flattened
+        # dict. Adopt its data onto this instance's own inherited tree via the
+        # .input/.output setters (a deep copy, not the old aliasing
+        # `instance.plasma_io = profiles`). Species bookkeeping (readSpecies()/
+        # DTplasma()/sumFast(), the cheap prefix of derive_quantities_base()) is
+        # still done eagerly here -- plasma_io_to_powerstate()/
+        # defineIonsFromPlasmaIO() already depend on the resulting
+        # self.Species/self.mi_first/self.Dion/self.Tion instance attributes
+        # directly, and these calls are cheap (get_profiles()-backed dict lookups,
+        # not the expensive MXH-geometry derived-quantity pipeline that
+        # get_derived() defers).
         if isinstance(profiles, io):
-            instance.plasma_io = profiles
+            if profiles.format == 'plasma':
+                src = profiles
+            else:
+                # fusio's `.to(fmt)` reads a single side of the source (side="output" by
+                # default) and always writes the conversion result onto the *new* object's
+                # .input -- calling it once would silently drop whichever side isn't the
+                # default, even though bare non-plasma-format objects (e.g. gacode_io) are
+                # a documented input to this branch. Convert each populated side
+                # independently and reassemble both onto one plasma_io.
+                src = plasma_io()
+                if profiles.has_input:
+                    src.input = profiles.to('plasma', side='input').input
+                if profiles.has_output:
+                    src.output = profiles.to('plasma', side='output').input
+            # Copy whichever side(s) `src` has onto `instance` first (via the deep-copying
+            # .input/.output setters -- never aliases `profiles`/`src`), THEN backfill any side
+            # `instance` still lacks by calling _ensure_plasma_io_deepcopy() on `instance`
+            # itself, not on `src`. `src` is `profiles` verbatim whenever no format conversion
+            # was needed (the `if profiles.format == 'plasma'` branch above) -- backfilling
+            # directly on `src` in that case would silently mutate the CALLER's own object (e.g.
+            # a bare, .output-only plasma_io the caller still holds a reference to) as a side
+            # effect of what's supposed to be a copy-only operation. Backfilling on `instance`
+            # instead gives the same guarantee (every downstream accessor below defaults to
+            # side="output", so a source with only .input populated would otherwise leave
+            # `instance` with has_output=False and no legacy `.profiles` dict to fall back on)
+            # with no risk of touching the caller's object. _ensure_plasma_io_deepcopy() only
+            # backfills a side that's genuinely empty -- it never touches a side that already has
+            # data, so this can't clobber independently-evolved .output content either (e.g. the
+            # post-remove_fast_ions/compute_derived_quantities state the filename branch above
+            # already established before recursing here).
+            if src.has_input:
+                instance.input = src.input
+            if src.has_output:
+                instance.output = src.output
+            _ensure_plasma_io_deepcopy(instance)
             instance.readSpecies()
             instance.mi_first = instance.Species[0]["A"]
             instance.DTplasma()
@@ -199,8 +330,8 @@ class mitim_state:
         """
         Dict-of-arrays view of the profile data, keyed/unit-suffixed exactly
         like the legacy `.profiles` attribute (e.g. "te(keV)"). For
-        plasma_io-backed instances (`self.plasma_io is not None`), this is
-        lazily materialized from `plasma_io.to("gacode", side=...).to_dict(side="input")`
+        plasma_io-backed instances (`self.has_output`), this is lazily
+        materialized from `self.to("gacode", side=...).to_dict(side="input")`
         (the same conversion `scratch()` used to make eagerly) and cached
         privately per-instance -- NOT re-derived on every call, since some
         callers perform in-place mutation on the returned arrays (e.g.
@@ -208,21 +339,21 @@ class mitim_state:
         that mutation to be visible on subsequent access. For legacy,
         dict-backed instances, just returns `.profiles` unchanged.
 
-        `side` selects which side of `self.plasma_io` (the source object) to
-        read -- NOT which side of the resulting dict (fusio's `.to(fmt)`
-        conversion always lands its output on the target's `.input`, per
-        `io.py`'s convention, so `to_dict(side="input")` is fixed regardless
-        of this parameter). Defaults to "output", matching the convention
-        established throughout PORTALS' plasma_io construction paths (both
-        the `.gacode` and `.nc` branches leave the live data on `.output` by
-        the time `scratch()` receives the object -- see
-        `PORTALS_workflow.py`), and matching what the original eager
-        `scratch()` code did implicitly (it never passed `side` to `.to()`,
-        so fusio's own `_from()` default of `side='output'` applied).
+        `side` selects which side of `self`'s own inherited fusio tree (the
+        source data) to read -- NOT which side of the resulting dict (fusio's
+        `.to(fmt)` conversion always lands its output on the target's
+        `.input`, per `io.py`'s convention, so `to_dict(side="input")` is
+        fixed regardless of this parameter). Defaults to "output", matching
+        the convention established throughout PORTALS' plasma_io construction
+        paths (both the `.gacode` and `.nc` branches leave the live data on
+        `.output` -- see `PORTALS_workflow.py`), and matching what the
+        original eager `scratch()` code did implicitly (it never passed
+        `side` to `.to()`, so fusio's own `_from()` default of `side='output'`
+        applied).
         """
-        if self.plasma_io is not None:
+        if self.has_output:
             if getattr(self, "_profiles_cache", None) is None or self._profiles_cache_side != side:
-                cache = self.plasma_io.to("gacode", side=side).to_dict(side="input")
+                cache = self.to("gacode", side=side).to_dict(side="input")
                 # gacode_io.from_plasma() (the .to("gacode") conversion) does not populate
                 # shape_cosN(-)/shape_sinN(-) (MXH shape coefficients) -- unlike plasma_io, fusio
                 # has no method that derives them from a plasma_io object's own mxh_cos/mxh_sin
@@ -252,19 +383,20 @@ class mitim_state:
     def get_derived(self, side="output"):
         """
         Dict of derived quantities, keyed exactly like the legacy `.derived`
-        attribute (e.g. "aLTe", "Q", "Pfus"). For plasma_io-backed instances,
-        lazily computed and cached privately per-instance on first access
-        (never on every call -- `plasma_io.compute_derived_quantities()` is
-        expensive, and nothing in PORTALS' BO sub-iteration hot path reads
+        attribute (e.g. "aLTe", "Q", "Pfus"). For plasma_io-backed instances
+        (`self.has_output`), lazily computed and cached privately per-instance
+        on first access (never on every call -- `compute_derived_quantities()`
+        is expensive, and nothing in PORTALS' BO sub-iteration hot path reads
         `.derived` except `ptot_manual`, which is handled separately by
         `selfconsistentPTOT()` without going through this cache at all -- see
         the migration plan doc). For legacy, dict-backed instances, just
         returns `.derived` unchanged.
 
-        `side` selects which side of `self.plasma_io` to read/compute on;
-        default "output" for the same reason as `get_profiles()`.
+        `side` selects which side of `self`'s own inherited fusio tree to
+        read/compute on; default "output" for the same reason as
+        `get_profiles()`.
         """
-        if self.plasma_io is not None:
+        if self.has_output:
             if getattr(self, "_derived_cache", None) is None or self._derived_cache_side != side:
                 self._derived_cache = self._compute_derived_from_plasma_io(side=side)
                 self._derived_cache_side = side
@@ -272,7 +404,8 @@ class mitim_state:
         # Legacy dict-backed instances: self-heal if .derived is missing/empty. This happens for
         # any unpickled powerstate whose profiles were saved via PORTALSmain._dropped_derived()
         # (stripped to {} to shrink the pickle) -- plasma_io-backed instances self-heal for free
-        # above since they always recompute from self.plasma_io regardless of what's cached, but
+        # above since they always recompute from self's own inherited tree regardless of what's
+        # cached, but
         # a legacy instance has no such fallback source, so it must rebuild via derive_quantities()
         # once here instead of raising a KeyError on every derived-quantity read downstream (e.g.
         # PORTALSanalysis.prep_metrics()'s Q/Pfus/tauE reads).
@@ -302,7 +435,7 @@ class mitim_state:
         cache, regardless of what X the BO optimizer actually proposed on later iterations. See
         test/fusio_integration/plasma_io_migration_plan.md.
         """
-        if self.plasma_io is not None:
+        if self.has_output:
             self._derived_cache = None
             self._derived_cache_side = None
 
@@ -315,13 +448,13 @@ class mitim_state:
         # geometry_factors_from_native()'s docstring).
         #
         # native/geometry_prepop are read here (not inside derive_quantities()) deliberately
-        # without calling self.plasma_io.compute_derived_quantities() first: that's an
-        # expensive six-stage call, and forcing it on every get_derived() cache miss (i.e.
-        # every BO evaluation, per invalidate_derived_cache()) would be a real cost regression
-        # over just falling back to calculateGeometricFactors() for this call. Whenever
-        # self.plasma_io already has fresh derived quantities (e.g. after
+        # without calling self.compute_derived_quantities() first: that's an expensive
+        # six-stage call, and forcing it on every get_derived() cache miss (i.e. every BO
+        # evaluation, per invalidate_derived_cache()) would be a real cost regression over
+        # just falling back to calculateGeometricFactors() for this call. Whenever self
+        # already has fresh derived quantities on its own tree (e.g. after
         # sync_plasma_io()/powerstate_to_plasma_io()), this is free.
-        native = self.plasma_io.to_dict(side=side)
+        native = self.to_dict(side=side)
         geometry_prepop = geometry_factors_from_native(native)
 
         # Shadow construction is replicated manually here (rather than calling scratch()
@@ -2216,7 +2349,7 @@ class mitim_state:
             # For plasma_io-backed instances, .derived is no longer stored -- skip the
             # (expensive, dict-based) recompute; selfconsistentPTOT() sources ptot_manual via
             # its own cheap, get_profiles()-based local calculation regardless.
-            if getattr(self, "plasma_io", None) is None:
+            if not self.has_output:
                 self.derive_quantities(rederiveGeometry=False)
             self.selfconsistentPTOT()
 
@@ -2236,7 +2369,7 @@ class mitim_state:
 
         # For plasma_io-backed instances .derived is sourced lazily via get_derived() instead
         # of eagerly stored -- nothing here needs it recomputed as a post-condition.
-        if getattr(self, "plasma_io", None) is None:
+        if not self.has_output:
             self.derive_quantities(rederiveGeometry=False)
 
         # ----------------------------------------------------------------------

--- a/src/mitim_tools/plasmastate_tools/MITIMstate.py
+++ b/src/mitim_tools/plasmastate_tools/MITIMstate.py
@@ -9,6 +9,7 @@ from mitim_tools.gacode_tools.utils import GACODEdefaults
 from mitim_tools.plasmastate_tools.utils import state_plotting
 from mitim_tools.misc_tools.LOGtools import printMsg as print
 from mitim_tools import __version__
+from fusio.classes.io import io
 from IPython import embed
 
 from mitim_tools.misc_tools.PLASMAtools import md_u
@@ -113,18 +114,31 @@ class mitim_state:
 
         self.type = type_file
 
+        # Populated when this state is constructed from a fusio plasma_io object
+        # (see scratch()); kept around so downstream code can eventually source
+        # data from it directly instead of only from the flattened profiles dict.
+        self.plasma_io = None
+
     @classmethod
     def scratch(cls, profiles, label_header='', **kwargs_process):
         # Method to write a scratch file
-        
+
         instance = cls(None)
 
         # Header
         instance.header = f'''
 #  Created from scratch with MITIM version {__version__}
-#  {label_header}                                                       
+#  {label_header}
 #
 '''
+        # `profiles` may be given as a fusio object (e.g. plasma_io) instead of
+        # an already-flattened dict. In that case, keep a handle on the source
+        # object and derive the "name(unit)"-keyed dict from its gacode
+        # conversion, the same way MITIM's file-based readers do.
+        if isinstance(profiles, io):
+            instance.plasma_io = profiles
+            profiles = profiles.to("gacode").to_dict(side="input")
+
         # Add data to profiles
         instance.profiles = profiles
 

--- a/src/mitim_tools/plasmastate_tools/MITIMstate.py
+++ b/src/mitim_tools/plasmastate_tools/MITIMstate.py
@@ -206,7 +206,11 @@ class mitim_state:
                 if i in self.titles_single:
                     listWrite = self.profiles[i]
 
-                    if IOtools.isnum(listWrite[0]):
+                    if i in ["nexp", "nion", "shot"] and IOtools.isnum(listWrite[0]):
+                        # Integer fields per the GACODE format; they may live as floats
+                        # internally (e.g. read cast or fusio-built dicts)
+                        f.write(f"{int(round(float(listWrite[0])))}\n")
+                    elif IOtools.isnum(listWrite[0]):
                         listWrite = [f"{i:.7e}".rjust(14) for i in listWrite]
                         f.write(f"{''.join(listWrite)}\n")
                     else:

--- a/src/mitim_tools/plasmastate_tools/utils/derived_field_map.py
+++ b/src/mitim_tools/plasmastate_tools/utils/derived_field_map.py
@@ -1,0 +1,125 @@
+"""
+Registry mapping MITIM `.derived` keys to fusio `plasma_io`'s own native
+derived-quantity field names, for plasma_io-backed `mitim_state` instances.
+
+Populated incrementally, one validated entry at a time (see
+`test/fusio_integration/plasma_io_migration_plan.md`, "New phase
+(2026-08-12)"), only for keys actually consumed by an in-scope PORTALS file.
+A key with no entry here simply falls back to `mitim_state`'s own
+`derive_quantities_full` computation (via `get_derived()`'s shadow-object
+bootstrap) -- unmapped is the safe default, not an error.
+
+No entry is added without first parity-testing it against
+`derive_quantities_full`'s existing value for that key (reusing the
+tolerance conventions already established in `test/fusio_integration/`).
+Keys with a known, unresolved discrepancy (e.g. `aLni`, see the migration
+plan doc) are deliberately kept out of this map rather than mapped anyway.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class FieldMapping:
+    plasma_io_key: str
+    factor: float = 1.0
+    transform: Optional[Callable[[Any], Any]] = None
+
+    def apply(self, native: Mapping[str, Any]) -> Any:
+        value = native[self.plasma_io_key]
+        if self.transform is not None:
+            return self.transform(value)
+        return value * self.factor
+
+
+# {mitim_derived_key: FieldMapping}. Empty until Phase 3 of the
+# self.profiles/self.derived removal work validates and adds entries
+# module-by-module.
+DERIVED_FIELD_MAP: dict[str, FieldMapping] = {}
+
+
+# Native plasma_io fields required to compute geometry_factors_from_native()'s six outputs.
+_GEOMETRY_FACTOR_NATIVE_KEYS = ('dvolume_dr', 'surface_area', 'mxh_field_inner', 'field_squared', 'field_unit')
+
+
+def geometry_factors_from_native(native: Mapping[str, Any]) -> Optional[Mapping[str, Any]]:
+    """
+    Pre-population values for the six quantities PROFILEStools.gacode_state.derive_geometry()
+    would otherwise get from calculateGeometricFactors() (volp_geo, surf_geo, gradr_geo,
+    bp2_geo, bt2_geo, bt_geo), sourced from plasma_io's own native derived-quantity fields
+    instead. Consumed by MITIMstate._compute_derived_from_plasma_io(), which stashes the
+    result on a throwaway shadow instance's `_geometry_factor_prepop` attribute --
+    derive_geometry() uses it instead of calling calculateGeometricFactors() when present,
+    leaving everything else in that method (flux-surface reconstruction, kappa95/delta95/etc,
+    B_ref) untouched.
+
+    Returns None if any required native key is missing from `native` (e.g.
+    plasma_io.compute_derived_quantities() hasn't been run on the source object yet) -- the
+    caller falls back to the unmodified calculateGeometricFactors()-based computation in that
+    case, matching this module's "unmapped is the safe default, not an error" convention.
+
+    Why this exists: calculateGeometricFactors() operates on shape_cosN(-)/shape_sinN(-),
+    which get_profiles() zero-fills whenever gacode_io.from_plasma() doesn't populate them
+    from the source plasma_io object's own mxh_cos/mxh_sin fields. For a genuinely-shaped
+    equilibrium this isn't just noise at the r/a=1 boundary -- it silently computes geometry
+    for a zero-shape (circular/Miller-only) approximation across the *whole* profile (see
+    test/fusio_integration/plasma_io_migration_plan.md, "mitim_plot_portals CLI check" entry,
+    2026-08-13). Sourcing these six quantities from plasma_io's own native fields instead
+    sidesteps that entirely, and does not depend on gacode_io.from_plasma()'s shape-coefficient
+    extraction (separately found to be flaky/non-deterministic, not chased further -- same
+    entry) at all.
+
+    Mappings (all indexed on plasma_io's native grid, which get_profiles() confirmed is
+    identical, point for point, to the grid derive_geometry() stores these under):
+      - volp_geo <- dvolume_dr directly: both are dV/dr in m^2 on the same r_minor grid.
+      - surf_geo <- surface_area directly: both are actual flux-surface area in m^2.
+      - gradr_geo <- surf_geo / volp_geo, using derive_geometry()'s own documented relation
+        ("Surf = V' <|grad r|>, Surf_GACODE = V'") -- self-consistent by construction, not an
+        independent native lookup.
+      - bt_geo <- mxh_field_inner's toroidal component (direction index 0), matching the
+        already-validated B_ref = field_unit * mxh_field_inner[:, 0] convention established
+        for TRANSFORMtools.plasma_io_to_powerstate() (see the migration plan's 2026-08-07
+        entries) -- derive_geometry()'s own `B_ref = B_unit * bt_geo` line then reproduces
+        that exact, already-validated B_ref automatically.
+      - bp2_geo / bt2_geo <- field_squared's poloidal/toroidal components (direction indices
+        1/0), divided by field_unit**2 to match calculateGeometricFactors()'s B_unit-normalized
+        convention (derive_quantities_full()'s `bp2_exp = bp2_geo * B_unit**2`).
+    """
+    if not all(k in native for k in _GEOMETRY_FACTOR_NATIVE_KEYS):
+        return None
+
+    dvolume_dr = native['dvolume_dr']
+    surface_area = native['surface_area']
+    field_unit_sq = native['field_unit'] ** 2
+
+    # Defensive: a handful of fusio's own geometry fields carry known, already-documented
+    # edge-case NaN/inf potential (e.g. dvolume_dr's r_minor=0 floor exists precisely because
+    # the raw finite-difference can misbehave there). A *large* non-finite fraction, though,
+    # means the source data itself is unreliable for this object (confirmed: the stale,
+    # pre-2026-08-07-fix arc_v3a_refined_plasma.nc/_v2/_v3 fixtures show ~97-98% NaN in
+    # surface_area when recomputed against current code) -- silently zero-filling that much of
+    # the array would produce worse volume integrals than just falling back to
+    # calculateGeometricFactors(), so bail out to the safe default (None) instead.
+    _max_nonfinite_fraction = 0.05
+    _checks = (dvolume_dr, surface_area, native['mxh_field_inner'], native['field_squared'])
+    if any(np.mean(~np.isfinite(arr)) > _max_nonfinite_fraction for arr in _checks):
+        return None
+
+    volp_geo = np.nan_to_num(dvolume_dr)
+    surf_geo = np.nan_to_num(surface_area)
+    gradr_geo = np.divide(surf_geo, volp_geo, out=np.zeros_like(surf_geo, dtype=float), where=(volp_geo != 0))
+    bt_geo = np.nan_to_num(native['mxh_field_inner'][:, 0])
+    bt2_geo = np.nan_to_num(native['field_squared'][:, 0] / field_unit_sq)
+    bp2_geo = np.nan_to_num(native['field_squared'][:, 1] / field_unit_sq)
+
+    return {
+        'volp_geo': volp_geo,
+        'surf_geo': surf_geo,
+        'gradr_geo': gradr_geo,
+        'bt_geo': bt_geo,
+        'bp2_geo': bp2_geo,
+        'bt2_geo': bt2_geo,
+    }

--- a/src/mitim_tools/plasmastate_tools/utils/state_plotting.py
+++ b/src/mitim_tools/plasmastate_tools/utils/state_plotting.py
@@ -114,19 +114,19 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
     
     [ax00, ax10, ax20, ax01, ax11, ax21, ax02, ax12, ax22] = axs1
     
-    rho = self.profiles["rho(-)"]
+    rho = self.get_profiles()["rho(-)"]
 
     lines = GRAPHICStools.listLS()
 
     ax=ax00
-    var = self.profiles["te(keV)"]
+    var = self.get_profiles()["te(keV)"]
     varL = "$T_e$ , $T_i$ (keV)"
     if legYN:
         lab = extralab + "e"
     else:
         lab = ""
     ax.plot(rho, var, lw=lw, ls="-", label=lab, c=color)
-    var = self.profiles["ti(keV)"][:, 0]
+    var = self.get_profiles()["ti(keV)"][:, 0]
     if legYN:
         lab = extralab + "i"
     else:
@@ -142,7 +142,7 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
 
 
     ax=ax01
-    var = self.profiles["ne(10^19/m^3)"] * 1e-1
+    var = self.get_profiles()["ne(10^19/m^3)"] * 1e-1
     varL = "$n_e$ ($10^{20}/m^3$)"
     if legYN:
         lab = extralab + "e"
@@ -161,14 +161,14 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
     cont = 0
     for i in range(len(self.Species)):
         if self.Species[i]["S"] == "therm":
-            var = self.profiles["ti(keV)"][:, i]
+            var = self.get_profiles()["ti(keV)"][:, i]
             ax.plot(
                 rho,
                 var,
                 lw=lw,
                 ls=lines[cont],
                 c=color,
-                label=extralab + f"{i + 1} = {self.profiles['name'][i]}",
+                label=extralab + f"{i + 1} = {self.get_profiles()['name'][i]}",
             )
             cont += 1
     varL = "Thermal $T_i$ (keV)"
@@ -186,20 +186,20 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
     cont = 0
     for i in range(len(self.Species)):
         if self.Species[i]["S"] == "fast":
-            var = self.profiles["ti(keV)"][:, i]
+            var = self.get_profiles()["ti(keV)"][:, i]
             ax.plot(
                 rho,
                 var,
                 lw=lw,
                 ls=lines[cont],
                 c=color,
-                label=extralab + f"{i + 1} = {self.profiles['name'][i]}",
+                label=extralab + f"{i + 1} = {self.get_profiles()['name'][i]}",
             )
             cont += 1
     varL = "Fast $T_i$ (keV)"
     ax.plot(
         rho,
-        self.profiles["ti(keV)"][:, 0],
+        self.get_profiles()["ti(keV)"][:, 0],
         lw=0.5,
         ls="-",
         alpha=0.5,
@@ -220,14 +220,14 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
     cont = 0
     for i in range(len(self.Species)):
         if self.Species[i]["S"] == "therm":
-            var = self.profiles["ni(10^19/m^3)"][:, i] * 1e-1
+            var = self.get_profiles()["ni(10^19/m^3)"][:, i] * 1e-1
             ax.plot(
                 rho,
                 var,
                 lw=lw,
                 ls=lines[cont],
                 c=color,
-                label=extralab + f"{i + 1} = {self.profiles['name'][i]}",
+                label=extralab + f"{i + 1} = {self.get_profiles()['name'][i]}",
             )
             cont += 1
     varL = "Thermal $n_i$ ($10^{20}/m^3$)"
@@ -245,14 +245,14 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
     cont = 0
     for i in range(len(self.Species)):
         if self.Species[i]["S"] == "fast":
-            var = self.profiles["ni(10^19/m^3)"][:, i] * 1e-1 * 1e5
+            var = self.get_profiles()["ni(10^19/m^3)"][:, i] * 1e-1 * 1e5
             ax.plot(
                 rho,
                 var,
                 lw=lw,
                 ls=lines[cont],
                 c=color,
-                label=extralab + f"{i + 1} = {self.profiles['name'][i]}",
+                label=extralab + f"{i + 1} = {self.get_profiles()['name'][i]}",
             )
             cont += 1
     varL = "Fast $n_i$ ($10^{15}/m^3$)"
@@ -267,7 +267,7 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
     GRAPHICStools.autoscale_y(ax, bottomy=0)
 
     ax = ax02
-    var = self.profiles["w0(rad/s)"]
+    var = self.get_profiles()["w0(rad/s)"]
     ax.plot(rho, var, lw=lw, ls="-", c=color)
     varL = "$\\omega_{0}$ (rad/s)"
     ax.set_xlim([0, 1])
@@ -278,12 +278,12 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
     GRAPHICStools.autoscale_y(ax)
 
     ax = ax12
-    var = self.profiles["ptot(Pa)"] * 1e-6
+    var = self.get_profiles()["ptot(Pa)"] * 1e-6
     ax.plot(rho, var, lw=lw, ls="-", c=color, label=extralab + "ptot")
-    if "ptot_manual" in self.derived:
+    if "ptot_manual" in self.get_derived():
         ax.plot(
             rho,
-            self.derived["ptot_manual"],
+            self.get_derived()["ptot_manual"],
             lw=lw,
             ls="--",
             c=color,
@@ -291,7 +291,7 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
         )
         ax.plot(
             rho,
-            self.derived["pthr_manual"],
+            self.get_derived()["pthr_manual"],
             lw=lw,
             ls="-.",
             c=color,
@@ -310,7 +310,7 @@ def plot_profiles(self, axs1, color="b", legYN=True, extralab="", lw=1, fs=6):
     GRAPHICStools.autoscale_y(ax, bottomy=0)
 
     ax = ax22
-    var = self.profiles["q(-)"]
+    var = self.get_profiles()["q(-)"]
     ax.plot(rho, var, lw=lw, ls="-", c=color)
     varL = "$q$ profile"
     ax.axhline(y=1.0, lw=0.5, ls="--", c="k")
@@ -326,36 +326,36 @@ def plot_powers(self, axs2, legYN=True, extralab="", color="b", lw=1, fs=6):
 
     [ax00b, ax01b, ax10b, ax11b, ax20b, ax21b, ax30b, ax31b] = axs2
 
-    rho = self.profiles["rho(-)"]
+    rho = self.get_profiles()["rho(-)"]
 
     lines = GRAPHICStools.listLS()
 
     ax = ax00b
     varL = "$MW/m^3$"
     cont = 0
-    var = -self.profiles["qei(MW/m^3)"]
+    var = -self.get_profiles()["qei(MW/m^3)"]
     ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "i->e", c=color)
     cont += 1
-    if "qrfe(MW/m^3)" in self.profiles:
-        var = self.profiles["qrfe(MW/m^3)"]
+    if "qrfe(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qrfe(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "rf", c=color)
         cont += 1
-    if "qfuse(MW/m^3)" in self.profiles:
-        var = self.profiles["qfuse(MW/m^3)"]
+    if "qfuse(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qfuse(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "fus", c=color)
         cont += 1
-    if "qbeame(MW/m^3)" in self.profiles:
-        var = self.profiles["qbeame(MW/m^3)"]
+    if "qbeame(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qbeame(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "beam", c=color)
         cont += 1
-    if "qione(MW/m^3)" in self.profiles:
-        var = self.profiles["qione(MW/m^3)"]
+    if "qione(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qione(MW/m^3)"]
         ax.plot(
             rho, var, lw=lw / 2, ls=lines[cont], label=extralab + "extra", c=color
         )
         cont += 1
-    if "qohme(MW/m^3)" in self.profiles:
-        var = self.profiles["qohme(MW/m^3)"]
+    if "qohme(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qohme(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "ohmic", c=color)
         cont += 1
 
@@ -371,7 +371,7 @@ def plot_powers(self, axs2, legYN=True, extralab="", color="b", lw=1, fs=6):
 
     ax = ax01b
 
-    ax.plot(rho, self.profiles["qmom(N/m^2)"], lw=lw, ls="-", c=color)
+    ax.plot(rho, self.get_profiles()["qmom(N/m^2)"], lw=lw, ls="-", c=color)
     ax.set_xlim([0, 1])
     ax.set_xlabel("$\\rho$")
     ax.set_ylabel("$N/m^2$, $J/m^3$")
@@ -383,23 +383,23 @@ def plot_powers(self, axs2, legYN=True, extralab="", color="b", lw=1, fs=6):
     ax = ax10b
     varL = "$MW/m^3$"
     cont = 0
-    var = self.profiles["qei(MW/m^3)"]
+    var = self.get_profiles()["qei(MW/m^3)"]
     ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "e->i", c=color)
     cont += 1
-    if "qrfi(MW/m^3)" in self.profiles:
-        var = self.profiles["qrfi(MW/m^3)"]
+    if "qrfi(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qrfi(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "rf", c=color)
         cont += 1
-    if "qfusi(MW/m^3)" in self.profiles:
-        var = self.profiles["qfusi(MW/m^3)"]
+    if "qfusi(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qfusi(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "fus", c=color)
         cont += 1
-    if "qbeami(MW/m^3)" in self.profiles:
-        var = self.profiles["qbeami(MW/m^3)"]
+    if "qbeami(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qbeami(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls=lines[cont], label=extralab + "beam", c=color)
         cont += 1
-    if "qioni(MW/m^3)" in self.profiles:
-        var = self.profiles["qioni(MW/m^3)"]
+    if "qioni(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qioni(MW/m^3)"]
         ax.plot(
             rho, var, lw=lw / 2, ls=lines[cont], label=extralab + "extra", c=color
         )
@@ -418,9 +418,9 @@ def plot_powers(self, axs2, legYN=True, extralab="", color="b", lw=1, fs=6):
 
     ax = ax11b
     cont = 0
-    var = self.profiles["qpar_beam(1/m^3/s)"] * 1e-20
+    var = self.get_profiles()["qpar_beam(1/m^3/s)"] * 1e-20
     ax.plot(rho, var, lw=lw, ls=lines[0], c=color, label=extralab + "beam")
-    var = self.profiles["qpar_wall(1/m^3/s)"] * 1e-20
+    var = self.get_profiles()["qpar_wall(1/m^3/s)"] * 1e-20
     ax.plot(rho, var, lw=lw, ls=lines[1], c=color, label=extralab + "wall")
 
     ax.set_xlim([0, 1])
@@ -438,17 +438,17 @@ def plot_powers(self, axs2, legYN=True, extralab="", color="b", lw=1, fs=6):
 
     ax = ax20b
     varL = "$Q_{rad}$ ($MW/m^3$)"
-    if "qbrem(MW/m^3)" in self.profiles:
-        var = self.profiles["qbrem(MW/m^3)"]
+    if "qbrem(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qbrem(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls="-", label=extralab + "brem", c=color)
-    if "qline(MW/m^3)" in self.profiles:
-        var = self.profiles["qline(MW/m^3)"]
+    if "qline(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qline(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls="--", label=extralab + "line", c=color)
-    if "qsync(MW/m^3)" in self.profiles:
-        var = self.profiles["qsync(MW/m^3)"]
+    if "qsync(MW/m^3)" in self.get_profiles():
+        var = self.get_profiles()["qsync(MW/m^3)"]
         ax.plot(rho, var, lw=lw, ls=":", label=extralab + "sync", c=color)
 
-    var = self.derived["qrad"]
+    var = self.get_derived()["qrad"]
     ax.plot(rho, var, lw=lw * 1.5, ls="-", label=extralab + "Total", c=color)
 
     ax.set_xlim([0, 1])
@@ -464,8 +464,8 @@ def plot_powers(self, axs2, legYN=True, extralab="", color="b", lw=1, fs=6):
 
 
     ax = ax30b
-    ax.plot(rho, self.derived["qe_MWm2"], lw=lw, ls="-", label=extralab + "qe", c=color)
-    ax.plot(rho, self.derived["qi_MWm2"], lw=lw, ls="--", label=extralab + "qi", c=color)
+    ax.plot(rho, self.get_derived()["qe_MWm2"], lw=lw, ls="-", label=extralab + "qe", c=color)
+    ax.plot(rho, self.get_derived()["qi_MWm2"], lw=lw, ls="--", label=extralab + "qi", c=color)
     
     ax.set_xlim([0, 1])
     ax.set_xlabel("$\\rho$")
@@ -481,7 +481,7 @@ def plot_powers(self, axs2, legYN=True, extralab="", color="b", lw=1, fs=6):
     ax = ax31b
     ax.plot(
         rho,
-        self.derived["ge_10E20m2"],
+        self.get_derived()["ge_10E20m2"],
         lw=lw,
         ls="-.",
         label=extralab + "$\\Gamma_e$",
@@ -532,15 +532,15 @@ def plot_gradients(
             axs4.append(axs[0, i])
             axs4.append(axs[1, i])
 
-    ix = np.argmin(np.abs(self.profiles["rho(-)"] - lastRho)) + 1
+    ix = np.argmin(np.abs(self.get_profiles()["rho(-)"] - lastRho)) + 1
 
-    xcoord = self.profiles["rho(-)"] if (not useRoa) else self.derived["roa"]
+    xcoord = self.get_profiles()["rho(-)"] if (not useRoa) else self.get_derived()["roa"]
     labelx = "$\\rho$" if (not useRoa) else "$r/a$"
 
     ax = axs4[0]
     ax.plot(
         xcoord,
-        self.profiles["te(keV)"],
+        self.get_profiles()["te(keV)"],
         ls,
         c=color,
         lw=lw,
@@ -551,7 +551,7 @@ def plot_gradients(
     ax = axs4[2]
     ax.plot(
         xcoord,
-        self.profiles["ti(keV)"][:, 0],
+        self.get_profiles()["ti(keV)"][:, 0],
         ls,
         c=color,
         lw=lw,
@@ -561,7 +561,7 @@ def plot_gradients(
     ax = axs4[4]
     ax.plot(
         xcoord,
-        self.profiles["ne(10^19/m^3)"] * 1e-1,
+        self.get_profiles()["ne(10^19/m^3)"] * 1e-1,
         ls,
         c=color,
         lw=lw,
@@ -573,7 +573,7 @@ def plot_gradients(
         ax = axs4[1]
         ax.plot(
             xcoord[:ix],
-            self.derived["aLTe"][:ix],
+            self.get_derived()["aLTe"][:ix],
             ls,
             c=color,
             lw=lw,
@@ -583,7 +583,7 @@ def plot_gradients(
         ax = axs4[3]
         ax.plot(
             xcoord[:ix],
-            self.derived["aLTi"][:ix, 0],
+            self.get_derived()["aLTi"][:ix, 0],
             ls,
             c=color,
             lw=lw,
@@ -596,7 +596,7 @@ def plot_gradients(
                 if self.Species[i]["S"] != "therm":
                                 ax.plot(
                                 xcoord[:ix],
-                                self.derived["aLTi"][:ix, i],
+                                self.get_derived()["aLTi"][:ix, i],
                                 ls,
                                 c=fast_color,
                                 lw=lw,
@@ -609,7 +609,7 @@ def plot_gradients(
         ax = axs4[5]
         ax.plot(
             xcoord[:ix],
-            self.derived["aLne"][:ix],
+            self.get_derived()["aLne"][:ix],
             ls,
             c=color,
             lw=lw,
@@ -658,7 +658,7 @@ def plot_gradients(
     if plotImpurity is not None:
         axs4[6 + cont].plot(
             xcoord,
-            self.profiles["ni(10^19/m^3)"][:, plotImpurity] * 1e-1,
+            self.get_profiles()["ni(10^19/m^3)"][:, plotImpurity] * 1e-1,
             ls,
             c=color,
             lw=lw,
@@ -672,7 +672,7 @@ def plot_gradients(
         if "derived" in self.__dict__:
             axs4[7 + cont].plot(
                 xcoord[:ix],
-                self.derived["aLni"][:ix, plotImpurity],
+                self.get_derived()["aLni"][:ix, plotImpurity],
                 ls,
                 c=color,
                 lw=lw,
@@ -689,7 +689,7 @@ def plot_gradients(
     if plotRotation:
         axs4[6 + cont].plot(
             xcoord,
-            self.profiles["w0(rad/s)"] * 1e-3,
+            self.get_profiles()["w0(rad/s)"] * 1e-3,
             ls,
             c=color,
             lw=lw,
@@ -699,10 +699,10 @@ def plot_gradients(
         axs4[6 + cont].set_ylabel("$w_0$ (krad/s)")
         axs4[6 + cont].set_xlabel(labelx)
         
-        var = -self.derived["dw0dr"][:ix] * 1e-5
+        var = -self.get_derived()["dw0dr"][:ix] * 1e-5
         varlab = "-$d\\omega_0/dr$ (krad/s/cm)"
         
-        # var = self.derived["dw0dr"][:ix] * self.derived["a"] / self.profiles['w0(rad/s)'][:ix]
+        # var = self.get_derived()["dw0dr"][:ix] * self.get_derived()["a"] / self.get_profiles()['w0(rad/s)'][:ix]
         # varlab = "a/$L_{w0}$"
         
         if "derived" in self.__dict__:
@@ -723,7 +723,7 @@ def plot_gradients(
         cont += 2
 
     for x0 in predicted_rhoPlot:
-        ix = np.argmin(np.abs(self.profiles["rho(-)"] - x0))
+        ix = np.argmin(np.abs(self.get_profiles()["rho(-)"] - x0))
         for ax in axs4:
             ax.axvline(x=xcoord[ix], ls="--", lw=0.5, c=color)
 
@@ -733,12 +733,12 @@ def plot_gradients(
 
 def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
     
-    rho = self.profiles["rho(-)"]
+    rho = self.get_profiles()["rho(-)"]
     lines = GRAPHICStools.listLS()
     
     # Others
     ax = axs6[0]
-    ax.plot(self.profiles["rho(-)"], self.derived["dw0dr"] * 1e-5, c=color, lw=lw)
+    ax.plot(self.get_profiles()["rho(-)"], self.get_derived()["dw0dr"] * 1e-5, c=color, lw=lw)
     ax.set_ylabel("$-d\\omega_0/dr$ (krad/s/cm)")
     ax.set_xlabel("$\\rho$")
     ax.set_xlim([0, 1])
@@ -748,7 +748,7 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
     ax.axhline(y=0, lw=1.0, c="k", ls="--")
 
     ax = axs6[2]
-    ax.plot(self.profiles["rho(-)"], self.derived["q_fus"], c=color, lw=lw)
+    ax.plot(self.get_profiles()["rho(-)"], self.get_derived()["q_fus"], c=color, lw=lw)
     ax.set_ylabel("$q_{fus}$ ($MW/m^3$)")
     ax.set_xlabel("$\\rho$")
     ax.set_xlim([0, 1])
@@ -757,7 +757,7 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
     GRAPHICStools.autoscale_y(ax, bottomy=0)
 
     ax = axs6[3]
-    ax.plot(self.profiles["rho(-)"], self.derived["q_fus_MW"], c=color, lw=lw)
+    ax.plot(self.get_profiles()["rho(-)"], self.get_derived()["q_fus_MW"], c=color, lw=lw)
     ax.set_ylabel("$P_{fus}$ ($MW$)")
     ax.set_xlim([0, 1])
 
@@ -765,7 +765,7 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
     GRAPHICStools.autoscale_y(ax, bottomy=0)
 
     ax = axs6[4]
-    ax.plot(self.profiles["rho(-)"], self.derived["tite"], c=color, lw=lw)
+    ax.plot(self.get_profiles()["rho(-)"], self.get_derived()["tite"], c=color, lw=lw)
     ax.set_ylabel("$T_i/T_e$")
     ax.set_xlabel("$\\rho$")
     ax.set_xlim([0, 1])
@@ -775,8 +775,8 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
     GRAPHICStools.autoscale_y(ax)
 
     ax = axs6[5]
-    if "MachNum" in self.derived:
-        ax.plot(self.profiles["rho(-)"], self.derived["MachNum"], c=color, lw=lw)
+    if "MachNum" in self.get_derived():
+        ax.plot(self.get_profiles()["rho(-)"], self.get_derived()["MachNum"], c=color, lw=lw)
     ax.set_ylabel("Mach Number")
     ax.set_xlabel("$\\rho$")
     ax.set_xlim([0, 1])
@@ -788,26 +788,26 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
 
     ax = axs6[6]
     safe_division = np.divide(
-        self.derived["qi_MWm2"],
-        self.derived["qe_MWm2"],
-        where=self.derived["qe_MWm2"] != 0,
-        out=np.full_like(self.derived["qi_MWm2"], np.nan),
+        self.get_derived()["qi_MWm2"],
+        self.get_derived()["qe_MWm2"],
+        where=self.get_derived()["qe_MWm2"] != 0,
+        out=np.full_like(self.get_derived()["qi_MWm2"], np.nan),
     )
     ax.plot(
-        self.profiles["rho(-)"],
+        self.get_profiles()["rho(-)"],
         safe_division,
         c=color,
         lw=lw,
         label=extralab + "$Q_i/Q_e$",
     )
     safe_division = np.divide(
-        self.derived["qi_aux_MW"],
-        self.derived["qe_aux_MW"],
-        where=self.derived["qe_aux_MW"] != 0,
-        out=np.full_like(self.derived["qi_aux_MW"], np.nan),
+        self.get_derived()["qi_aux_MW"],
+        self.get_derived()["qe_aux_MW"],
+        where=self.get_derived()["qe_aux_MW"] != 0,
+        out=np.full_like(self.get_derived()["qi_aux_MW"], np.nan),
     )
     ax.plot(
-        self.profiles["rho(-)"],
+        self.get_profiles()["rho(-)"],
         safe_division,
         c=color,
         lw=lw,
@@ -815,13 +815,13 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
         label=extralab + "$P_{aux,i}/P_{aux,e}$",
     )
     safe_division = np.divide(
-        self.derived["qi_aux_MW"]+self.derived['qi_fus_MW'],
-        self.derived["qe_aux_MW"]+self.derived['qe_fus_MW'],
-        where=(self.derived["qe_aux_MW"]+self.derived['qe_fus_MW']) != 0,
-        out=np.full_like(self.derived["qi_aux_MW"], np.nan),
+        self.get_derived()["qi_aux_MW"]+self.get_derived()['qi_fus_MW'],
+        self.get_derived()["qe_aux_MW"]+self.get_derived()['qe_fus_MW'],
+        where=(self.get_derived()["qe_aux_MW"]+self.get_derived()['qe_fus_MW']) != 0,
+        out=np.full_like(self.get_derived()["qi_aux_MW"], np.nan),
     )
     ax.plot(
-        self.profiles["rho(-)"],
+        self.get_profiles()["rho(-)"],
         safe_division,
         c=color,
         lw=lw,
@@ -840,12 +840,16 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
     
     ax = axs6[1]
     
-    var = self.profiles["johm(MA/m^2)"]
+    var = self.get_profiles()["johm(MA/m^2)"]
     ax.plot(rho, var, "-", lw=lw, c=color, label=extralab + "$J_{OH}$")
-    var = self.profiles["jbs(MA/m^2)"]
+    var = self.get_profiles()["jbs(MA/m^2)"]
     ax.plot(rho, var, "--", lw=lw, c=color, label=extralab + "$J_{BS,par}$")
-    var = self.profiles["jbstor(MA/m^2)"]
-    ax.plot(rho, var, "-.", lw=lw, c=color, label=extralab + "$J_{BS,tor}$")
+    # jbstor(MA/m^2) (toroidal bootstrap current component) is not populated by fusio's
+    # plasma_io -> gacode dict conversion (unlike jbs/johm) -- narrow, display-only gap, not
+    # used anywhere in the physics/evaluation path. Skip the line rather than crash.
+    if "jbstor(MA/m^2)" in self.get_profiles():
+        var = self.get_profiles()["jbstor(MA/m^2)"]
+        ax.plot(rho, var, "-.", lw=lw, c=color, label=extralab + "$J_{BS,tor}$")
 
     ax.set_xlim([0, 1])
     ax.set_xlabel("$\\rho$")
@@ -857,17 +861,17 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
 
     ax = axs6[7]
     cont = 0
-    if "vtor(m/s)" in self.profiles:
+    if "vtor(m/s)" in self.get_profiles():
         for i in range(len(self.Species)):
             try:  # REMOVE FOR FUTURE
-                var = self.profiles["vtor(m/s)"][:, i] * 1e-3
+                var = self.get_profiles()["vtor(m/s)"][:, i] * 1e-3
                 ax.plot(
                     rho,
                     var,
                     lw=lw,
                     ls=lines[cont],
                     c=color,
-                    label=extralab + f"{i + 1} = {self.profiles['name'][i]}",
+                    label=extralab + f"{i + 1} = {self.get_profiles()['name'][i]}",
                 )
                 cont += 1
             except:
@@ -882,9 +886,9 @@ def plot_other(self, axs6, color="b", lw=1.0, extralab="", fs=6):
 
     ax = axs6[8]
     
-    ax.plot(rho, self.derived["B_unit"], "-", lw=lw, c=color, label=extralab + "$B_{unit}$")
-    ax.plot(rho, self.derived["B_ref"], "--", lw=lw, c=color, label=extralab + "$B_{ref}$")
-    ax.axhline(y=self.profiles["bcentr(T)"][0], lw=lw, ls=":", c=color, label=extralab + "$B_{centr}$")
+    ax.plot(rho, self.get_derived()["B_unit"], "-", lw=lw, c=color, label=extralab + "$B_{unit}$")
+    ax.plot(rho, self.get_derived()["B_ref"], "--", lw=lw, c=color, label=extralab + "$B_{ref}$")
+    ax.axhline(y=self.get_profiles()["bcentr(T)"][0], lw=lw, ls=":", c=color, label=extralab + "$B_{centr}$")
     ax.set_xlim([0, 1])
     ax.set_xlabel("$\\rho$")
     ax.set_ylabel("$B$ (T)")
@@ -914,12 +918,12 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
 
     ax = axs[0]
     axT = axs[1]
-    roa = self.derived['roa']
-    Te = self.profiles["te(keV)"]
-    ne = self.profiles["ne(10^19/m^3)"] * 1e-1
-    ni = self.profiles["ni(10^19/m^3)"] * 1e-1
+    roa = self.get_derived()['roa']
+    Te = self.get_profiles()["te(keV)"]
+    ne = self.get_profiles()["ne(10^19/m^3)"] * 1e-1
+    ni = self.get_profiles()["ni(10^19/m^3)"] * 1e-1
     niT = np.sum(ni, axis=1)
-    Ti = self.profiles["ti(keV)"][:, 0]
+    Ti = self.get_profiles()["ti(keV)"][:, 0]
     ax.plot(roa, Te, lw=2, c="r", label="$T_e$" if leg else "", ls=ls)
     ax.plot(roa, Ti, lw=2, c="b", label="$T_i$" if leg else "", ls=ls)
     axT.plot(roa, ne, lw=2, c="m", label="$n_e$" if leg else "", ls=ls)
@@ -954,11 +958,11 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     GRAPHICStools.autoscale_y(axT, bottomy=0)
 
     if showtexts:
-        if self.derived["Q"] > 0.005:
+        if self.get_derived()["Q"] > 0.005:
             ax.text(
                 0.05,
                 0.05,
-                f"Pfus = {self.derived['Pfus']:.1f}MW, Q = {self.derived['Q']:.2f}",
+                f"Pfus = {self.get_derived()['Pfus']:.1f}MW, Q = {self.get_derived()['Q']:.2f}",
                 color="k",
                 fontsize=10,
                 fontweight="normal",
@@ -972,9 +976,9 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
             0.05,
             0.4,
             "ne_20 = {0:.1f} (fG = {1:.2f}), Zeff = {2:.1f}".format(
-                self.derived["ne_vol20"],
-                self.derived["fG"],
-                self.derived["Zeff_vol"],
+                self.get_derived()["ne_vol20"],
+                self.get_derived()["fG"],
+                self.get_derived()["Zeff_vol"],
             ),
             color="k",
             fontsize=10,
@@ -988,15 +992,15 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     # F
     ax = axs[2]
     P = (
-        self.derived["qe_fus_MW"]
-        + self.derived["qe_aux_MW"]
-        + -self.derived["qe_rad_MW"]
-        + -self.derived["qe_exc_MW"]
+        self.get_derived()["qe_fus_MW"]
+        + self.get_derived()["qe_aux_MW"]
+        + -self.get_derived()["qe_rad_MW"]
+        + -self.get_derived()["qe_exc_MW"]
     )
 
     ax.plot(
         roa,
-        -self.derived["qe_MW"],
+        -self.get_derived()["qe_MW"],
         c="g",
         lw=2,
         label="$P_{e}$" if leg else "",
@@ -1004,7 +1008,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qe_fus_MW"],
+        self.get_derived()["qe_fus_MW"],
         c="r",
         lw=2,
         label="$P_{fus,e}$" if leg else "",
@@ -1012,7 +1016,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qe_aux_MW"],
+        self.get_derived()["qe_aux_MW"],
         c="b",
         lw=2,
         label="$P_{aux,e}$" if leg else "",
@@ -1020,7 +1024,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        -self.derived["qe_exc_MW"],
+        -self.get_derived()["qe_exc_MW"],
         c="m",
         lw=2,
         label="$P_{exc,e}$" if leg else "",
@@ -1028,7 +1032,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        -self.derived["qe_rad_MW"],
+        -self.get_derived()["qe_rad_MW"],
         c="c",
         lw=2,
         label="$P_{rad,e}$" if leg else "",
@@ -1036,12 +1040,12 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(roa, -P, lw=1, c="y", label="sum" if leg else "", ls=ls)
 
-    # Pe = self.profiles['te(keV)']*1E3*e_J*self.profiles['ne(10^19/m^3)']*1E-1*1E20 *1E-6
+    # Pe = self.get_profiles()['te(keV)']*1E3*e_J*self.get_profiles()['ne(10^19/m^3)']*1E-1*1E20 *1E-6
     # ax.plot(roa,Pe,ls='-',lw=3,alpha=0.1,c='k',label='$W_e$ (MJ/m^3)')
 
     ax.plot(
         roa,
-        -self.derived["ce_MW"],
+        -self.get_derived()["ce_MW"],
         c="k",
         lw=1,
         label="($P_{conv,e}$)" if leg else "",
@@ -1062,14 +1066,14 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
 
     ax = axs[3]
     P = (
-        self.derived["qi_fus_MW"]
-        + self.derived["qi_aux_MW"]
-        + self.derived["qe_exc_MW"]
+        self.get_derived()["qi_fus_MW"]
+        + self.get_derived()["qi_aux_MW"]
+        + self.get_derived()["qe_exc_MW"]
     )
 
     ax.plot(
         roa,
-        -self.derived["qi_MW"],
+        -self.get_derived()["qi_MW"],
         c="g",
         lw=2,
         label="$P_{i}$" if leg else "",
@@ -1077,7 +1081,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qi_fus_MW"],
+        self.get_derived()["qi_fus_MW"],
         c="r",
         lw=2,
         label="$P_{fus,i}$" if leg else "",
@@ -1085,7 +1089,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qi_aux_MW"],
+        self.get_derived()["qi_aux_MW"],
         c="b",
         lw=2,
         label="$P_{aux,i}$" if leg else "",
@@ -1093,7 +1097,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qe_exc_MW"],
+        self.get_derived()["qe_exc_MW"],
         c="m",
         lw=2,
         label="$P_{exc,i}$" if leg else "",
@@ -1101,7 +1105,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(roa, -P, lw=1, c="y", label="sum" if leg else "", ls=ls)
 
-    # Pi = self.profiles['ti(keV)'][:,0]*1E3*e_J*self.profiles['ni(10^19/m^3)'][:,0]*1E-1*1E20 *1E-6
+    # Pi = self.get_profiles()['ti(keV)'][:,0]*1E3*e_J*self.get_profiles()['ni(10^19/m^3)'][:,0]*1E-1*1E20 *1E-6
     # ax.plot(roa,Pi,ls='-',lw=3,alpha=0.1,c='k',label='$W_$ (MJ/m^3)')
 
     ax.set_xlabel("r/a")
@@ -1122,13 +1126,13 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
 
     ax.plot(
         roa,
-        self.derived["ge_10E20"],
+        self.get_derived()["ge_10E20"],
         c="g",
         lw=2,
         label="$\\Gamma_{e}$" if leg else "",
         ls=ls,
     )
-    # ax.plot(roa,self.profiles['ne(10^19/m^3)']*1E-1,lw=3,alpha=0.1,c='k',label='$n_e$ ($10^{20}/m^3$)' if leg else '',ls=ls)
+    # ax.plot(roa,self.get_profiles()['ne(10^19/m^3)']*1E-1,lw=3,alpha=0.1,c='k',label='$n_e$ ($10^{20}/m^3$)' if leg else '',ls=ls)
 
     ax.set_xlabel("r/a")
     ax.set_xlim([0, 1])
@@ -1145,17 +1149,17 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     # TOTAL
     ax = axs[5]
     P = (
-        self.derived["qOhm_MW"]
-        + self.derived["qRF_MW"]
-        + self.derived["qFus_MW"]
-        + -self.derived["qe_rad_MW"]
-        + self.derived["qz_MW"]
-        + self.derived["qBEAM_MW"]
+        self.get_derived()["qOhm_MW"]
+        + self.get_derived()["qRF_MW"]
+        + self.get_derived()["qFus_MW"]
+        + -self.get_derived()["qe_rad_MW"]
+        + self.get_derived()["qz_MW"]
+        + self.get_derived()["qBEAM_MW"]
     )
 
     ax.plot(
         roa,
-        -self.derived["q_MW"],
+        -self.get_derived()["q_MW"],
         c="g",
         lw=2,
         label="$P$" if leg else "",
@@ -1163,7 +1167,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qOhm_MW"],
+        self.get_derived()["qOhm_MW"],
         c="k",
         lw=2,
         label="$P_{Oh}$" if leg else "",
@@ -1171,7 +1175,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qRF_MW"],
+        self.get_derived()["qRF_MW"],
         c="b",
         lw=2,
         label="$P_{RF}$" if leg else "",
@@ -1179,7 +1183,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qBEAM_MW"],
+        self.get_derived()["qBEAM_MW"],
         c="pink",
         lw=2,
         label="$P_{NBI}$" if leg else "",
@@ -1187,7 +1191,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qFus_MW"],
+        self.get_derived()["qFus_MW"],
         c="r",
         lw=2,
         label="$P_{fus}$" if leg else "",
@@ -1195,7 +1199,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        -self.derived["qe_rad_MW"],
+        -self.get_derived()["qe_rad_MW"],
         c="c",
         lw=2,
         label="$P_{rad}$" if leg else "",
@@ -1203,7 +1207,7 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
     )
     ax.plot(
         roa,
-        self.derived["qz_MW"],
+        self.get_derived()["qz_MW"],
         c="orange",
         lw=1,
         label="$P_{ionz.}$" if leg else "",
@@ -1236,15 +1240,15 @@ def plot_flows(self, axs=None, limits=None, ls="-", leg=True, showtexts=True):
 
 def plot_ions(self, axsImps, legYN=True, extralab="", color="b", lw=1, fs=6):
 
-    rho = self.profiles["rho(-)"]
+    rho = self.get_profiles()["rho(-)"]
     lines = GRAPHICStools.listLS()
 
     # Impurities
     ax = axsImps[0]
     for i in range(len(self.Species)):
         var = (
-            self.profiles["ni(10^19/m^3)"][:, i]
-            / self.profiles["ni(10^19/m^3)"][0, i]
+            self.get_profiles()["ni(10^19/m^3)"][:, i]
+            / self.get_profiles()["ni(10^19/m^3)"][0, i]
         )
         ax.plot(
             rho,
@@ -1252,7 +1256,7 @@ def plot_ions(self, axsImps, legYN=True, extralab="", color="b", lw=1, fs=6):
             lw=lw,
             ls=lines[i],
             c=color,
-            label=extralab + f"{i + 1} = {self.profiles['name'][i]}",
+            label=extralab + f"{i + 1} = {self.get_profiles()['name'][i]}",
         )
     varL = "$n_i/n_{i,0}$"
     ax.set_xlim([0, 1])
@@ -1266,14 +1270,14 @@ def plot_ions(self, axsImps, legYN=True, extralab="", color="b", lw=1, fs=6):
 
     ax = axsImps[1]
     for i in range(len(self.Species)):
-        var = self.derived["fi"][:, i]
+        var = self.get_derived()["fi"][:, i]
         ax.plot(
             rho,
             var,
             lw=lw,
             ls=lines[i],
             c=color,
-            label=extralab + f"{i + 1} = {self.profiles['name'][i]}",
+            label=extralab + f"{i + 1} = {self.get_profiles()['name'][i]}",
         )
     varL = "$f_i$"
     ax.set_xlim([0, 1])
@@ -1290,19 +1294,19 @@ def plot_ions(self, axsImps, legYN=True, extralab="", color="b", lw=1, fs=6):
 
     lastRho = 0.9
 
-    ix = np.argmin(np.abs(self.profiles["rho(-)"] - lastRho)) + 1
+    ix = np.argmin(np.abs(self.get_profiles()["rho(-)"] - lastRho)) + 1
     ax.plot(
-        rho[:ix], self.derived["aLne"][:ix], lw=lw * 3, ls="-", c=color, label="e"
+        rho[:ix], self.get_derived()["aLne"][:ix], lw=lw * 3, ls="-", c=color, label="e"
     )
     for i in range(len(self.Species)):
-        var = self.derived["aLni"][:, i]
+        var = self.get_derived()["aLni"][:, i]
         ax.plot(
             rho[:ix],
             var[:ix],
             lw=lw,
             ls=lines[i],
             c=color,
-            label=extralab + f"{i + 1} = {self.profiles['name'][i]}",
+            label=extralab + f"{i + 1} = {self.get_profiles()['name'][i]}",
         )
     varL = "$a/L_{ni}$"
     ax.set_xlim([0, 1])
@@ -1318,7 +1322,7 @@ def plot_ions(self, axsImps, legYN=True, extralab="", color="b", lw=1, fs=6):
     GRAPHICStools.autoscale_y(ax, bottomy=0)
 
     ax = axsImps[3]
-    ax.plot(self.profiles["rho(-)"], self.derived["Zeff"], c=color, lw=lw)
+    ax.plot(self.get_profiles()["rho(-)"], self.get_derived()["Zeff"], c=color, lw=lw)
     ax.set_ylabel("$Z_{eff}$")
     ax.set_xlabel("$\\rho$")
     ax.set_xlim([0, 1])

--- a/src/mitim_tools/simulation_tools/SIMtools.py
+++ b/src/mitim_tools/simulation_tools/SIMtools.py
@@ -116,7 +116,8 @@ class mitim_simulation:
         # Keep a copy of the file
         self.profiles.write_state(file=self.FolderGACODE / "input.gacode_torun")
 
-        self.profiles.derive_quantities(mi_ref=md_u)
+        if getattr(self.profiles, "plasma_io", None) is None:
+            self.profiles.derive_quantities(mi_ref=md_u)
 
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         # Initialize from state

--- a/src/mitim_tools/simulation_tools/SIMtools.py
+++ b/src/mitim_tools/simulation_tools/SIMtools.py
@@ -116,7 +116,7 @@ class mitim_simulation:
         # Keep a copy of the file
         self.profiles.write_state(file=self.FolderGACODE / "input.gacode_torun")
 
-        if getattr(self.profiles, "plasma_io", None) is None:
+        if not getattr(self.profiles, "has_output", False):
             self.profiles.derive_quantities(mi_ref=md_u)
 
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Introduces fusio's `plasma_io` as an optional, opt-in state representation alongside MITIM's existing GACODE-ASCII-based mitim_state/gacode_state, starting with the PORTALS `powertorch` path. All new behavior is additive and gated behind `plasma_io is not None`, so runs that start from a plain `input.gacode` file are unaffected.

- State construction: `MITIMstate.mitim_state.scratch()` now accepts a fusio `io` object directly, converts it to a flattened profiles dict via `.to("gacode").to_dict(side="input")`, and keeps a handle to the source object on `self.plasma_io`.
- PORTALS initialization (`PORTALSinit.initializeProblem`): accepts a fusio io object as `fileStart`, writes the corresponding `input.gacode`, and builds the initial gacode_state from it.
- Powerstate construction, `plasma_io`-native path (`TRANSFORMtools.plasma_io_to_powerstate()`): when the source state carries a `plasma_io`, this new ~300-line function becomes `powerstate`'s sole construction path (`STATEtools.powerstate` wires `self.to_powerstate` to it instead of `gacode_to_powerstate()`) and sources essentially everything directly from `plasma_io`'s SI-native fields rather than the GACODE-unit dict: radial grid, geometry (`roa`, `Rmajoa`, `volp`, `rmin`, `a`, `eps`), kinetic profiles (`te`, `ti`, `ne`, `nZ`, `w0`) and their gradient parameterizations, ion species/densities (`defineIonsFromPlasmaIO()`), the "additional quantities" tier (`B_unit`, `B_ref`, `q`, `s_q`, `Zeff`, `kappa`, `delta`, `betae`), and the fixed-target heat/particle/momentum sources -- with MITIM's own sign/summation convention applied explicitly where it differs from `plasma_io`'s (e.g. `plasma_io` stores ionization/radiation as negative loss terms; MITIM adds `qione`/`qioni` positively and defines `qrad` as positive).
- Powerstate write-back, `plasma_io`-native path (`TRANSFORMtools.powerstate_to_plasma_io()`, `to_plasma_io()`, `sync_plasma_io()`): `plasma_io`-native siblings of `powerstate_to_gacode()`/`to_gacode()`, writing the `powerstate`'s currently-predicted `te`/`ti`/`ne`/`nZ`/`w0` profiles into a deep copy of `plasma_io`'s own SI-native DataTree (with the same `Ti_thermals`/`ni_thermals` postprocessing as the GACODE path), optionally recomputing `plasma_io`'s derived quantities. `sync_plasma_io()` is called once per real BO step (`PORTALSmain.runModelEvaluator()`, right after the single `powerstate.calculate(X, ...)` that represents the proposed-gradients evaluation) to keep `self.profiles.plasma_io` current; it is deliberately not called from `to_gacode()`'s hot path or from `flux_match()`'s internal sub-iterations, which run far more often and would make the recompute cost (MXH geometry decomposition) prohibitive for data that is immediately superseded.
- Separately, a narrower parity-checked override inside the existing `gacode_to_powerstate()` dict-based path: when `input_gacode.plasma_io` is set, `rmin` is read from `plasma_io`'s r_minor and substituted for the dict-derived `rmin(m)`, but only after checking the two agree within tolerance `(rtol=1e-2, atol=1e-3)`; this exists for `gacode_to_powerstate()` callers, not as a restriction on `plasma_io_to_powerstate()`'s scope.
- PORTALS output (`PORTALSmain.py`): final-iteration output prefers writing `plasma_final_<suffix>.nc` via `to_plasma_io()` when the run was `plasma_io`-backed, falling back to `input.gacode_final_<suffix>` otherwise. `profiles_transport` (the transport-evaluated, non-flux-matched snapshot) still has no `plasma_io`-native path, so it's always written as GACODE ASCII.
- Adds fusio as a project dependency (`pyproject.toml`).
- Minor bugfix in `PROFILEStools.py`: integer-typed GACODE fields (nexp, nion, shot, time) now cast to float before array conversion.
- Reverts an unrelated, earlier `B_ref` calculation change in `powertorch` back to the GACODE definition.

## Scope / caveats

- `profiles_transport` has no `plasma_io`-native equivalent yet -- still round-trips through GACODE ASCII.
- `powerstate_to_plasma_io()` has no `Tfast_ratio`/`force_mach` equivalent (fast-ion and `w0`-from-`Mach` handling) -- narrower postprocessing scope than `powerstate_to_gacode()`.
- `plasma_io_to_powerstate()` does not replicate `improve_resolution_profiles()`'s fine-grid resampling; it interpolates directly from `plasma_io`'s native radial grid onto `rho_vec`.
- `plasma_io.compute_derived_quantities()` (MXH shape decomposition) must already have been run by the caller before `plasma_io_to_powerstate()` is invoked -- not called automatically, since it's expensive.
